### PR TITLE
Add a build environment for gnu fortran compiler

### DIFF
--- a/ARTED/FDTD/FDTD.f90
+++ b/ARTED/FDTD/FDTD.f90
@@ -355,8 +355,8 @@ subroutine dt_evolve_Ac_1d
   real(8) :: RR(3) ! rot rot Ac
 
 !$omp parallel do default(none) &
-!$    private(ix_m) &
-!$    shared(NXvacL_m,NXvacR_m,Ac_m,Ac_old_m,Ac_new_m)
+!$omp&    private(ix_m) &
+!$omp&    shared(NXvacL_m,NXvacR_m,Ac_m,Ac_old_m,Ac_new_m)
   do ix_m=NXvacL_m-1,NXvacR_m+1
     Ac_old_m(:,ix_m,1) = Ac_m    (:,ix_m,1)
     Ac_m    (:,ix_m,1) = Ac_new_m(:,ix_m,1)
@@ -364,9 +364,9 @@ subroutine dt_evolve_Ac_1d
 !$omp end parallel do
 
 !$omp parallel do default(none) &
-!$    private(ix_m,RR) &
-!$    shared(NXvacL_m,NXvacR_m,Ac_m,HX_m,j_m,Ac_old_m,Ac_new_m) &
-!$    firstprivate(dt)
+!$omp&    private(ix_m,RR) &
+!$omp&    shared(NXvacL_m,NXvacR_m,Ac_m,HX_m,j_m,Ac_old_m,Ac_new_m) &
+!$omp&    firstprivate(dt)
   do ix_m=NXvacL_m,NXvacR_m
     RR(1) = 0.0d0
     RR(2) = -(Ac_m(2,ix_m+1,1) - 2*Ac_m(2,ix_m,1) + Ac_m(2,ix_m-1,1)) * (1.0 / HX_m**2) 
@@ -388,8 +388,8 @@ subroutine dt_evolve_Ac_2d
   ! (written by M.Uemoto on 2016-11-22)
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,Ac_m,Ac_old_m,Ac_new_m)
+!$omp&    private(iy_m,ix_m) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,Ac_m,Ac_old_m,Ac_new_m)
   do iy_m=NYvacB_m-1,NYvacT_m+1
     do ix_m=NXvacL_m-1,NXvacR_m+1
       Ac_old_m(:,ix_m,iy_m) = Ac_m    (:,ix_m,iy_m)
@@ -399,9 +399,9 @@ subroutine dt_evolve_Ac_2d
 !$omp end parallel do
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m,RR) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HX_m,HY_m,Ac_m,j_m,Ac_old_m,Ac_new_m) &
-!$    firstprivate(dt)
+!$omp&    private(iy_m,ix_m,RR) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HX_m,HY_m,Ac_m,j_m,Ac_old_m,Ac_new_m) &
+!$omp&    firstprivate(dt)
   do iy_m=NYvacB_m,NYvacT_m
     do ix_m=NXvacL_m,NXvacR_m
       RR(1) = +(-1.00d0/HY_m**2) * Ac_m(1, ix_m, iy_m-1) &
@@ -433,8 +433,8 @@ subroutine dt_evolve_Ac_2d
   select case(TwoD_shape)
   case('periodic')
 !$omp parallel do default(none) &
-!$    private(ix_m) &
-!$    shared(Ac_new_m,NXvacL_m,NXvacR_m,NYvacB_m,NYvacT_m)
+!$omp&    private(ix_m) &
+!$omp&    shared(Ac_new_m,NXvacL_m,NXvacR_m,NYvacB_m,NYvacT_m)
     do ix_m=NXvacL_m-1,NXvacR_m+1
       Ac_new_m(:,ix_m,NYvacB_m-1)=Ac_new_m(:,ix_m,NYvacT_m)
       Ac_new_m(:,ix_m,NYvacT_m+1)=Ac_new_m(:,ix_m,NYvacB_m)
