### PR TITLE
Remove comm_finalize before end_parallel

### DIFF
--- a/ARTED/control/control_ms.f90
+++ b/ARTED/control/control_ms.f90
@@ -619,7 +619,7 @@ subroutine main
 !  if(comm_is_root(1)) then
 !    close(940)
 !  endif
-  call comm_finalize
+  !call comm_finalize
 
 contains
   subroutine get_macro_data(ixy_m)

--- a/ARTED/control/control_sc.f90
+++ b/ARTED/control/control_sc.f90
@@ -538,7 +538,6 @@ subroutine main
   if (comm_is_root()) call timer_show_hour('Total time =',LOG_ALL)
 
 1 if(comm_is_root()) write(*,*)  'This calculation is shutdown successfully!'
-  call comm_finalize
 
 contains
   subroutine reset_gs_timer


### PR DESCRIPTION
This pull request contains a bugfix to doubly finalize the MPI.