### PR TITLE
Exclude features supported in fortran2008

### DIFF
--- a/ARTED/control/control_ms.f90
+++ b/ARTED/control/control_ms.f90
@@ -747,10 +747,13 @@ Subroutine Read_data
     write(*,*) 'KbTev=',KbTev ! sato
   end if
 
-
+#ifdef ARTED_USE_FORTRAN2008
   write (process_directory,'(A,A,I5.5,A)') trim(directory),'/work_p',procid(1),'/'
   call create_directory(process_directory)
-
+#else
+  process_directory = trim(directory)
+#endif
+  
   call comm_bcast(need_backup,proc_group(1))
   call comm_bcast(file_GS,proc_group(1))
   call comm_bcast(file_RT,proc_group(1))

--- a/ARTED/control/control_sc.f90
+++ b/ARTED/control/control_sc.f90
@@ -616,9 +616,12 @@ Subroutine Read_data
     write(*,*) 'KbTev=',KbTev ! sato
   end if
 
-
+#ifdef ARTED_USE_FORTRAN2008
   write (process_directory,'(A,A,I5.5,A)') trim(directory),'/work_p',procid(1),'/'
   call create_directory(process_directory)
+#else
+  process_directory = trim(directory)
+#endif
 
   call comm_bcast(need_backup,proc_group(1))
   call comm_bcast(file_GS,proc_group(1))

--- a/ARTED/modules/misc_routines.f90
+++ b/ARTED/modules/misc_routines.f90
@@ -19,7 +19,10 @@ module misc_routines
   public :: floor_pow2, ceiling_pow2
   public :: gen_logfilename
   public :: get_wtime
+
+#ifdef ARTED_USE_FORTRAN2008
   public :: create_directory
+#endif
 
 private
 contains
@@ -72,9 +75,11 @@ contains
 
   ! NOTE: execute_command_line() is standardized at Fortran2008.
   !       In specification, `Execute command line` is defined this feature.
+#ifdef ARTED_USE_FORTRAN2008
   subroutine create_directory(dirpath)
     implicit none
     character(*), intent(in) :: dirpath
     call execute_command_line('mkdir -p '//adjustl(trim(dirpath)), wait=.true.)
   end subroutine
+#endif
 end module


### PR DESCRIPTION
This Pull Request provides a preprocessor variable `ARTED_USE_FORTRAN2008` to toggle subroutines using the non-standard features before fortran2008:
- Exclude the process independed directories for output (default), due to the `create_directory` subroutine which contains fortran2008 procedure.
- To enable the directory creation, set  `ARTED_USE_FORTRAN2008`  variable in Makefile