@@ -442,8 +442,8 @@ subroutine dt_evolve_Ac_2d
 !$omp end parallel do
   case('isolated')
 !$omp parallel do default(none) &
-!$    private(ix_m) &
-!$    shared(Ac_new_m,NXvacL_m,NXvacR_m,NYvacB_m,NYvacT_m)
+!$omp&    private(ix_m) &
+!$omp&    shared(Ac_new_m,NXvacL_m,NXvacR_m,NYvacB_m,NYvacT_m)
     do ix_m=NXvacL_m-1,NXvacR_m+1
       Ac_new_m(:,ix_m,NYvacB_m-1)=Ac_new_m(:,ix_m,NYvacB_m)
       Ac_new_m(:,ix_m,NYvacT_m+1)=0.0d0
@@ -462,8 +462,8 @@ subroutine dt_evolve_Ac_2dc()
   real(8) :: Y, RR(3) ! rot rot Ac
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,Ac_m,Ac_old_m,Ac_new_m)
+!$omp&    private(iy_m,ix_m) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,Ac_m,Ac_old_m,Ac_new_m)
   do iy_m=NYvacB_m-1,NYvacT_m+1
     do ix_m=NXvacL_m-1,NXvacR_m+1
       Ac_old_m(:,ix_m,iy_m) = Ac_m    (:,ix_m,iy_m)
@@ -473,9 +473,9 @@ subroutine dt_evolve_Ac_2dc()
 !$omp end parallel do
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m,RR,Y) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HX_m,HY_m,Ac_m,j_m,Ac_old_m,Ac_new_m) &
-!$    firstprivate(dt)
+!$omp&    private(iy_m,ix_m,RR,Y) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HX_m,HY_m,Ac_m,j_m,Ac_old_m,Ac_new_m) &
+!$omp&    firstprivate(dt)
   do iy_m=NYvacB_m,NYvacT_m
     do ix_m=NXvacL_m,NXvacR_m
       Y = iy_m * HY_m
@@ -508,8 +508,8 @@ subroutine dt_evolve_Ac_2dc()
 
   ! Boundary condition
 !$omp parallel do default(none) &
-!$    private(ix_m) &
-!$    shared(Ac_new_m,NXvacL_m,NXvacR_m,NYvacB_m,NYvacT_m)
+!$omp&    private(ix_m) &
+!$omp&    shared(Ac_new_m,NXvacL_m,NXvacR_m,NYvacB_m,NYvacT_m)
   do ix_m=NXvacL_m-1,NXvacR_m+1
     Ac_new_m(1,ix_m,NYvacB_m-1)=Ac_new_m(1,ix_m,NYvacB_m)
     !!Following BCs are automatically satisfied by adequate initial state.
@@ -549,9 +549,9 @@ subroutine calc_elec_field()
   integer ix_m,iy_m
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,Elec,Ac_new_m,Ac_old_m) &
-!$    firstprivate(dt)
+!$omp&    private(iy_m,ix_m) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,Elec,Ac_new_m,Ac_old_m) &
+!$omp&    firstprivate(dt)
   do iy_m=NYvacB_m, NYvacT_m
     do ix_m=NXvacL_m, NXvacR_m
       Elec(:,ix_m,iy_m)=-(Ac_new_m(:,ix_m,iy_m)-Ac_old_m(:,ix_m,iy_m))/(2d0*dt)
@@ -569,8 +569,8 @@ subroutine calc_bmag_field_1d()
   ! (written by M.Uemoto on 2016-11-22)
 
 !$omp parallel do default(none) &
-!$    private(ix_m,Rc) &
-!$    shared(NXvacL_m,NXvacR_m,HX_m,Bmag,Ac_m)
+!$omp&    private(ix_m,Rc) &
+!$omp&    shared(NXvacL_m,NXvacR_m,HX_m,Bmag,Ac_m)
   do ix_m=NXvacL_m, NXvacR_m
     Rc(1) = 0.0d0
     Rc(2) = - (Ac_m(3,ix_m+1,1) - Ac_m(3,ix_m-1,1)) / (2 * HX_m)
