### PR TITLE
Prepared explicit choice for the BJ exchange.

### DIFF
--- a/ARTED/RT/dt_evolve.f90
+++ b/ARTED/RT/dt_evolve.f90
@@ -156,7 +156,7 @@ Subroutine dt_evolve_omp_KB(zu)
 
 ! yabana
   select case(functional)
-  case('VS98','TPSS','TBmBJ')
+  case('VS98','TPSS','TBmBJ','BJ_PW')
 !$acc update self(zu, ekr_omp, vloc)
 
 !$omp parallel do private(ik,ib)
@@ -336,7 +336,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
 
 !== predictor-corrector ==
   select case(functional)
-  case('VS98','TPSS','TBmBJ')
+  case('VS98','TPSS','TBmBJ','BJ_PW')
 !$acc update self(zu, ekr_omp, vloc)
 
 !$omp parallel do private(ik,ib)
@@ -462,7 +462,7 @@ Subroutine dt_evolve_omp_KB_MS(zu)
 
 ! yabana
   select case(functional)
-  case('VS98','TPSS','TBmBJ')
+  case('VS98','TPSS','TBmBJ','BJ_PW')
 !$acc update self(zu, ekr_omp, vloc)
 
 

--- a/ARTED/common/acc/hpsi.f90
+++ b/ARTED/common/acc/hpsi.f90
@@ -39,7 +39,7 @@ subroutine hpsi_acc_KB_RT_LBLK(tpsi,htpsi, ikb_s,ikb_e)
 
   NVTX_BEG('hpsi_acc_KB_RT_LBLK()', 3)
   select case(functional)
-    case('PZ','PZM', 'PBE','TBmBJ')
+    case('PZ','PZM', 'PBE','TBmBJ','BJ_PW')
       call hpsi1_LBLK(tpsi(:,:),htpsi(:,:), ikb_s,ikb_e)
     case('TPSS','VS98')
       call err_finalize('hpsi_acc_KB_RT_LBLK: TPSS/VS98 ver. not implemented.')

--- a/ARTED/control/control_ms.f90
+++ b/ARTED/control/control_ms.f90
@@ -97,9 +97,11 @@ subroutine main
   call Hartree
 ! yabana
   functional_t = functional
-  if(functional_t == 'TBmBJ') functional = 'PZM'
+  if(functional_t == 'TBmBJ' .or. functional_t == 'BJ_PW') functional = 'PZM'
   call Exc_Cor(calc_mode_gs,NBoccmax,zu_t)
   if(functional_t == 'TBmBJ') functional = 'TBmBJ'
+  if(functional_t == 'BJ_PW') functional = 'BJ_PW'
+
 ! yabana
   Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
 !  call Total_Energy(Rion_update,calc_mode_gs)
@@ -163,8 +165,10 @@ subroutine main
 ! yabana
     functional_t = functional
     if(functional_t == 'TBmBJ' .and. iter < 20) functional = 'PZM'
+    if(functional_t == 'BJ_PW' .and. iter < 20) functional = 'PZM'
     call Exc_Cor(calc_mode_gs,NBoccmax,zu_t)
     if(functional_t == 'TBmBJ' .and. iter < 20) functional = 'TBmBJ'
+    if(functional_t == 'BJ_PW' .and. iter < 20) functional = 'BJ_PW'
 ! yabana
     Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
     call Total_Energy_omp(Rion_update,calc_mode_gs)
@@ -782,7 +786,8 @@ Subroutine Read_data
 !sym ---
   select case(crystal_structure)
   case("diamond2")
-     if(functional == "PZ" .or. functional == "PZM" .or. functional == "TBmBJ")then
+     if(functional == "PZ" .or. functional == "PZM" &
+          .or. functional == "TBmBJ" .or. functional == "BJ_PW")then
         if(Sym == 8)then
            if((mod(NLx,2)+mod(NLy,2)+mod(NLz,4)) /= 0)call err_finalize('Bad grid point')
            if(NLx /= NLy)call err_finalize('Bad grid point: NLx /= NLy')
@@ -794,7 +799,8 @@ Subroutine Read_data
         if(Sym /= 1)call err_finalize('Bad crystal structure')
      end if
   case("diamond")
