### PR TITLE
Optimized hpsi and Laplacian in GCEED.

### DIFF
--- a/GCEED/modules/hpsi2.f90
+++ b/GCEED/modules/hpsi2.f90
@@ -1,5 +1,5 @@
-! Copyright 2017 Katsuyuki Nobusada, Masashi Noda, Kazuya Ishimura, Kenji Iida, Maiku Yamaguchi
-!
+! Copyright 2017 Katsuyuki Nobusada, Masashi Noda, Kazuya Ishimura, Kenji Iida, Maiku Yamaguchi,
+!                Shunsuke A. Sato
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
 ! You may obtain a copy of the License at
@@ -211,7 +211,7 @@ call calc_laplacian2(wk2,rlap_wk)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
-  htpsi(ix,iy,iz)=htpsi(ix,iy,iz)-1d0/2d0*rlap_wk(ix,iy,iz)
+  htpsi(ix,iy,iz)=htpsi(ix,iy,iz)-0.5d0*rlap_wk(ix,iy,iz)
 end do                         
 end do
 end do
@@ -349,18 +349,18 @@ if(isub==0)then
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
     htpsi(ix,iy,iz)=(Vlocal(ix,iy,iz,ispin)+fdN0)*tpsi(ix,iy,iz)     &
-      +fdN1(1,1)*tpsi(ix+1,iy,iz) + fdN1(1,1)*tpsi(ix-1,iy,iz)      &
-      +fdN1(1,2)*tpsi(ix,iy+1,iz) + fdN1(1,2)*tpsi(ix,iy-1,iz)      &
-      +fdN1(1,3)*tpsi(ix,iy,iz+1) + fdN1(1,3)*tpsi(ix,iy,iz-1)      &
-      +fdN1(2,1)*tpsi(ix+2,iy,iz) + fdN1(2,1)*tpsi(ix-2,iy,iz)      &
-      +fdN1(2,2)*tpsi(ix,iy+2,iz) + fdN1(2,2)*tpsi(ix,iy-2,iz)      &
-      +fdN1(2,3)*tpsi(ix,iy,iz+2) + fdN1(2,3)*tpsi(ix,iy,iz-2)      &
-      +fdN1(3,1)*tpsi(ix+3,iy,iz) + fdN1(3,1)*tpsi(ix-3,iy,iz)      &
-      +fdN1(3,2)*tpsi(ix,iy+3,iz) + fdN1(3,2)*tpsi(ix,iy-3,iz)      &
-      +fdN1(3,3)*tpsi(ix,iy,iz+3) + fdN1(3,3)*tpsi(ix,iy,iz-3)      &
-      +fdN1(4,1)*tpsi(ix+4,iy,iz) + fdN1(4,1)*tpsi(ix-4,iy,iz)      &
-      +fdN1(4,2)*tpsi(ix,iy+4,iz) + fdN1(4,2)*tpsi(ix,iy-4,iz)      &
-      +fdN1(4,3)*tpsi(ix,iy,iz+4) + fdN1(4,3)*tpsi(ix,iy,iz-4) 
+      +fdN1(1,1)*(tpsi(ix+1,iy,iz) + tpsi(ix-1,iy,iz))      &
+      +fdN1(1,2)*(tpsi(ix,iy+1,iz) + tpsi(ix,iy-1,iz))      &
+      +fdN1(1,3)*(tpsi(ix,iy,iz+1) + tpsi(ix,iy,iz-1))      &
+      +fdN1(2,1)*(tpsi(ix+2,iy,iz) + tpsi(ix-2,iy,iz))      &
+      +fdN1(2,2)*(tpsi(ix,iy+2,iz) + tpsi(ix,iy-2,iz))      &
+      +fdN1(2,3)*(tpsi(ix,iy,iz+2) + tpsi(ix,iy,iz-2))      &
+      +fdN1(3,1)*(tpsi(ix+3,iy,iz) + tpsi(ix-3,iy,iz))      &
+      +fdN1(3,2)*(tpsi(ix,iy+3,iz) + tpsi(ix,iy-3,iz))      &
+      +fdN1(3,3)*(tpsi(ix,iy,iz+3) + tpsi(ix,iy,iz-3))      &
+      +fdN1(4,1)*(tpsi(ix+4,iy,iz) + tpsi(ix-4,iy,iz))      &
+      +fdN1(4,2)*(tpsi(ix,iy+4,iz) + tpsi(ix,iy-4,iz))      &
+      +fdN1(4,3)*(tpsi(ix,iy,iz+4) + tpsi(ix,iy,iz-4)) 
   end do
   end do
   end do