@@ -592,8 +592,8 @@ subroutine calc_bmag_field_2d()
   ! (written by M.Uemoto on 2016-11-22)
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m,Rc) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HY_m,HX_m,Bmag,Ac_m)
+!$omp&    private(iy_m,ix_m,Rc) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HY_m,HX_m,Bmag,Ac_m)
   do iy_m=NYvacB_m, NYvacT_m
     do ix_m=NXvacL_m, NXvacR_m
       Rc(1) = + (Ac_m(3, ix_m, iy_m+1) - Ac_m(3, ix_m, iy_m-1)) / (2*HY_m)
@@ -618,8 +618,8 @@ subroutine calc_bmag_field_2dc()
   ! (written by M.Uemoto on 2016-11-22)
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m,Rc,Y) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HY_m,HX_m,Bmag,Ac_m)
+!$omp&    private(iy_m,ix_m,Rc,Y) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,HY_m,HX_m,Bmag,Ac_m)
   do iy_m=NYvacB_m, NYvacT_m
     do ix_m=NXvacL_m, NXvacR_m
       Y = iy_m * HY_m
@@ -660,12 +660,11 @@ subroutine calc_energy_joule()
   implicit none
   integer :: ix_m,iy_m
   ! calculate the Ohmic losses in the media
-  ! (written by M.Uemoto on 2016-11-22)
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,energy_joule,j_m,Elec,aLxyz) &
-!$    firstprivate(dt)
+!$omp&    private(iy_m,ix_m) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,energy_joule,j_m,Elec,aLxyz) &
+!$omp&    firstprivate(dt)
   do iy_m=NYvacB_m,NYvacT_m
     do ix_m=NXvacL_m,NXvacR_m
       energy_joule(ix_m, iy_m) = energy_joule(ix_m, iy_m) &
@@ -684,11 +683,10 @@ subroutine calc_energy_elemag()
   integer :: ix_m,iy_m
   real(8) :: e2, b2
   ! calculate the total electromagnetic energy
-  ! (written by M.Uemoto on 2016-11-22)
 
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m,ix_m,e2,b2) &
-!$    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,Elec,Bmag,energy_elemag,aLxyz)
+!$omp&    private(iy_m,ix_m,e2,b2) &
+!$omp&    shared(NYvacB_m,NYvacT_m,NXvacL_m,NXvacR_m,Elec,Bmag,energy_elemag,aLxyz)
   do iy_m=NYvacB_m,NYvacT_m
     do ix_m=NXvacL_m,NXvacR_m
       e2 = sum(Elec(:, ix_m, iy_m) ** 2)
@@ -711,9 +709,9 @@ real(8) function calc_pulse_xcenter()
   ex_tot = 0.0
   e_tot = 0.0
 !$omp parallel do collapse(2) default(none) &
-!$    private(iy_m, ix_m, x) & 
-!$    shared(NYvacB_m, NYvacT_m, NXvacL_m, NXvacR_m, HX_m, energy_elemag) &
-!$    reduction(+: ex_tot, e_tot)
+!$omp&    private(iy_m, ix_m, x) & 
+!$omp&    shared(NYvacB_m, NYvacT_m, NXvacL_m, NXvacR_m, HX_m, energy_elemag) &
+!$omp&    reduction(+: ex_tot, e_tot)
 do iy_m = NYvacB_m, NYvacT_m
   do ix_m = NXvacL_m, NXvacR_m
     x = ix_m * HX_m

--- a/ARTED/control/control_ms.f90
+++ b/ARTED/control/control_ms.f90
@@ -626,11 +626,9 @@ contains
     implicit none
     integer, intent(in) :: ixy_m
     integer :: il
