### PR TITLE
Fix a problem of build in GCC environment

### DIFF
--- a/ARTED/modules/global_variables.f90
+++ b/ARTED/modules/global_variables.f90
@@ -251,6 +251,13 @@ Module Global_Variables
       logical,intent(in) :: Rion_update
       integer,intent(in),optional :: ixy_m
     end subroutine Ion_Force_omp
+  
+    subroutine hpsi_omp_KB_base(ik,tpsi,htpsi,ttpsi)
+      integer,intent(in)              :: ik
+      complex(8),intent(in)           ::  tpsi
+      complex(8),intent(out)          :: htpsi
+      complex(8),intent(out),optional :: ttpsi
+    end subroutine hpsi_omp_KB_base
   end interface
 
 #if defined(__KNC__) || defined(__AVX512F__)


### PR DESCRIPTION
This pull request contains additional interface block for __hpsi__ related subroutine, which causes the problem in some version of gcc environments (e.g.  gcc 4.8.5).