--- a/GCEED/modules/laplacian2.f90
+++ b/GCEED/modules/laplacian2.f90
@@ -1,5 +1,5 @@
 ! Copyright 2017 Katsuyuki Nobusada, Masashi Noda, Kazuya Ishimura, Kenji Iida, Maiku Yamaguchi
-!
+!                Shunsuke A. Sato
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
 ! You may obtain a copy of the License at
@@ -33,11 +33,15 @@ implicit none
 integer :: ix,iy,iz,ist
 real(8) :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end(3))
 real(8) :: lap_wk(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
-real(8) :: f0
+real(8) :: f0, Hgs_i2(3)
 
 f0=(1.d0/Hgs(1)**2   &
    +1.d0/Hgs(2)**2   &
    +1.d0/Hgs(3)**2)
+
+Hgs_i2(1) = 1d0/Hgs(1)**2
+Hgs_i2(2) = 1d0/Hgs(2)**2
+Hgs_i2(3) = 1d0/Hgs(3)**2
 
 !$OMP parallel do private(ist)
 do iz=iwk3sta(3),iwk3end(3)
@@ -46,9 +50,9 @@ do ix=iwk3sta(1),iwk3end(1)
   lap_wk(ix,iy,iz)=cNmat(0,Nd)*f0*wk2(ix,iy,iz)
   do ist=1,Nd
     lap_wk(ix,iy,iz)=lap_wk(ix,iy,iz)     &
-           +cNmat(ist,Nd)*( wk2(ix+ist,iy,iz)/Hgs(1)**2 + wk2(ix-ist,iy,iz)/Hgs(1)**2       &
-                           +wk2(ix,iy+ist,iz)/Hgs(2)**2 + wk2(ix,iy-ist,iz)/Hgs(2)**2       &
-                           +wk2(ix,iy,iz+ist)/Hgs(3)**2 + wk2(ix,iy,iz-ist)/Hgs(3)**2  )
+           +cNmat(ist,Nd)*( Hgs_i2(1)*(wk2(ix+ist,iy,iz)+wk2(ix-ist,iy,iz))  &
+                           +Hgs_i2(2)*(wk2(ix,iy+ist,iz)+wk2(ix,iy-ist,iz))  &
+                           +Hgs_i2(3)*(wk2(ix,iy,iz+ist)+wk2(ix,iy,iz-ist)) )
   end do
 end do
 end do
@@ -66,11 +70,15 @@ implicit none
 integer :: ix,iy,iz,ist
 complex(8) :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end(3))
 complex(8) :: lap_wk(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
-real(8) :: f0
+real(8) :: f0, Hgs_i2(3)
 
 f0=(1.d0/Hgs(1)**2   &
    +1.d0/Hgs(2)**2   &
    +1.d0/Hgs(3)**2)
+
+Hgs_i2(1) = 1d0/Hgs(1)**2
+Hgs_i2(2) = 1d0/Hgs(2)**2
+Hgs_i2(3) = 1d0/Hgs(3)**2
 
 !$OMP parallel do private(ist)
 do iz=iwk3sta(3),iwk3end(3)
@@ -79,9 +87,9 @@ do ix=iwk3sta(1),iwk3end(1)
   lap_wk(ix,iy,iz)=cNmat(0,Nd)*f0*wk2(ix,iy,iz)
   do ist=1,Nd
     lap_wk(ix,iy,iz)=lap_wk(ix,iy,iz)     &
-           +cNmat(ist,Nd)*( wk2(ix+ist,iy,iz)/Hgs(1)**2 + wk2(ix-ist,iy,iz)/Hgs(1)**2       &
-                           +wk2(ix,iy+ist,iz)/Hgs(2)**2 + wk2(ix,iy-ist,iz)/Hgs(2)**2       &
-                           +wk2(ix,iy,iz+ist)/Hgs(3)**2 + wk2(ix,iy,iz-ist)/Hgs(3)**2  )
+           +cNmat(ist,Nd)*( Hgs_i2(1)*(wk2(ix+ist,iy,iz)+wk2(ix-ist,iy,iz))  &
+                           +Hgs_i2(2)*(wk2(ix,iy+ist,iz)+wk2(ix,iy-ist,iz))  &
+                           +Hgs_i2(3)*(wk2(ix,iy,iz+ist)+wk2(ix,iy,iz-ist)) )
   end do
 end do
 end do

--- a/GCEED/rt/hpsi_groupob.f90
+++ b/GCEED/rt/hpsi_groupob.f90
@@ -1,5 +1,5 @@
 ! Copyright 2017 Katsuyuki Nobusada, Masashi Noda, Kazuya Ishimura, Kenji Iida, Maiku Yamaguchi
-!
+!                Shunsuke A. Sato
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
 ! You may obtain a copy of the License at
@@ -91,14 +91,14 @@ if(Nd==4)then
       do ix=iwk3sta(1),iwk3end(1)
         htpsi(ix,iy,iz,iob,1) =   &
           ( tVlocal(ix,iy,iz,ispin)+fdN0)*tpsi(ix,iy,iz,iob,1)  &
-          +fdN1(1,1)* tpsi(ix+1,iy,iz,iob,1) + fdN1(1,1)* tpsi(ix-1,iy,iz,iob,1)  &
-          +fdN1(2,1)* tpsi(ix+2,iy,iz,iob,1) + fdN1(2,1)* tpsi(ix-2,iy,iz,iob,1)  &
-          +fdN1(3,1)* tpsi(ix+3,iy,iz,iob,1) + fdN1(3,1)* tpsi(ix-3,iy,iz,iob,1)  &
-          +fdN1(4,1)* tpsi(ix+4,iy,iz,iob,1) + fdN1(4,1)* tpsi(ix-4,iy,iz,iob,1)  &
-          +fdN1(1,2)* tpsi(ix,iy+1,iz,iob,1) + fdN1(1,2)* tpsi(ix,iy-1,iz,iob,1)  &
-          +fdN1(2,2)* tpsi(ix,iy+2,iz,iob,1) + fdN1(2,2)* tpsi(ix,iy-2,iz,iob,1)  &
-          +fdN1(3,2)* tpsi(ix,iy+3,iz,iob,1) + fdN1(3,2)* tpsi(ix,iy-3,iz,iob,1)  &
-          +fdN1(4,2)* tpsi(ix,iy+4,iz,iob,1) + fdN1(4,2)* tpsi(ix,iy-4,iz,iob,1)  
+          +fdN1(1,1)*(tpsi(ix+1,iy,iz,iob,1) + tpsi(ix-1,iy,iz,iob,1))  &
+          +fdN1(2,1)*(tpsi(ix+2,iy,iz,iob,1) + tpsi(ix-2,iy,iz,iob,1))  &
+          +fdN1(3,1)*(tpsi(ix+3,iy,iz,iob,1) + tpsi(ix-3,iy,iz,iob,1))  &
+          +fdN1(4,1)*(tpsi(ix+4,iy,iz,iob,1) + tpsi(ix-4,iy,iz,iob,1))  &
+          +fdN1(1,2)*(tpsi(ix,iy+1,iz,iob,1) + tpsi(ix,iy-1,iz,iob,1))  &
+          +fdN1(2,2)*(tpsi(ix,iy+2,iz,iob,1) + tpsi(ix,iy-2,iz,iob,1))  &
+          +fdN1(3,2)*(tpsi(ix,iy+3,iz,iob,1) + tpsi(ix,iy-3,iz,iob,1))  &
+          +fdN1(4,2)*(tpsi(ix,iy+4,iz,iob,1) + tpsi(ix,iy-4,iz,iob,1))  
       end do
       end do
 !$OMP end do nowait
@@ -106,10 +106,10 @@ if(Nd==4)then
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         htpsi(ix,iy,iz,iob,1) = htpsi(ix,iy,iz,iob,1)  &
-          +fdN1(1,3)* tpsi(ix,iy,iz+1,iob,1) + fdN1(1,3)* tpsi(ix,iy,iz-1,iob,1)  &
-          +fdN1(2,3)* tpsi(ix,iy,iz+2,iob,1) + fdN1(2,3)* tpsi(ix,iy,iz-2,iob,1)  &
-          +fdN1(3,3)* tpsi(ix,iy,iz+3,iob,1) + fdN1(3,3)* tpsi(ix,iy,iz-3,iob,1)  &
-          +fdN1(4,3)* tpsi(ix,iy,iz+4,iob,1) + fdN1(4,3)* tpsi(ix,iy,iz-4,iob,1)
+          +fdN1(1,3)*(tpsi(ix,iy,iz+1,iob,1) + tpsi(ix,iy,iz-1,iob,1))  &
+          +fdN1(2,3)*(tpsi(ix,iy,iz+2,iob,1) + tpsi(ix,iy,iz-2,iob,1))  &
+          +fdN1(3,3)*(tpsi(ix,iy,iz+3,iob,1) + tpsi(ix,iy,iz-3,iob,1))  &
+          +fdN1(4,3)*(tpsi(ix,iy,iz+4,iob,1) + tpsi(ix,iy,iz-4,iob,1))
       end do
       end do
 !$OMP end do nowait
@@ -134,8 +134,8 @@ else
         htpsi(ix,iy,iz,iob,1) = (tVlocal(ix,iy,iz,ispin)+fdN0) *tpsi(ix,iy,iz,iob,1)  
         do ist=1,Nd  
           htpsi(ix,iy,iz,iob,1) = htpsi(ix,iy,iz,iob,1)         &
-            +fdN1(ist,1)* tpsi(ix+ist,iy,iz,iob,1) + fdN1(ist,1)* tpsi(ix-ist,iy,iz,iob,1)     &
-            +fdN1(ist,2)* tpsi(ix,iy+ist,iz,iob,1) + fdN1(ist,2)* tpsi(ix,iy-ist,iz,iob,1)
+            +fdN1(ist,1)* (tpsi(ix+ist,iy,iz,iob,1) + tpsi(ix-ist,iy,iz,iob,1))     &
+            +fdN1(ist,2)* (tpsi(ix,iy+ist,iz,iob,1) + tpsi(ix,iy-ist,iz,iob,1))
         end do 
       end do
       end do
@@ -145,7 +145,7 @@ else
       do ix=iwk3sta(1),iwk3end(1)
         do ist=1,Nd  
           htpsi(ix,iy,iz,iob,1) = htpsi(ix,iy,iz,iob,1)  &
-            +fdN1(ist,3)* tpsi(ix,iy,iz+ist,iob,1) + fdN1(ist,3)* tpsi(ix,iy,iz-ist,iob,1)
+            +fdN1(ist,3)* (tpsi(ix,iy,iz+ist,iob,1) + tpsi(ix,iy,iz-ist,iob,1))
         end do 
       end do
       end do


### PR DESCRIPTION
I found a possibility of optimization for hpsi and Laplacian in the GCEED part.
The optimization is just based on factorization (see implementation).

Elapsed time for example `scf` is shortened from `67.91` sec. to `40.36` sec. on my environment. Furthermore, the elapsed time for CG method is shortened from `34.07` sec. to `10.95` sec.