### PR TITLE
Implemented unit-converter for input

### DIFF
--- a/ARTED/control/inputfile.f90
+++ b/ARTED/control/inputfile.f90
@@ -15,7 +15,7 @@
 !
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
 module inputfile
-  use input
+  use inputoutput
   implicit none
   
   
@@ -240,7 +240,7 @@ contains
     call comm_bcast(functional, proc_group(1))
     call comm_bcast(cval, proc_group(1))
     call comm_bcast(propagator,proc_group(1))
-    call comm_bcast(aL, proc_group(1))
+    call comm_bcast(aL, proc_group(1)); aL = aL*ulength_to_au ! convert to a.u.
     call comm_bcast(ax, proc_group(1))
     call comm_bcast(ay, proc_group(1))
     call comm_bcast(az, proc_group(1))
@@ -262,7 +262,7 @@ contains
     call comm_bcast(NKz, proc_group(1))
     call comm_bcast(file_kw, proc_group(1))
     call comm_bcast(Nt, proc_group(1))
-    call comm_bcast(dt, proc_group(1))
+    call comm_bcast(dt, proc_group(1)); dt = dt*utime_to_au ! convert to a.u.
     call comm_bcast(ps_format, proc_group(1))
     call comm_bcast(PSmask_option, proc_group(1))
     call comm_bcast(alpha_mask, proc_group(1))
@@ -279,7 +279,7 @@ contains
     call comm_bcast(NFSset_every, proc_group(1))
     call comm_bcast(Nscf, proc_group(1))
     call comm_bcast(Longi_Trans, proc_group(1))
-    call comm_bcast(dAc, proc_group(1))
+    call comm_bcast(dAc, proc_group(1)); dAc = dAc*(uenergy_to_au/ulength_to_au)
     call comm_bcast(AE_shape, proc_group(1))
     call comm_bcast(IWcm2_1, proc_group(1))
     call comm_bcast(tpulsefs_1, proc_group(1))
@@ -293,13 +293,13 @@ contains
     call comm_bcast(Epdir_2, proc_group(1))
     call comm_bcast(T1_T2fs, proc_group(1))
     call comm_bcast(Nomega, proc_group(1))
-    call comm_bcast(domega, proc_group(1))
+    call comm_bcast(domega, proc_group(1)); domega=domega*uenergy_to_au
     call comm_bcast(FDTDdim, proc_group(1))
     call comm_bcast(TwoD_shape, proc_group(1))
     call comm_bcast(NX_m, proc_group(1))
     call comm_bcast(NY_m, proc_group(1))
-    call comm_bcast(HX_m, proc_group(1))
-    call comm_bcast(HY_m, proc_group(1))
+    call comm_bcast(HX_m, proc_group(1)); HX_m=HX_m*ulength_to_au
+    call comm_bcast(HY_m, proc_group(1)); HY_m=HY_m*ulength_to_au
     call comm_bcast(NKsplit, proc_group(1))
     call comm_bcast(NXYsplit, proc_group(1))
     call comm_bcast(NXvacL_m, proc_group(1))

--- a/GCEED/read_input_gceed.f90
+++ b/GCEED/read_input_gceed.f90
@@ -1,5 +1,5 @@
 subroutine read_input_gceed(procid,cfunction2)
-  use input
+  use inputoutput
   implicit none
   include 'mpif.h'
   character(30),intent(out) :: cfunction2

--- a/GCEED/rt/read_input_rt.f90
+++ b/GCEED/rt/read_input_rt.f90
@@ -15,7 +15,7 @@
 subroutine read_input_rt(IC_rt,OC_rt,Ntime,Nenergy,dE,file_IN,file_RT,file_alpha,file_RT_q,file_alpha_q,file_RT_e, &
     & file_RT_dip2,file_alpha_dip2,file_RT_dip2_q,file_alpha_dip2_q,file_RT_dip2_e,file_external, &
     & file_IN_rt,file_OUT_rt)
-use input
+use inputoutput
 use scf_data
 use new_world_sub
 !$ use omp_lib