-!$omp parallel default(none) &
-!$    shared(NL,Vh,Vh_m,Vexc, &
-!$           Vexc_m,Eexc,Eexc_m,Vloc,Vloc_m,Vloc_old,Vloc_old_m) &
-!$    firstprivate(ixy_m)
-!$omp do private(il)
+!$omp parallel do &
+!$omp&    default(none) private(il) firstprivate(ixy_m) &
+!$omp&    shared(NL,Vh,Vh_m,Vexc,Vexc_m,Eexc,Eexc_m,Vloc,Vloc_m,Vloc_old,Vloc_old_m)
     do il=1,NL
       Vh(il)         = Vh_m(il,ixy_m)
       Vexc(il)       = Vexc_m(il,ixy_m)
@@ -638,26 +636,23 @@ contains
       Vloc(il)       = Vloc_m(il,ixy_m)
       Vloc_old(il,:) = Vloc_old_m(il,:,ixy_m)
     end do
-!$omp end do
-!$omp end parallel
+!$omp end parallel do
   end subroutine
 
   subroutine put_macro_data(ixy_m)
     implicit none
     integer, intent(in) :: ixy_m
     integer :: il
-!$omp parallel default(none) &
-!$    shared(NL,Vh,Vh_m,Vexc,Vexc_m,Eexc,Eexc_m,Vloc,Vloc_m) &
-!$    firstprivate(ixy_m)
-!$omp do private(il)
+!$omp parallel do &
+!$omp&    default(none) private(il) firstprivate(ixy_m) &
+!$omp&    shared(NL,Vh,Vh_m,Vexc,Vexc_m,Eexc,Eexc_m,Vloc,Vloc_m)
     do il=1,NL
       Vh_m(il,ixy_m)   = Vh(il)
       Vexc_m(il,ixy_m) = Vexc(il)
       Eexc_m(il,ixy_m) = Eexc(il)
       Vloc_m(il,ixy_m) = Vloc(il)
     end do
-!$omp end do
-!$omp end parallel
+!$omp end parallel do
   end subroutine
 
   subroutine reset_gs_timer

--- a/ARTED/control/control_ms.f90
+++ b/ARTED/control/control_ms.f90
@@ -747,10 +747,13 @@ Subroutine Read_data
     write(*,*) 'KbTev=',KbTev ! sato
   end if
 
-
+#ifdef ARTED_USE_FORTRAN2008
   write (process_directory,'(A,A,I5.5,A)') trim(directory),'/work_p',procid(1),'/'
   call create_directory(process_directory)
-
+#else
+  process_directory = trim(directory)
+#endif
+  
   call comm_bcast(need_backup,proc_group(1))
   call comm_bcast(file_GS,proc_group(1))
   call comm_bcast(file_RT,proc_group(1))

--- a/ARTED/control/control_sc.f90
+++ b/ARTED/control/control_sc.f90
@@ -616,9 +616,12 @@ Subroutine Read_data
     write(*,*) 'KbTev=',KbTev ! sato
   end if
 
-
+#ifdef ARTED_USE_FORTRAN2008
   write (process_directory,'(A,A,I5.5,A)') trim(directory),'/work_p',procid(1),'/'
   call create_directory(process_directory)
+#else
+  process_directory = trim(directory)
+#endif
 
   call comm_bcast(need_backup,proc_group(1))
   call comm_bcast(file_GS,proc_group(1))

--- a/ARTED/modules/misc_routines.f90
+++ b/ARTED/modules/misc_routines.f90
@@ -19,7 +19,10 @@ module misc_routines
   public :: floor_pow2, ceiling_pow2
   public :: gen_logfilename
   public :: get_wtime
+
+#ifdef ARTED_USE_FORTRAN2008
   public :: create_directory
+#endif
 
 private
 contains
@@ -72,9 +75,11 @@ contains
 
   ! NOTE: execute_command_line() is standardized at Fortran2008.
   !       In specification, `Execute command line` is defined this feature.
