### PR TITLE
Add the density difference plot routine

### DIFF
--- a/ARTED/control/control_sc.f90
+++ b/ARTED/control/control_sc.f90
@@ -434,13 +434,21 @@ subroutine main
         select case(format3d)
         case ('cube')
           write(file_dns_rt, '(2A,"_dns_rt_",I6.6,".cube")') trim(directory), trim(SYSname), iter
+          write(file_dns_dlt, '(2A,"_dns_dlt_",I6.6,".cube")') trim(directory), trim(SYSname), iter
           open(501,file=file_dns_rt,position = position_option)
           call write_density_cube(501, .false.)
           close(501)
-        case ('vtk')
-          write(file_dns_gs, '(2A,"_dns_rt_",I6.6,".vtk")') trim(directory), trim(SYSname), iter
+          open(501,file=file_dns_dlt,position = position_option)
+          call write_density_cube(501, .true.)
+          close(501)
+        case ('vtk')          
+          write(file_dns_rt, '(2A,"_dns_rt_",I6.6,".vtk")') trim(directory), trim(SYSname), iter
+          write(file_dns_dlt, '(2A,"_dns_dlt_",I6.6,".vtk")') trim(directory), trim(SYSname), iter
           open(501,file=file_dns_rt,position = position_option)
           call write_density_vtk(501, .false.)
+          close(501)
+          open(501,file=file_dns_dlt,position = position_option)
+          call write_density_vtk(501, .true.)
           close(501)
         end select
       end if

--- a/ARTED/modules/global_variables.f90
+++ b/ARTED/modules/global_variables.f90
@@ -124,8 +124,9 @@ Module Global_Variables
   character(256) :: file_force_dR,file_j_ac
   character(256) :: file_DoS,file_band
   character(256) :: file_dns,file_ovlp,file_nex
-  character(256) :: file_dns_gs ! 501
-  character(256) :: file_dns_rt ! 502
+  character(256) :: file_dns_gs
+  character(256) :: file_dns_rt
+  character(256) :: file_dns_dlt
   character(256) :: file_energy_transfer ! 940
   character(256) :: file_ac_vac          ! 941
   character(256) :: file_ac_vac_back     ! 942


### PR DESCRIPTION
This PR makes possible to output the difference electronic density to `vtk` and `cube` file.
- In the case of  `analysis`.`out_dns_rt` is set to `y`, the series of output file `SYSNAME_dns_dlt_XXXXXX.out` is generated.
- The filetype of density profile is specified by the input variable `analysis`.`format_3d`.
