### PR TITLE
evaluation of convergence criterions

### DIFF
--- a/GCEED/common/hartree_cg.f90
+++ b/GCEED/common/hartree_cg.f90
@@ -193,7 +193,7 @@ Iteration : do iter=1,maxiter
 
   sum2=tottmp*Hvol
 
-  if ( abs(sum2) < Hconv ) exit
+  if ( abs(sum2) < Hconv*dble(lg_num(1)*lg_num(2)*lg_num(3)) ) exit
 
   ck=sum2/sum1 ; sum1=sum2
 
@@ -210,7 +210,9 @@ end do Iteration
 
 iterVh=iter
 if ( iterVh>maxiter .and. myrank.eq.0) then
-   write(*,*) "Warning:Vh iteration is not converged, sum2=",sum2
+   write(*,*) "Warning:Vh iteration is not converged"
+   write(*,'("||tVh(i)-tVh(i-1)||**2/(# of grids) = ",e15.8)') &
+                              sum2/dble(lg_num(1)*lg_num(2)*lg_num(3))
 end if
 
 return

--- a/GCEED/rt/read_input_rt.f90
+++ b/GCEED/rt/read_input_rt.f90
@@ -154,7 +154,8 @@ if(Ntime==0)then
 end if
 
 !===== namelist for group_hartree =====