@@ -76,7 +76,7 @@ if(myrank==0)then
   rewind(fh_namelist)
 end if
 call MPI_Bcast(Nenergy,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-call MPI_Bcast(dE,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+call MPI_Bcast(dE,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr); dE = dE*uenergy_to_au
 call MPI_Bcast(N_hamil,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(icalcforce,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(iflag_md,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
@@ -141,7 +141,7 @@ if(myrank==0)then
   read(fh_namelist,NML=group_propagation)
   rewind(fh_namelist)
 end if
-call MPI_Bcast(dt,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+call MPI_Bcast(dt,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr); dt=dt*utime_to_au
 call MPI_Bcast(Ntime,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 if(dt<=1.d-10)then
   write(*,*) "please set dt."
@@ -294,17 +294,26 @@ if(myrank==0)then
 end if
 call MPI_Bcast(ikind_eext,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(Fst,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+  Fst=Fst*(uenergy_to_au/ulength_to_au)
 call MPI_Bcast(dir,3,MPI_Character,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(dir2,2,MPI_Character,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(romega,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+romega = romega*uenergy_to_au
 call MPI_Bcast(pulse_T,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+pulse_T=pulse_T*utime_to_au
 call MPI_Bcast(rlaser_I,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(tau,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+tau_1=tau_1*utime_to_au
 call MPI_Bcast(romega2,2,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+romega2 = romega2*uenergy_to_au
 call MPI_Bcast(pulse_T2,2,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+pulse_T2=pulse_T2*utime_to_au
 call MPI_Bcast(rlaser_I2,2,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(tau2,2,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+tau_2=tau_2*utime_to_au
+
 call MPI_Bcast(delay,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
+delay=delay*utime_to_au
 call MPI_Bcast(rcycle,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
 
 !===== namelist for group_others =====

--- a/GCEED/rt/real_time_dft.f90
+++ b/GCEED/rt/real_time_dft.f90
@@ -1,4 +1,4 @@
-! Copyright 2017 Shunsuke A. Sato, Katsuyuki Nobusada, Masashi Noda, Kazuya Ishimura, Kenji Iida, Maiku Yamaguchi
+! Copyright 2017 Katsuyuki Nobusada, Masashi Noda, Kazuya Ishimura, Kenji Iida, Maiku Yamaguchi, Shunsuke A. Sato
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -102,13 +102,13 @@ call read_input_rt(IC_rt,OC_rt,Ntime,Nenergy,dE,file_IN,file_RT,file_alpha,file_
 if(myrank.eq.0)then
   write(*,*)
   write(*,*) "Total time step      =",Ntime
-  write(*,*) "Time step[fs]        =",dt*1au_time_fs
+  write(*,*) "Time step[fs]        =",dt*au_time_fs
   write(*,*) "Field strength[?]    =",Fst
   if(ikind_eext <= 1)then
     write(*,*) "      direction      =  ",dir
   end if
   write(*,*) "Energy range         =",Nenergy
-  write(*,*) "Energy resolution[eV]=",dE*1au_energy_ev
+  write(*,*) "Energy resolution[eV]=",dE*au_energy_ev
   write(*,*) "ikind_eext is           ", ikind_eext
   write(*,*) "Step for writing dens=", iwdenstep
   write(*,*) "Plane showing density=", denplane
@@ -117,39 +117,39 @@ if(myrank.eq.0)then
   select case (ikind_eext)
     case(1,6,7,8,15)
       write(*,'(a21,f5.2,a4)') "Laser frequency     =",       &
-                           romega*1au_energy_ev, "[eV]"
+                           romega*au_energy_ev, "[eV]"
       write(*,'(a21,f16.8,a4)') "Pulse width of laser=",      &
-                           pulse_T*1au_time_fs,"[fs]"
+                           pulse_T*au_time_fs,"[fs]"
       write(*,'(a21,e16.8,a8)') "Laser intensity      =",      &
                            rlaser_I, "[W/cm^2]"
       write(*,'(a21,e16.8,a8)') "tau                  =",      &
-                           tau*1au_time_fs, "[fs]"
+                           tau*au_time_fs, "[fs]"
     case(4,12)
       write(*,'(a21,2f5.2,a4)') "Laser frequency     =",       &
-                          romega2(1)*1au_energy_ev &
-                          ,romega2(2)*1au_energy_ev, "[eV]"
+                          romega2(1)*au_energy_ev &
+                          ,romega2(2)*au_energy_ev, "[eV]"
       write(*,'(a21,2f16.8,a4)') "Pulse width of laser=",      &
-                          pulse_T2(1)*1au_time_fs&
-                          ,pulse_T2(2)*1au_time_fs,"[fs]"
+                          pulse_T2(1)*au_time_fs&
+                          ,pulse_T2(2)*au_time_fs,"[fs]"
       write(*,'(a21,2e16.8,a8)') "Laser intensity      =",      &
                           rlaser_I2(1),rlaser_I2(2), "[W/cm^2]"
       write(*,'(a21,f16.8,a4)') "delay time           =",      &
-                          delay*1au_time_fs, "[fs]"
+                          delay*au_time_fs, "[fs]"
       write(*,'(a21,f16.8)') "rcycle                =",rcycle
   end select
   
   if(iflag_dip2 == 1) then
     write(*,'(a21)',advance="no") "dipole boundary      ="
     do jj=1,num_dip2-2
-      write(*,'(1e16.8,a8)',advance="no") dip2boundary(jj), "[A],"
+      write(*,'(1e16.8,a8)',advance="no") dip2boundary(jj)*au_length_aa, "[A],"
     end do
-    write(*,'(1e16.8,a8)',advance="yes") dip2boundary(num_dip2-1), "[A]"
+    write(*,'(1e16.8,a8)',advance="yes") dip2boundary(num_dip2-1)*au_length_aa, "[A]"
   end if
   
   if(iflag_fourier_omega == 1) then
     write(*,'(a61)') "===== List of frequencies for fourier transform (in eV) ====="
     do jj=1,num_fourier_omega  
-      write(*,'(f16.8)') fourier_omega(jj)
+      write(*,'(f16.8)') fourier_omega(jj)*au_energy_ev
     end do
     write(*,'(a61)') "============================================================="
   end if
@@ -160,7 +160,7 @@ debye2au = 0.393428d0
 
 select case (ikind_eext)
   case(0,10)
-    Fst=Fst/5.14223d1
+    Fst=Fst !/5.14223d1
 end select
 dE=dE !/2d0/Ry 
 dt=dt !*fs2eVinv*2.d0*Ry!a.u. ! 1[fs] = 1.51925 [1/eV]  !2.d0*Ry*1.51925d0
@@ -173,8 +173,8 @@ select case (ikind_eext)
     pulse_T=pulse_T !*fs2eVinv*2.d0*Ry 
     Fst=sqrt(rlaser_I)*1.0d2*2.74492d1/(5.14223d11)!I[W/cm^2]->E[a.u.]
     tau=tau !*fs2eVinv*2.d0*Ry 
-    lasbound_sta(1:3)=lasbound_sta(1:3)/a_B
-    lasbound_end(1:3)=lasbound_end(1:3)/a_B
+    lasbound_sta(1:3)=lasbound_sta(1:3) !/a_B
+    lasbound_end(1:3)=lasbound_end(1:3) !/a_B
   case(4,12)
     romega2=romega2 !/2.d0/Ry 
     pulse_T2=pulse_T2 !*fs2eVinv*2.d0*Ry 
@@ -184,7 +184,7 @@ select case (ikind_eext)
 end select
 
 if(iflag_fourier_omega==1)then
-   fourier_omega(1:num_fourier_omega)=fourier_omega(1:num_fourier_omega)/2.d0/Ry 
+   fourier_omega(1:num_fourier_omega)=fourier_omega(1:num_fourier_omega) !/2.d0/Ry 
 end if
 
 elp3(402)=MPI_Wtime()
@@ -228,11 +228,11 @@ elp3(403)=MPI_Wtime()
 
 if(iflag_dip2==1) then
   if(imesh_oddeven==1)then
-    dip2boundary(1:num_dip2-1)=dip2boundary(1:num_dip2-1)/a_B
+    dip2boundary(1:num_dip2-1)=dip2boundary(1:num_dip2-1) !/a_B
     idip2int(1:num_dip2-1)=nint(dip2boundary(1:num_dip2-1)/Hgs(1))
     rto(1:num_dip2-1)=(dip2boundary(1:num_dip2-1)-((dble(idip2int(1:num_dip2-1))-0.5d0)*Hgs(1)))/Hgs(1)
   else if(imesh_oddeven==2)then
-    dip2boundary(1:num_dip2-1)=dip2boundary(1:num_dip2-1)/a_B
+    dip2boundary(1:num_dip2-1)=dip2boundary(1:num_dip2-1) !/a_B
     idip2int(1:num_dip2-1)=nint(dip2boundary(1:num_dip2-1)/Hgs(1)+0.5d0)
     rto(1:num_dip2-1)=(dip2boundary(1:num_dip2-1)-((dble(idip2int(1:num_dip2-1))-1.0d0)*Hgs(1)))/Hgs(1)
   end if
@@ -318,7 +318,7 @@ end if
 ntmg=1
 ! 'Hartree' parameter
 
-Hconv  = Hconv/(2d0*Ry)**2d0/a_B**3   ! Convergence criterion
+Hconv  = Hconv !/(2d0*Ry)**2d0/a_B**3   ! Convergence criterion
 iterVh = 0        ! Iteration counter
 
 

--- a/GCEED/rt/real_time_dft.f90
+++ b/GCEED/rt/real_time_dft.f90
@@ -1,4 +1,4 @@
-! Copyright 2017 Katsuyuki Nobusada, Masashi Noda, Kazuya Ishimura, Kenji Iida, Maiku Yamaguchi
+! Copyright 2017 Shunsuke A. Sato, Katsuyuki Nobusada, Masashi Noda, Kazuya Ishimura, Kenji Iida, Maiku Yamaguchi
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 
 MODULE global_variables_rt
-
+use inputoutput
 use scf_data
 use allocate_mat_sub
 use deallocate_mat_sub
@@ -102,13 +102,13 @@ call read_input_rt(IC_rt,OC_rt,Ntime,Nenergy,dE,file_IN,file_RT,file_alpha,file_
 if(myrank.eq.0)then
   write(*,*)
   write(*,*) "Total time step      =",Ntime
-  write(*,*) "Time step[fs]        =",dt
+  write(*,*) "Time step[fs]        =",dt*1au_time_fs
   write(*,*) "Field strength[?]    =",Fst
   if(ikind_eext <= 1)then
     write(*,*) "      direction      =  ",dir
   end if
   write(*,*) "Energy range         =",Nenergy
-  write(*,*) "Energy resolution[eV]=",dE
+  write(*,*) "Energy resolution[eV]=",dE*1au_energy_ev
   write(*,*) "ikind_eext is           ", ikind_eext
   write(*,*) "Step for writing dens=", iwdenstep
   write(*,*) "Plane showing density=", denplane
@@ -117,22 +117,24 @@ if(myrank.eq.0)then
   select case (ikind_eext)
     case(1,6,7,8,15)
       write(*,'(a21,f5.2,a4)') "Laser frequency     =",       &
-                           romega, "[eV]"
+                           romega*1au_energy_ev, "[eV]"
       write(*,'(a21,f16.8,a4)') "Pulse width of laser=",      &
-                           pulse_T,"[fs]"
+                           pulse_T*1au_time_fs,"[fs]"
       write(*,'(a21,e16.8,a8)') "Laser intensity      =",      &
                            rlaser_I, "[W/cm^2]"
       write(*,'(a21,e16.8,a8)') "tau                  =",      &
-                           tau, "[fs]"
+                           tau*1au_time_fs, "[fs]"
     case(4,12)
       write(*,'(a21,2f5.2,a4)') "Laser frequency     =",       &
-                          romega2(1),romega2(2), "[eV]"
+                          romega2(1)*1au_energy_ev &
+                          ,romega2(2)*1au_energy_ev, "[eV]"
       write(*,'(a21,2f16.8,a4)') "Pulse width of laser=",      &
-                          pulse_T2(1),pulse_T2(2),"[fs]"
+                          pulse_T2(1)*1au_time_fs&
+                          ,pulse_T2(2)*1au_time_fs,"[fs]"
       write(*,'(a21,2e16.8,a8)') "Laser intensity      =",      &
                           rlaser_I2(1),rlaser_I2(2), "[W/cm^2]"
       write(*,'(a21,f16.8,a4)') "delay time           =",      &
-                          delay, "[fs]"
+                          delay*1au_time_fs, "[fs]"
       write(*,'(a21,f16.8)') "rcycle                =",rcycle
   end select
   
@@ -160,25 +162,25 @@ select case (ikind_eext)
   case(0,10)
     Fst=Fst/5.14223d1
 end select
-dE=dE/2d0/Ry 
-dt=dt*fs2eVinv*2.d0*Ry!a.u. ! 1[fs] = 1.51925 [1/eV]  !2.d0*Ry*1.51925d0
+dE=dE !/2d0/Ry 
+dt=dt !*fs2eVinv*2.d0*Ry!a.u. ! 1[fs] = 1.51925 [1/eV]  !2.d0*Ry*1.51925d0
 
 if(idensum==0) posplane=posplane/a_B 
 
 select case (ikind_eext)
   case(1,6:8,11,15)
-    romega=romega/2.d0/Ry 
-    pulse_T=pulse_T*fs2eVinv*2.d0*Ry 
+    romega=romega !/2.d0/Ry 
+    pulse_T=pulse_T !*fs2eVinv*2.d0*Ry 
     Fst=sqrt(rlaser_I)*1.0d2*2.74492d1/(5.14223d11)!I[W/cm^2]->E[a.u.]
-    tau=tau*fs2eVinv*2.d0*Ry 
+    tau=tau !*fs2eVinv*2.d0*Ry 
     lasbound_sta(1:3)=lasbound_sta(1:3)/a_B
     lasbound_end(1:3)=lasbound_end(1:3)/a_B
   case(4,12)
-    romega2=romega2/2.d0/Ry 
-    pulse_T2=pulse_T2*fs2eVinv*2.d0*Ry 
+    romega2=romega2 !/2.d0/Ry 
+    pulse_T2=pulse_T2 !*fs2eVinv*2.d0*Ry 
     Fst2=sqrt(rlaser_I2)*1.0d2*2.74492d1/(5.14223d11)!I[W/cm^2]->E[a.u.]
-    tau2=tau2*fs2eVinv*2.d0*Ry 
-    delay  = delay*fs2eVinv*2.d0*Ry 
+    tau2=tau2 !*fs2eVinv*2.d0*Ry 
+    delay  = delay !*fs2eVinv*2.d0*Ry 
 end select
 
 if(iflag_fourier_omega==1)then

--- a/GCEED/scf/read_input_scf.f90
+++ b/GCEED/scf/read_input_scf.f90
@@ -13,7 +13,7 @@
 ! limitations under the License.
 
 subroutine read_input_scf(file_IN,file_OUT,LDA_Info,file_ini,iDiterYBCG,file_atoms_coo)
-use input
+use inputoutput
 use scf_data
 use new_world_sub
 !$ use omp_lib
@@ -136,8 +136,8 @@ call MPI_Bcast(ilsda,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(MST,2,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(ifMST,2,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 
-Harray=Harray/a_B
-rLsize=rLsize/a_B
+Harray=Harray*ulength_to_au
+rLsize=rLsize*ulength_to_au
 
 if(ilsda==1)then
   nproc_ob_spin(1)=(nproc_ob+1)/2
@@ -232,7 +232,7 @@ call MPI_Bcast(num_pole_xyz,3,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(lmax_MEO,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 
 num_pole=num_pole_xyz(1)*num_pole_xyz(2)*num_pole_xyz(3)
-Hconv  = Hconv/(2d0*Ry)**2d0/a_B**3     ! Convergence criterion
+Hconv  = Hconv*uenergy_to_au**2*ulength_to_au**3     ! Convergence criterion
 
 !===== namelist for group_file =====
 IC=0
@@ -391,7 +391,7 @@ call MPI_Bcast(iflag_pdos,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 if(iflag_ps==1)then
   do ii=1,3
     do iatom=1,MI
-      Rion(ii,iatom)=Rion(ii,iatom)/a_B
+      Rion(ii,iatom)=Rion(ii,iatom)*ulength_to_au
     end do
   end do
 end if

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ MOD_ARTED = modules/backup_routines.f90 modules/communication.f90 \
             modules/performance_analyzer.f90 control/control_ms.f90 \
             control/control_sc.f90 
 
-MOD_SALMON = input.f90
+MOD_SALMON = inputoutput.f90
 
 
 OBJDIR = obj

--- a/example/C2H2/scfrt-intel/input_rt
+++ b/example/C2H2/scfrt-intel/input_rt
@@ -1,3 +1,9 @@
+&units
+unit_length='Angstrom'
+unit_energy='eV'
+unit_time='fs'
+/
+
 &group_function
   cfunction='nanostructure'
 /

--- a/example/C2H2/scfrt-intel/input_scf
+++ b/example/C2H2/scfrt-intel/input_scf
@@ -1,3 +1,9 @@
+&units
+unit_length='Angstrom'
+unit_energy='eV'
+unit_time='fs'
+/
+
 &group_function
   cfunction='nanostructure'
 /

--- a/main/main.f90
+++ b/main/main.f90
@@ -1,5 +1,5 @@
 program main
-  use input
+  use inputoutput
   implicit none
   integer :: nprocs,myrank
   character(30) :: cfunction

--- a/main/main.f90
+++ b/main/main.f90
@@ -5,7 +5,10 @@ program main
   character(30) :: cfunction
 
   call setup_parallel(nprocs,myrank)
-  call read_stdin(myrank,cfunction)
+  call read_stdin(myrank)
+  call read_input_common(myrank,cfunction)
+! read_stdin and read_input_common will be wrapped by a single routine routine
+! after proper implementation for 'cfunction'.
 
   select case(cfunction)
   case("nanostructure")

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TARGET_NAME   salmon_module)
 
 set(SOURCES
-    input.f90
+    inputoutput.f90
 )
 
 add_library(${TARGET_NAME} STATIC ${SOURCES})

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -14,14 +14,22 @@
 !  limitations under the License.
 !
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
-module input
+module inputoutput
 
   implicit none
+!Physical constant
+  real(8),parameter :: 1au_time_fs = 0.02418884326505d0
+  real(8),parameter :: 1au_energy_ev = 27.21138505d0
+  real(8),parameter :: 1au_length_aa = 0.52917721067d0
+
+
   integer, parameter :: fh_namelist = 901
   integer, parameter :: fh_atomic_spiecies = 902
   integer, parameter :: fh_atomic_positions = 903
   integer, parameter :: fh_reentrance = 904
 
+  integer :: inml_group_function
+  integer :: inml_units
   integer :: inml_control
   integer :: inml_system
   integer :: inml_incident
@@ -34,18 +42,20 @@ module input
   integer :: inml_response
   integer :: inml_multiscale
 
-
+!Input/Output units
+  character(16) :: unit_time,unit_length,unit_energy
+  real(8) :: utime_to_au, utime_from_au
+  real(8) :: length_to_au, length_from_au
+  real(8) :: energy_to_au, energy_from_au
 
 contains
 
 
-  subroutine read_stdin(myrank,cfunction)
+  subroutine read_stdin(myrank)
     implicit none
     include 'mpif.h'
-    character(30),intent(out) :: cfunction
+    integer,intent(in) :: myrank
     integer :: ierr
-    integer :: myrank
-    namelist/group_function/ cfunction
 
     integer :: cur = fh_namelist
     integer :: ret = 0
@@ -99,17 +109,97 @@ contains
 
 !    call comm_sync_all()
 
-    if (myrank == 0) then
-       open(fh_namelist, file='.namelist.tmp', status='old')
-       read(fh_namelist, nml=group_function)
-       close(fh_namelist)
-    end if
-    call mpi_bcast(cfunction,30,mpi_character,0,mpi_comm_world,ierr)
 
     return
   end subroutine read_stdin
 
-end module input
+  subroutine read_input_common(myrank,cfunction)
+    include 'mpif.h'
+    integer,intent(in) :: myrank
+    character(30),intent(out) :: cfunction
+    integer :: ierr
+    implicit none
+
+    namelist/group_function/ cfunction
+    namelist/units/ &
+            & unit_time, &
+            & unit_length, &
+            & unit_energy
+
+
+    if (myrank == 0)then
+      open(fh_namelist, file='.namelist.tmp', status='old')
+
+      read(fh_namelist, nml=group_function, iostat=inml_group_function)
+      rewind(fh_namelist)
+
+
+      unit_time='au'
+      unit_length='au'
+      unit_energy='au'
+      read(fh_namelist, nml=units, iostat=inml_units)
+      rewind(fh_namelist)
+
+      close(fh_namelist)
+    end if
+
+
+    call mpi_bcast(cfunction,30,mpi_character,0,mpi_comm_world,ierr)
+    call mpi_bcast(unit_time,16,mpi_character,0,mpi_comm_world,ierr)
+    call mpi_bcast(unit_length,16,mpi_character,0,mpi_comm_world,ierr)
+    call mpi_bcast(unit_energy,16,mpi_character,0,mpi_comm_world,ierr)
+
+
+    call initialize_inputoutput_units
+
+  end subroutine read_input_common
+
+  subroutine initialize_inputoutput_units
+    implicit none
+
+
+! Unit for time
+    select case(unit_time)
+    case('au','a.u.')
+      utime_to_au   = 1d0
+      utime_from_au = 1d0
+    case('fs','femtosecond')
+      utime_to_au   = 1d0/1au_time_fs
+      utime_from_au = 1au_time_fs
+    case default
+      if(myrank == 0)write(*,*)"Invalid unit for time."
+      stop
+    end select
+
+! Unit for length
+    select case(unit_length)
+    case('au','a.u.')
+      ulength_to_au   = 1d0
+      ulength_from_au = 1d0
+    case('AA','angstrom','Angstrom')
+      ulength_to_au   = 1d0/1au_length_aa
+      ulength_from_au = 1au_length_aa
+    case default
+      if(myrank == 0)write(*,*)"Invalid unit for length."
+      stop
+    end select
+
+! Unit for energy
+    select case(unit_energy)
+    case('au','a.u.')
+      uenergy_to_au   = 1d0
+      uenergy_from_au = 1d0
+    case('ev','eV')
+      uenergy_to_au   = 1d0/1au_energy_ev
+      uenergy_from_au = 1au_energy_ev
+    case default
+      if(myrank == 0)write(*,*)"Invalid unit for energy."
+      stop
+    end select
+
+  end subroutine initialize_inputoutput_units
+    
+end module inputoutput
 
 
 

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -151,6 +151,7 @@ contains
     call mpi_bcast(unit_time,16,mpi_character,0,mpi_comm_world,ierr)
     call mpi_bcast(unit_length,16,mpi_character,0,mpi_comm_world,ierr)
     call mpi_bcast(unit_energy,16,mpi_character,0,mpi_comm_world,ierr)
+    call mpi_bcast(unit_charge,16,mpi_character,0,mpi_comm_world,ierr)
 
 
     call initialize_inputoutput_units
@@ -203,7 +204,7 @@ contains
       ucharge_to_au   = 1d0
       ucharge_from_au = 1d0
     case default
-      stop "Invalid unit for time."
+      stop "Invalid unit for charge."
     end select
 
   end subroutine initialize_inputoutput_units

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -18,9 +18,9 @@ module inputoutput
 
   implicit none
 !Physical constant
-  real(8),parameter :: 1au_time_fs = 0.02418884326505d0
-  real(8),parameter :: 1au_energy_ev = 27.21138505d0
-  real(8),parameter :: 1au_length_aa = 0.52917721067d0
+  real(8),parameter :: au_time_fs = 0.02418884326505d0
+  real(8),parameter :: au_energy_ev = 27.21138505d0
+  real(8),parameter :: au_length_aa = 0.52917721067d0
 
 
   integer, parameter :: fh_namelist = 901
@@ -43,10 +43,11 @@ module inputoutput
   integer :: inml_multiscale
 
 !Input/Output units
-  character(16) :: unit_time,unit_length,unit_energy
+  character(16) :: unit_time,unit_length,unit_energy,unit_charge
   real(8) :: utime_to_au, utime_from_au
-  real(8) :: length_to_au, length_from_au
-  real(8) :: energy_to_au, energy_from_au
+  real(8) :: ulength_to_au, ulength_from_au
+  real(8) :: uenergy_to_au, uenergy_from_au
+  real(8) :: ucharge_to_au, ucharge_from_au
 
 contains
 
@@ -114,11 +115,12 @@ contains
   end subroutine read_stdin
 
   subroutine read_input_common(myrank,cfunction)
+    implicit none
     include 'mpif.h'
     integer,intent(in) :: myrank
     character(30),intent(out) :: cfunction
     integer :: ierr
-    implicit none
+
 
     namelist/group_function/ cfunction
     namelist/units/ &
@@ -137,6 +139,7 @@ contains
       unit_time='au'
       unit_length='au'
       unit_energy='au'
+      unit_charge='au'
       read(fh_namelist, nml=units, iostat=inml_units)
       rewind(fh_namelist)
 
@@ -164,11 +167,10 @@ contains
       utime_to_au   = 1d0
       utime_from_au = 1d0
     case('fs','femtosecond')
-      utime_to_au   = 1d0/1au_time_fs
-      utime_from_au = 1au_time_fs
+      utime_to_au   = 1d0/au_time_fs
+      utime_from_au = au_time_fs
     case default
-      if(myrank == 0)write(*,*)"Invalid unit for time."
-      stop
+      stop "Invalid unit for time."
     end select
 
 ! Unit for length
@@ -177,11 +179,10 @@ contains
       ulength_to_au   = 1d0
       ulength_from_au = 1d0
     case('AA','angstrom','Angstrom')
-      ulength_to_au   = 1d0/1au_length_aa
-      ulength_from_au = 1au_length_aa
+      ulength_to_au   = 1d0/au_length_aa
+      ulength_from_au = au_length_aa
     case default
-      if(myrank == 0)write(*,*)"Invalid unit for length."
-      stop
+      stop "Invalid unit for length."
     end select
 
 ! Unit for energy
@@ -190,11 +191,19 @@ contains
       uenergy_to_au   = 1d0
       uenergy_from_au = 1d0
     case('ev','eV')
-      uenergy_to_au   = 1d0/1au_energy_ev
-      uenergy_from_au = 1au_energy_ev
+      uenergy_to_au   = 1d0/au_energy_ev
+      uenergy_from_au = au_energy_ev
     case default
-      if(myrank == 0)write(*,*)"Invalid unit for energy."
-      stop
+      stop "Invalid unit for energy."
+    end select
+
+! Unit for charge
+    select case(unit_charge)
+    case('au','a.u.')
+      ucharge_to_au   = 1d0
+      ucharge_from_au = 1d0
+    case default
+      stop "Invalid unit for time."
     end select
 
   end subroutine initialize_inputoutput_units


### PR DESCRIPTION
**Please merge This PR!**

To employ common input for both ARTED and GCEED parts, I implemented the unit converter for the input variables. Now, units can be chosen by the namelist `&units`:
For time `unit_time`, the atomic unit (`au` and `a.u.`) and the femtosecond (`fs` and `femtosecond`) can be chosen.
For length `unit_length`, the atomic unit, and the Angstrom  (`AA`, `Angstrom`,and `angstrom`) can be chosen.
For energy `unit_energy`, the atomic unit and the electron-volt (`eV` and `ev`) can be chosen.
For charge `unit_charge`, the atomic unit is only available.

For all the unit, the atomic unit is default at the moment.