-     if(functional == "PZ" .or. functional == "PZM" .or. functional == "TBmBJ")then
+     if(functional == "PZ" .or. functional == "PZM" &
+          .or. functional == "TBmBJ"  .or. functional == "BJ_PW")then
         if(Sym == 8)then
            if((mod(NLx,4)+mod(NLy,4)+mod(NLz,4)) /= 0)call err_finalize('Bad grid point')
            if(NLx /= NLy)call err_finalize('Bad grid point')

--- a/ARTED/control/control_sc.f90
+++ b/ARTED/control/control_sc.f90
@@ -95,9 +95,11 @@ subroutine main
   call Hartree
 ! yabana
   functional_t = functional
-  if(functional_t == 'TBmBJ') functional = 'PZM'
+  if(functional_t == 'TBmBJ' .or. functional_t == 'BJ_PW') functional = 'PZM'
   call Exc_Cor(calc_mode_gs,NBoccmax,zu_t)
   if(functional_t == 'TBmBJ') functional = 'TBmBJ'
+  if(functional_t == 'BJ_PW') functional = 'BJ_PW'
+
 ! yabana
   Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
   call Total_Energy_omp(Rion_update,calc_mode_gs) ! debug
@@ -160,8 +162,10 @@ subroutine main
 ! yabana
     functional_t = functional
     if(functional_t == 'TBmBJ' .and. iter < 20) functional = 'PZM'
+    if(functional_t == 'BJ_PW' .and. iter < 20) functional = 'PZM'
     call Exc_Cor(calc_mode_gs,NBoccmax,zu_t)
     if(functional_t == 'TBmBJ' .and. iter < 20) functional = 'TBmBJ'
+    if(functional_t == 'BJ_PW' .and. iter < 20) functional = 'BJ_PW'
 ! yabana
     Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
     call Total_Energy_omp(Rion_update,calc_mode_gs)
@@ -708,7 +712,8 @@ Subroutine Read_data
 !sym ---
   select case(crystal_structure)
   case("diamond2")
-     if(functional == "PZ" .or. functional == "PZM" .or. functional == "TBmBJ")then
+     if(functional == "PZ" .or. functional == "PZM" &
+          .or. functional == "TBmBJ" .or. functional == "BJ_PW")then
         if(Sym == 8)then
            if((mod(NLx,2)+mod(NLy,2)+mod(NLz,4)) /= 0)call err_finalize('Bad grid point')
            if(NLx /= NLy)call err_finalize('Bad grid point: NLx /= NLy')
@@ -720,7 +725,8 @@ Subroutine Read_data
         if(Sym /= 1)call err_finalize('Bad crystal structure')
      end if
   case("diamond")
-     if(functional == "PZ" .or. functional == "PZM" .or. functional == "TBmBJ")then
+     if(functional == "PZ" .or. functional == "PZM" &
+          .or. functional == "TBmBJ"  .or. functional == "BJ_PW")then
         if(Sym == 8)then
            if((mod(NLx,4)+mod(NLy,4)+mod(NLz,4)) /= 0)call err_finalize('Bad grid point')
            if(NLx /= NLy)call err_finalize('Bad grid point')

--- a/ARTED/data/input_sc_Si.inp
+++ b/ARTED/data/input_sc_Si.inp
@@ -25,7 +25,7 @@
 /
 
 &functional
-  xc ='TBmBJ'
+  xc ='BJ_PW'
   cval = 1d0
 /
 

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -415,7 +415,7 @@ contains
     eta_mask      = 15d0
 !! == default for &functional
     xc   = 'PZ'
-    cval = 1d0
+    cval = -1d0
 !! == default for &rgrid
     dl        = 0d0
     num_rgrid = 0


### PR DESCRIPTION
- For usability, I prepared an explicit  choice for the Becke-Johnson potential with PW correlation, `BJ_PW`.
Originally, this choice was implicitly possible with `functional=TBmBJ` and `cval=1.0`. However, this way of the selection seems a bit weird. 

- I also changed the default value for the c-parameter of TBmBJ potential to `cval=-1.0`, negative value, which triggers the internal evaluation of the parameter based on the expression in the original paper.