-Hconv=1.d-12*(uenergy_from_au/au_energy_ev) ! [eV]
+! Convergence criterion, ||Vh(i)-Vh(i-1)||**2/(# of grids), 1.d-15 a.u. = 1.10d-13 eV**2*AA**3
+Hconv=1.d-15*uenergy_from_au**2*ulength_from_au**3
 num_pole_xyz(1:3)=1
 MEO=2
 lmax_MEO=4
@@ -171,13 +172,12 @@ if(myrank==0)then
   end if
 end if
 call MPI_Bcast(Hconv,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ierr)
-Hconv  = Hconv*uenergy_to_au**2*ulength_to_au**3     ! Convergence criterion
+Hconv  = Hconv*uenergy_to_au**2*ulength_to_au**3
 call MPI_Bcast(MEO,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(num_pole_xyz,3,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(lmax_MEO,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 
 num_pole=num_pole_xyz(1)*num_pole_xyz(2)*num_pole_xyz(3)
-!Hconv  = Hconv/(2d0*Ry)**2d0/a_B**3     ! Convergence criterion
 
 !===== namelist for group_file =====
 IC=1

--- a/GCEED/scf/read_input_scf.f90
+++ b/GCEED/scf/read_input_scf.f90
@@ -60,9 +60,13 @@ iflag_subspace_diag=0
 iDiter_nosubspace_diag=10
 ntmg=1
 iflag_convergence=2
-ithresholdVh(:)=1.d-11
-threshold_norm_diff_rho(:)=1.d-11
-threshold_square_norm_diff_Vlocal(:)=1.d-11
+ithresholdVh(:)=1
+
+! Convergence criterion, ||rho(i)-rho(i-1)||**2/(# of grids), 1.d-17 a.u. = 6.75d-17 AA**(-3)
+threshold_norm_diff_rho(:)=1.d-17/ulength_from_au**3
+
+! Convergence criterion, ||Vlocal(i)-Vlocal(i-1)||**2/(# of grids), 1.d-17 a.u. = 1.10d-15 eV**2*AA**3
+threshold_square_norm_diff_Vlocal(:)=1.d-17*uenergy_from_au**2*ulength_from_au**3
 mixrate=0.1d0
 Nmemory_MB=8
 icalcforce=0
@@ -211,7 +215,9 @@ nproc_Mxin_mul=nproc_Mxin(1)*nproc_Mxin(2)*nproc_Mxin(3)
 nproc_Mxin_mul_s_dm=nproc_Mxin_s_dm(1)*nproc_Mxin_s_dm(2)*nproc_Mxin_s_dm(3)
 
 !===== namelist for group_hartree =====
-Hconv=1.d-8
+! Convergence criterion, ||Vh(i)-Vh(i-1)||**2/(# of grids), 1.d-15 a.u. = 1.10d-13 eV**2*AA**3
+Hconv=1.d-15*uenergy_from_au**2*ulength_from_au**3
+
 num_pole_xyz(1:3)=-1
 MEO=3
 lmax_MEO=4
@@ -233,7 +239,7 @@ call MPI_Bcast(num_pole_xyz,3,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 call MPI_Bcast(lmax_MEO,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 
 num_pole=num_pole_xyz(1)*num_pole_xyz(2)*num_pole_xyz(3)
-Hconv  = Hconv*uenergy_to_au**2*ulength_to_au**3     ! Convergence criterion
+Hconv  = Hconv*uenergy_to_au**2*ulength_to_au**3
 
 !===== namelist for group_file =====
 IC=0

--- a/GCEED/scf/real_space_dft.f90
+++ b/GCEED/scf/real_space_dft.f90
@@ -17,6 +17,7 @@
 
 MODULE global_variables_scf
 
+use inputoutput
 use scf_data
 use hpsi2_sub
 use allocate_mat_sub
@@ -425,7 +426,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     end do
     end do
     call MPI_Allreduce(sum0,sum1,1,MPI_DOUBLE_PRECISION,MPI_SUM,newworld_comm_h,ierr)
-    sum1=sum1*Hvol
+    sum1=sum1*Hvol/dble(lg_num(1)*lg_num(2)*lg_num(3))
   else if(iflag_convergence==3)then
     sum0=0.d0
 !$OMP parallel do reduction(+:sum0)
@@ -437,7 +438,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     end do
     end do
     call MPI_Allreduce(sum0,sum1,1,MPI_DOUBLE_PRECISION,MPI_SUM,newworld_comm_h,ierr)
-    sum1=sum1*Hvol
+    sum1=sum1*Hvol/dble(lg_num(1)*lg_num(2)*lg_num(3))
   end if
 
   if(myrank.eq.0) then
@@ -452,9 +453,10 @@ DFT_Iteration : do iter=1,iDiter(img)
       write(*,'(1x,4(i5,f15.4,2x))') (iob,esp(iob,1)*2d0*Ry,iob=p1,p2)
     end do
     if(iflag_convergence==2)then
-      write(*,'("iter and square of norm of difference of rho = ",i6,e15.8)') Miter,sum1/a_B**3
+      write(*,'("iter and ||rho(i)-rho(i-1)||**2/(# of grids) = ",i6,e15.8)') Miter,sum1/a_B**3
     else if(iflag_convergence==3)then
-      write(*,'("iter and square of norm of difference of Vlocal = ",i6,e15.8)') Miter, sum1*(2.d0*Ry)**2*a_B**3
+      write(*,'("iter and ||Vlocal(i)-Vlocal(i-1)||**2/(# of grids) = ",i6,e15.8)') Miter,     &
+                                                                       sum1*(2.d0*Ry)**2*a_B**3
     end if
   end if 
   rNebox1=0.d0 

--- a/example/C2H2/scfrt-intel/input_rt
+++ b/example/C2H2/scfrt-intel/input_rt
@@ -26,7 +26,6 @@ unit_time='fs'
   Ntime=100
 /
 &group_hartree
-  Hconv=1.d-8
   MEO=3
   num_pole_xyz(1)=2
   num_pole_xyz(2)=2

--- a/example/C2H2/scfrt-intel/input_scf
+++ b/example/C2H2/scfrt-intel/input_scf
@@ -31,7 +31,6 @@ unit_time='fs'
   nproc_Mxin_s(3)=1
 /
 &group_hartree
-  Hconv=1.d-5
   MEO=3
   num_pole_xyz(1)=2
   num_pole_xyz(2)=2


### PR DESCRIPTION
I modify evaluation of convergence criterions. So far, the criterions of electron density and potential were ||rho(i)-rho(i-1)||**2 and ||Vlocal(i)-Vlocal(i-1)||**2 (variable i is an iteration number). I'd like to change them to  ||rho(i)-rho(i-1)||**2/(# of grids) and ||Vlocal(i)-Vlocal(i-1)||**2/(# of grids), because previous criterions  are quantities which are proportinal to # of grids. RSDFT changed these criterions at some point (maybe two or three years ago). I explained this at a SALMON meeting in May, and all participants agreed. 

I also applied this rule to a hartree CG routine. In addition, I also changed default values for these criterion to round numbers in atomic unit. Then, an induced dipole moment slightly changes (about 7x10**(-5) AA).