+#ifdef ARTED_USE_FORTRAN2008
   subroutine create_directory(dirpath)
     implicit none
     character(*), intent(in) :: dirpath
     call execute_command_line('mkdir -p '//adjustl(trim(dirpath)), wait=.true.)
   end subroutine
+#endif
 end module

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,10 @@
 # This is a makefile for SALMON program.
-
-
-
 # please select archtecture by deleting "#"
 
-ARCH = intel
+ARCH = gnu_with_mkl
+#ARCH = intel
 #ARCH = fujitsu
 #ARCH = intel-knl
-
-
 
 #### explanation for environmental values #########
 # FC: compiler                                    #
@@ -18,12 +14,24 @@ ARCH = intel
 # LIBSCALAPACK: options for scalapack libraries   #
 ###################################################
 
+ifeq ($(ARCH), gnu_with_mkl)
+    TARGET = salmon.cpu
+    FC = mpifc
+    CC = mpicc
+    FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-form -ffree-line-length-none
+    CFLAGS = -O3 -fopenmp -Wall
+    FILE_MATHLIB = lapack
+    LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5
+    LIBSCALAPACK = $(LIBLAPACK) -lmkl_blacs_intelmpi_lp64 -lmkl_scalapack_lp64 -lm
+    MODULE_SWITCH = -J
+endif
+
 ifeq ($(ARCH), intel)
     TARGET = salmon.cpu
     FC = mpiifort
     CC = mpiicc
-    FFLAGS = -O2 -qopenmp -ansi-alias -fno-alias -fpp -nogen-interface -std90 -warn all
-    CFLAGS = -O2 -qopenmp -ansi-alias -fno-alias -Wall -restrict
+    FFLAGS = -O3 -qopenmp -ansi-alias -fno-alias -fpp -nogen-interface -std03 -warn all
+    CFLAGS = -O3 -qopenmp -ansi-alias -fno-alias -Wall -restrict
     FILE_MATHLIB = lapack
     LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5
     LIBSCALAPACK = $(LIBLAPACK) -lmkl_blacs_intelmpi_lp64 -lmkl_scalapack_lp64 -lm
@@ -52,7 +60,7 @@ ifeq ($(ARCH), intel-knl)
             -DARTED_EXPLICIT_VECTORIZATION \
             -DARTED_REDUCE_FOR_MANYCORE \
             -DARTED_ENABLE_SOFTWARE_PREFETCH
-    FFLAGS = $(FLAGS) -O3 -fpp -nogen-interface -std90 -warn all -diag-disable 6187,6477,6916,7025,7416
+    FFLAGS = $(FLAGS) -O3 -fpp -nogen-interface -std03 -warn all -diag-disable 6187,6477,6916,7025,7416
     CFLAGS = $(FLAGS) -O3 -Wall -diag-disable=10388 -restrict
     FILE_MATHLIB = lapack
     LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5
@@ -60,6 +68,7 @@ ifeq ($(ARCH), intel-knl)
     SIMD_SET = IMCI
     MODULE_SWITCH = -module
 endif
+
 
 ####################################################
 ##### please do not modify following sentences #####

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # This is a makefile for SALMON program.
 # please select archtecture by deleting "#"
 
-ARCH = gnu_with_mkl
-#ARCH = intel
+#ARCH = gnu
+ARCH = intel
 #ARCH = fujitsu
 #ARCH = intel-knl
 
@@ -14,7 +14,7 @@ ARCH = gnu_with_mkl
 # LIBSCALAPACK: options for scalapack libraries   #
 ###################################################
 
-ifeq ($(ARCH), gnu_with_mkl)
+ifeq ($(ARCH), gnu)
     TARGET = salmon.cpu
     FC = mpifc
     CC = mpicc


### PR DESCRIPTION
This pull request provides a makefile configulation for build envorinment of `gnu fortran compiler`.

- To build for the gnu environment,  delete commentout of Makefile as below:
```
ARCH = gnu
#ARCH = intel
#ARCH = fujitsu
#ARCH = intel-knl
```

- By default, `Intel MKL` is linked as a required numerical libraries; lapack and scalapack. To use other libraries in your environment, rewrite the variables of `LIBLAPACK` and `LIBSCALAPACK`.