### PR TITLE
Fix a problem with OpenMP in GCEED part

### DIFF
--- a/GCEED/common/OUT_IN_data.f90
+++ b/GCEED/common/OUT_IN_data.f90
@@ -838,7 +838,7 @@ allocate( cmatbox_read2(ig_sta(1):ig_end(1),ig_sta(2):ig_end(2),ig_sta(3):ig_end
 allocate( matbox_read3(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)) )
 allocate( cmatbox_read3(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)) )
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=ig_sta(3),ig_end(3)
 do iy=ig_sta(2),ig_end(2)
 do ix=ig_sta(1),ig_end(1)
@@ -1180,7 +1180,7 @@ end if
 if(iSCFRT==2)then
   allocate(Vh_stock1(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
   allocate(Vh_stock2(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)

--- a/GCEED/common/OUT_IN_data.f90
+++ b/GCEED/common/OUT_IN_data.f90
@@ -838,7 +838,7 @@ allocate( cmatbox_read2(ig_sta(1):ig_end(1),ig_sta(2):ig_end(2),ig_sta(3):ig_end
 allocate( matbox_read3(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)) )
 allocate( cmatbox_read3(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)) )
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ig_sta(3),ig_end(3)
 do iy=ig_sta(2),ig_end(2)
 do ix=ig_sta(1),ig_end(1)
@@ -1180,7 +1180,7 @@ end if
 if(iSCFRT==2)then
   allocate(Vh_stock1(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
   allocate(Vh_stock2(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)

--- a/GCEED/common/calcELF.f90
+++ b/GCEED/common/calcELF.f90
@@ -64,11 +64,11 @@ real(8) :: rho_half(mg_sta(1):mg_end(1),   &
 
 elp3(801)=get_wtime()
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
-  rho_half(ix,iy,iz)=rho(ix,iy,iz)/2.d0
+  rho_half(ix,iy,iz)=0.5d0*rho(ix,iy,iz)
 end do
 end do
 end do
@@ -86,7 +86,7 @@ if(iSCFRT==1)then
   do iob=1,iobnum
     call calc_gradient(psi(:,:,:,iob,1),gradpsi(:,:,:,:))
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -117,7 +117,7 @@ else if(iSCFRT==2)then
 
   do iob=1,iobnum
     if(itt==0)then
-      !$OMP parallel do collapse(2)
+      !$OMP parallel do collapse(3) private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -127,7 +127,7 @@ else if(iSCFRT==2)then
       end do
     else
       if(mod(itt,2)==1)then
-      !$OMP parallel do collapse(2)
+      !$OMP parallel do collapse(3) private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -136,7 +136,7 @@ else if(iSCFRT==2)then
         end do
         end do
       else
-      !$OMP parallel do collapse(2)
+      !$OMP parallel do collapse(3) private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -151,7 +151,7 @@ else if(iSCFRT==2)then
 
     elp3(807)=get_wtime()
 
-!$OMP parallel do
+!$OMP parallel do collapse(3) private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -220,7 +220,7 @@ end do
 elp3(817)=get_wtime()
 elp3(847)=elp3(847)+elp3(817)-elp3(816)
 
-!$OMP parallel do collapse(2)
+!$OMP parallel do collapse(3) private(iz,iy,ix)
 do iz=lg_sta(3),lg_end(3)
 do iy=lg_sta(2),lg_end(2)
 do ix=lg_sta(1),lg_end(1)
@@ -229,7 +229,7 @@ end do
 end do
 end do
 
-!$OMP parallel do collapse(2)
+!$OMP parallel do collapse(3) private(iz,iy,ix)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/calcELF.f90
+++ b/GCEED/common/calcELF.f90
@@ -64,7 +64,7 @@ real(8) :: rho_half(mg_sta(1):mg_end(1),   &
 
 elp3(801)=get_wtime()
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -86,7 +86,7 @@ if(iSCFRT==1)then
   do iob=1,iobnum
     call calc_gradient(psi(:,:,:,iob,1),gradpsi(:,:,:,:))
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -117,7 +117,7 @@ else if(iSCFRT==2)then
 
   do iob=1,iobnum
     if(itt==0)then
-      !$OMP parallel do collapse(3) private(iz,iy,ix)
+      !$OMP parallel do collapse(2) private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -127,7 +127,7 @@ else if(iSCFRT==2)then
       end do
     else
       if(mod(itt,2)==1)then
-      !$OMP parallel do collapse(3) private(iz,iy,ix)
+      !$OMP parallel do collapse(2) private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -136,7 +136,7 @@ else if(iSCFRT==2)then
         end do
         end do
       else
-      !$OMP parallel do collapse(3) private(iz,iy,ix)
+      !$OMP parallel do collapse(2) private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -151,7 +151,7 @@ else if(iSCFRT==2)then
 
     elp3(807)=get_wtime()
 
-!$OMP parallel do collapse(3) private(iz,iy,ix)
+!$OMP parallel do collapse(2) private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -220,7 +220,7 @@ end do
 elp3(817)=get_wtime()
 elp3(847)=elp3(847)+elp3(817)-elp3(816)
 
-!$OMP parallel do collapse(3) private(iz,iy,ix)
+!$OMP parallel do collapse(2) private(iz,iy,ix)
 do iz=lg_sta(3),lg_end(3)
 do iy=lg_sta(2),lg_end(2)
 do ix=lg_sta(1),lg_end(1)
@@ -229,7 +229,7 @@ end do
 end do
 end do
 
-!$OMP parallel do collapse(3) private(iz,iy,ix)
+!$OMP parallel do collapse(2) private(iz,iy,ix)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/calc_gradient_fast.f90
+++ b/GCEED/common/calc_gradient_fast.f90
@@ -30,7 +30,7 @@ if(Nd==4)then
   do iob=1,iobnum
 !$OMP parallel private(iz)
     do iz=mg_sta(3),mg_end(3)
-!$OMP do private(iy, ix) collapse(2)
+!$OMP do private(iy, ix) 
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
       grad_wk(ix,iy,iz,iob,1,1) =  &
@@ -46,7 +46,7 @@ if(Nd==4)then
     end do
     end do
 !$OMP end do nowait
-!$OMP do private(iy, ix) collapse(2)
+!$OMP do private(iy, ix) 
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
       grad_wk(ix,iy,iz,iob,1,3) =  &

--- a/GCEED/common/calc_gradient_fast.f90
+++ b/GCEED/common/calc_gradient_fast.f90
@@ -30,7 +30,7 @@ if(Nd==4)then
   do iob=1,iobnum
 !$OMP parallel private(iz)
     do iz=mg_sta(3),mg_end(3)
-!$OMP do
+!$OMP do private(iy, ix) collapse(2)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
       grad_wk(ix,iy,iz,iob,1,1) =  &
@@ -46,7 +46,7 @@ if(Nd==4)then
     end do
     end do
 !$OMP end do nowait
-!$OMP do
+!$OMP do private(iy, ix) collapse(2)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
       grad_wk(ix,iy,iz,iob,1,3) =  &

--- a/GCEED/common/calc_gradient_fast_c.f90
+++ b/GCEED/common/calc_gradient_fast_c.f90
@@ -29,7 +29,7 @@ if(Nd==4)then
   do iob=1,iobnum
 !$OMP parallel private(iz)
     do iz=mg_sta(3),mg_end(3)
-!$OMP do
+!$OMP do private(iy,ix) collapse(2)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
       cgrad_wk(ix,iy,iz,iob,1,1) =  &
@@ -45,7 +45,7 @@ if(Nd==4)then
     end do
     end do
 !$OMP end do nowait
-!$OMP do
+!$OMP do private(iy,ix) collapse(2)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
       cgrad_wk(ix,iy,iz,iob,1,3) =  &

--- a/GCEED/common/calc_gradient_fast_c.f90
+++ b/GCEED/common/calc_gradient_fast_c.f90
@@ -29,7 +29,7 @@ if(Nd==4)then
   do iob=1,iobnum
 !$OMP parallel private(iz)
     do iz=mg_sta(3),mg_end(3)
-!$OMP do private(iy,ix) collapse(2)
+!$OMP do private(iy,ix) 
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
       cgrad_wk(ix,iy,iz,iob,1,1) =  &
@@ -45,7 +45,7 @@ if(Nd==4)then
     end do
     end do
 !$OMP end do nowait
-!$OMP do private(iy,ix) collapse(2)
+!$OMP do private(iy,ix) 
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
       cgrad_wk(ix,iy,iz,iob,1,3) =  &

--- a/GCEED/common/hartree_boundary.f90
+++ b/GCEED/common/hartree_boundary.f90
@@ -85,7 +85,7 @@ itrho(1)=1
 do LL=0,lmax_MEO
 do lm=LL**2+1,(LL+1)**2
   rholm2box=0.d0
-!$OMP parallel do reduction ( + : rholm2box)&
+!$OMP parallel do collapse(3) reduction ( + : rholm2box)&
 !$OMP private(ix,iy,iz,xx,yy,zz,rr,xxxx,yyyy,zzzz,Ylm)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
@@ -115,7 +115,7 @@ if(iflag_ps==1)then
   Rion2(:,:)=Rion(:,:)
 end if
 
-!$OMP parallel do
+!$OMP parallel do private(icen, lm, jj)
 do icen=1,num_center
   do lm=1,(lmax_MEO+1)**2
     rholm(lm,icen)=0.d0
@@ -160,7 +160,7 @@ allocate(center_trho(3,num_center))
 allocate(center_trho_nume_deno(4,num_center))
 allocate(center_trho_nume_deno2(4,num_center))
 
-!$OMP parallel do
+!$OMP parallel do private(icen, jj, lm)
 do icen=1,num_center
   do jj=1,4
     center_trho_nume_deno2(jj,icen)=0.d0
@@ -254,7 +254,7 @@ else
   elp3(252)=elp3(252)+elp3(202)-elp3(201)
 end if
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
@@ -285,7 +285,7 @@ do k=1,3
   end do
 
 !$OMP parallel do &
-!$OMP private(xx,yy,zz,rr,xxxx,yyyy,zzzz,lm,LL,sum1,Ylm2,rrrr,xp2,yp2,zp2,xy,yz,xz,rinv,rbox,deno)
+!$OMP private(xx,yy,zz,rr,xxxx,yyyy,zzzz,lm,LL,sum1,Ylm2,rrrr,xp2,yp2,zp2,xy,yz,xz,rinv,rbox,deno,icen)
   do jj=istart(nproc_id_bound(k)),iend(nproc_id_bound(k))
     do icen=1,num_center
       if(itrho(icen)==1)then

--- a/GCEED/common/hartree_boundary.f90
+++ b/GCEED/common/hartree_boundary.f90
@@ -85,7 +85,7 @@ itrho(1)=1
 do LL=0,lmax_MEO
 do lm=LL**2+1,(LL+1)**2
   rholm2box=0.d0
-!$OMP parallel do collapse(3) reduction ( + : rholm2box)&
+!$OMP parallel do reduction ( + : rholm2box)&
 !$OMP private(ix,iy,iz,xx,yy,zz,rr,xxxx,yyyy,zzzz,Ylm)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
@@ -254,7 +254,7 @@ else
   elp3(252)=elp3(252)+elp3(202)-elp3(201)
 end if
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh

--- a/GCEED/common/hartree_cg.f90
+++ b/GCEED/common/hartree_cg.f90
@@ -55,7 +55,7 @@ call hartree_boundary(trho,wk2)
 
 !------------------------- C-G minimization
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -69,7 +69,7 @@ call sendrecvh(wk2)
 
 call calc_laplacianh(wk2,rlap_wk)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -78,7 +78,7 @@ end do
 end do
 end do
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
@@ -86,7 +86,7 @@ do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
 end do
 end do
 end do
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -96,7 +96,7 @@ end do
 end do
 
 sum1=0.d0
-!$OMP parallel do reduction(+ : sum1) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+ : sum1) private(iz,iy,ix) 
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -117,7 +117,7 @@ end if
 Iteration : do iter=1,maxiter
 
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -130,7 +130,7 @@ Iteration : do iter=1,maxiter
 
   call calc_laplacianh(wk2,rlap_wk)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -140,7 +140,7 @@ Iteration : do iter=1,maxiter
   end do
 
   totbox=0d0
-!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) 
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -160,7 +160,7 @@ Iteration : do iter=1,maxiter
 
   ak=sum1/tottmp/Hvol
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -171,7 +171,7 @@ Iteration : do iter=1,maxiter
   end do
 
   totbox=0d0
-!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) 
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -195,7 +195,7 @@ Iteration : do iter=1,maxiter
 
   ck=sum2/sum1 ; sum1=sum2
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/hartree_cg.f90
+++ b/GCEED/common/hartree_cg.f90
@@ -55,7 +55,7 @@ call hartree_boundary(trho,wk2)
 
 !------------------------- C-G minimization
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -69,7 +69,7 @@ call sendrecvh(wk2)
 
 call calc_laplacianh(wk2,rlap_wk)
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -78,7 +78,7 @@ end do
 end do
 end do
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
@@ -86,7 +86,7 @@ do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
 end do
 end do
 end do
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -96,7 +96,7 @@ end do
 end do
 
 sum1=0.d0
-!$OMP parallel do reduction(+ : sum1)
+!$OMP parallel do reduction(+ : sum1) private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -117,7 +117,7 @@ end if
 Iteration : do iter=1,maxiter
 
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -130,7 +130,7 @@ Iteration : do iter=1,maxiter
 
   call calc_laplacianh(wk2,rlap_wk)
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -140,7 +140,7 @@ Iteration : do iter=1,maxiter
   end do
 
   totbox=0d0
-!$OMP parallel do reduction(+ : totbox)
+!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -160,7 +160,7 @@ Iteration : do iter=1,maxiter
 
   ak=sum1/tottmp/Hvol
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -171,7 +171,7 @@ Iteration : do iter=1,maxiter
   end do
 
   totbox=0d0
-!$OMP parallel do reduction(+ : totbox)
+!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -195,7 +195,7 @@ Iteration : do iter=1,maxiter
 
   ck=sum2/sum1 ; sum1=sum2
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/inner_product3.f90
+++ b/GCEED/common/inner_product3.f90
@@ -28,7 +28,7 @@ real(8) :: matbox2(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3en
 real(8) :: rbox,rbox2
 
 rbox=0.d0
-!$omp parallel do reduction(+ : rbox) collapse(3) private(iz,iy,ix)
+!$omp parallel do reduction(+ : rbox) private(iz,iy,ix)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/common/inner_product3.f90
+++ b/GCEED/common/inner_product3.f90
@@ -28,7 +28,7 @@ real(8) :: matbox2(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3en
 real(8) :: rbox,rbox2
 
 rbox=0.d0
-!$omp parallel do reduction(+ : rbox)
+!$omp parallel do reduction(+ : rbox) collapse(3) private(iz,iy,ix)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/common/inner_product4.f90
+++ b/GCEED/common/inner_product4.f90
@@ -27,7 +27,7 @@ complex(8) :: matbox2(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk
 complex(8) :: cbox,cbox2
 
 cbox=0.d0
-!$omp parallel do reduction(+ : cbox)
+!$omp parallel do private(iz,iy,ix) collapse(3) reduction(+ : cbox)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/common/inner_product4.f90
+++ b/GCEED/common/inner_product4.f90
@@ -27,7 +27,7 @@ complex(8) :: matbox2(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk
 complex(8) :: cbox,cbox2
 
 cbox=0.d0
-!$omp parallel do private(iz,iy,ix) collapse(3) reduction(+ : cbox)
+!$omp parallel do private(iz,iy,ix) reduction(+ : cbox)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/common/laplacianh.f90
+++ b/GCEED/common/laplacianh.f90
@@ -29,7 +29,7 @@ f0=(1.d0/Hgs(1)**2   &
    +1.d0/Hgs(3)**2)
 Hinv2(1:3)=1.d0/Hgs(1:3)**2
 
-!$OMP parallel do collapse(3) private(ist,iz,iy,ix)
+!$OMP parallel do collapse(2) private(ist,iz,iy,ix)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/common/laplacianh.f90
+++ b/GCEED/common/laplacianh.f90
@@ -29,7 +29,7 @@ f0=(1.d0/Hgs(1)**2   &
    +1.d0/Hgs(3)**2)
 Hinv2(1:3)=1.d0/Hgs(1:3)**2
 
-!$OMP parallel do collapse(2) private(ist)
+!$OMP parallel do collapse(3) private(ist,iz,iy,ix)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/common/nabla.f90
+++ b/GCEED/common/nabla.f90
@@ -37,7 +37,7 @@ real(8) :: rnab_wkx(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3e
 real(8) :: rnab_wky(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 real(8) :: rnab_wkz(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
-!$OMP parallel do collapse(3) private(iz,iy,ix)
+!$OMP parallel do private(iz,iy,ix)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
@@ -63,7 +63,7 @@ complex(8) :: cnab_wkx(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iw
 complex(8) :: cnab_wky(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 complex(8) :: cnab_wkz(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/common/nabla.f90
+++ b/GCEED/common/nabla.f90
@@ -37,7 +37,7 @@ real(8) :: rnab_wkx(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3e
 real(8) :: rnab_wky(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 real(8) :: rnab_wkz(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
-!$OMP parallel do
+!$OMP parallel do collapse(3) private(iz,iy,ix)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
@@ -63,7 +63,7 @@ complex(8) :: cnab_wkx(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iw
 complex(8) :: cnab_wky(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 complex(8) :: cnab_wkz(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/common/read_copy_pot.f90
+++ b/GCEED/common/read_copy_pot.f90
@@ -31,7 +31,7 @@ end if
 
 call comm_bcast(matbox_read,nproc_group_global)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)

--- a/GCEED/common/read_copy_pot.f90
+++ b/GCEED/common/read_copy_pot.f90
@@ -31,7 +31,7 @@ end if
 
 call comm_bcast(matbox_read,nproc_group_global)
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)

--- a/GCEED/common/sendrecv_copy.f90
+++ b/GCEED/common/sendrecv_copy.f90
@@ -22,7 +22,7 @@ real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
                 mg_sta(3)-Nd:mg_end(3)+Nd,1:iobnum,1)
 
 do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=mg_sta(3)-Nd,mg_end(3)+Nd
   do iy=mg_sta(2)-Nd,mg_end(2)+Nd
   do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -30,7 +30,7 @@ do iob=1,iobnum
   end do
   end do
   end do
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)

--- a/GCEED/common/sendrecv_copy.f90
+++ b/GCEED/common/sendrecv_copy.f90
@@ -22,7 +22,7 @@ real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
                 mg_sta(3)-Nd:mg_end(3)+Nd,1:iobnum,1)
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3)-Nd,mg_end(3)+Nd
   do iy=mg_sta(2)-Nd,mg_end(2)+Nd
   do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -30,7 +30,7 @@ do iob=1,iobnum
   end do
   end do
   end do
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)

--- a/GCEED/common/writedns.f90
+++ b/GCEED/common/writedns.f90
@@ -25,7 +25,7 @@ subroutine writedns
   character(30) :: phys_quantity
   character(10) :: filenum
 
-  !$OMP parallel do collapse(3) private(iz,iy,ix)
+  !$OMP parallel do collapse(2) private(iz,iy,ix)
   do iz=lg_sta(3),lg_end(3)
   do iy=lg_sta(2),lg_end(2)
   do ix=lg_sta(1),lg_end(1)
@@ -34,7 +34,7 @@ subroutine writedns
   end do
   end do
 
-  !$OMP parallel do collapse(3) private(iz,iy,ix)
+  !$OMP parallel do collapse(2) private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -59,7 +59,7 @@ subroutine writedns
   end if
 
   if(iSCFRT==2)then
-    !$OMP parallel do collapse(3) private(iz,iy,ix)
+    !$OMP parallel do collapse(2) private(iz,iy,ix)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)
@@ -68,7 +68,7 @@ subroutine writedns
     end do
     end do
 
-    !$OMP parallel do collapse(3) private(iz,iy,ix)
+    !$OMP parallel do collapse(2) private(iz,iy,ix)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/writedns.f90
+++ b/GCEED/common/writedns.f90
@@ -25,7 +25,7 @@ subroutine writedns
   character(30) :: phys_quantity
   character(10) :: filenum
 
-  !$OMP parallel do collapse(2)
+  !$OMP parallel do collapse(3) private(iz,iy,ix)
   do iz=lg_sta(3),lg_end(3)
   do iy=lg_sta(2),lg_end(2)
   do ix=lg_sta(1),lg_end(1)
@@ -34,7 +34,7 @@ subroutine writedns
   end do
   end do
 
-  !$OMP parallel do collapse(2)
+  !$OMP parallel do collapse(3) private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -59,7 +59,7 @@ subroutine writedns
   end if
 
   if(iSCFRT==2)then
-    !$OMP parallel do collapse(2)
+    !$OMP parallel do collapse(3) private(iz,iy,ix)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)
@@ -68,7 +68,7 @@ subroutine writedns
     end do
     end do
 
-    !$OMP parallel do collapse(2)
+    !$OMP parallel do collapse(3) private(iz,iy,ix)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/writeestatic.f90
+++ b/GCEED/common/writeestatic.f90
@@ -27,7 +27,7 @@ subroutine writeestatic
 
   do jj=1,3
 
-    !$OMP parallel do collapse(2)
+    !$OMP parallel do collapse(3) private(iz,iy,ix)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)
@@ -37,7 +37,7 @@ subroutine writeestatic
     end do
     
     if(jj==1)then
-      !$OMP parallel do collapse(2)
+      !$OMP parallel do collapse(3) private(iz,iy,ix)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)
@@ -46,7 +46,7 @@ subroutine writeestatic
       end do
       end do
     else if(jj==2)then
-      !$OMP parallel do collapse(2)
+      !$OMP parallel do collapse(3) private(iz,iy,ix)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)
@@ -55,7 +55,7 @@ subroutine writeestatic
       end do
       end do
     else if(jj==3)then
-      !$OMP parallel do collapse(2)
+      !$OMP parallel do collapse(3) private(iz,iy,ix)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/writeestatic.f90
+++ b/GCEED/common/writeestatic.f90
@@ -27,7 +27,7 @@ subroutine writeestatic
 
   do jj=1,3
 
-    !$OMP parallel do collapse(3) private(iz,iy,ix)
+    !$OMP parallel do collapse(2) private(iz,iy,ix)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)
@@ -37,7 +37,7 @@ subroutine writeestatic
     end do
     
     if(jj==1)then
-      !$OMP parallel do collapse(3) private(iz,iy,ix)
+      !$OMP parallel do collapse(2) private(iz,iy,ix)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)
@@ -46,7 +46,7 @@ subroutine writeestatic
       end do
       end do
     else if(jj==2)then
-      !$OMP parallel do collapse(3) private(iz,iy,ix)
+      !$OMP parallel do collapse(2) private(iz,iy,ix)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)
@@ -55,7 +55,7 @@ subroutine writeestatic
       end do
       end do
     else if(jj==3)then
-      !$OMP parallel do collapse(3) private(iz,iy,ix)
+      !$OMP parallel do collapse(2) private(iz,iy,ix)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/xc.f90
+++ b/GCEED/common/xc.f90
@@ -28,7 +28,7 @@ real(8) :: trho_s(mg_sta(1):mg_end(1),  &
                 mg_sta(2):mg_end(2),  &
                 mg_sta(3):mg_end(3),2)
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -44,7 +44,7 @@ end do
 end do
 end do
 if(ilsda == 1) then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -144,7 +144,7 @@ sgnsigma(1)=1.d0
 sgnsigma(2)=-1.d0
 
 !!$OMP parallel do &
-!!$OMP private(Cx,rs,zeta,sf,dsf)
+!!$OMP private(Cx,rs,zeta,sf,dsf,iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -248,7 +248,7 @@ end do
 end do
 
 sum1=0.d0
-!$omp parallel do reduction(+ : sum1)
+!$omp parallel do reduction(+ : sum1) private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)

--- a/GCEED/common/xc.f90
+++ b/GCEED/common/xc.f90
@@ -28,7 +28,7 @@ real(8) :: trho_s(mg_sta(1):mg_end(1),  &
                 mg_sta(2):mg_end(2),  &
                 mg_sta(3):mg_end(3),2)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -44,7 +44,7 @@ end do
 end do
 end do
 if(ilsda == 1) then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -144,7 +144,7 @@ sgnsigma(1)=1.d0
 sgnsigma(2)=-1.d0
 
 !!$OMP parallel do &
-!!$OMP private(Cx,rs,zeta,sf,dsf,iz,iy,ix) collapse(3)
+!!$OMP private(Cx,rs,zeta,sf,dsf,iz,iy,ix) 
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -248,7 +248,7 @@ end do
 end do
 
 sum1=0.d0
-!$omp parallel do reduction(+ : sum1) private(iz,iy,ix) collapse(3)
+!$omp parallel do reduction(+ : sum1) private(iz,iy,ix) 
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)

--- a/GCEED/modules/calc_density.f90
+++ b/GCEED/modules/calc_density.f90
@@ -42,7 +42,7 @@ if(ilsda==0)then
   matbox_m=0d0
   do i1=1,iobnum
     call calc_allob(i1,i1_allob)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -71,7 +71,7 @@ else if(ilsda==1)then
       call calc_myob(iob,iob_myob)
       call check_corrkob(iob,icorr_p)
       if(icorr_p==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -90,7 +90,7 @@ else if(ilsda==1)then
     end if
   end do
   
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -120,7 +120,7 @@ if(ilsda==0)then
   matbox_m=0d0
   do i1=1,iobnum
     call calc_allob(i1,i1_allob)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -149,7 +149,7 @@ else if(ilsda==1)then
       call calc_myob(iob,iob_myob)
       call check_corrkob(iob,icorr_p)
       if(icorr_p==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -168,7 +168,7 @@ else if(ilsda==1)then
     end if
   end do
   
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)

--- a/GCEED/modules/calc_density.f90
+++ b/GCEED/modules/calc_density.f90
@@ -42,7 +42,7 @@ if(ilsda==0)then
   matbox_m=0d0
   do i1=1,iobnum
     call calc_allob(i1,i1_allob)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -71,7 +71,7 @@ else if(ilsda==1)then
       call calc_myob(iob,iob_myob)
       call check_corrkob(iob,icorr_p)
       if(icorr_p==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -90,7 +90,7 @@ else if(ilsda==1)then
     end if
   end do
   
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -120,7 +120,7 @@ if(ilsda==0)then
   matbox_m=0d0
   do i1=1,iobnum
     call calc_allob(i1,i1_allob)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -149,7 +149,7 @@ else if(ilsda==1)then
       call calc_myob(iob,iob_myob)
       call check_corrkob(iob,icorr_p)
       if(icorr_p==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -168,7 +168,7 @@ else if(ilsda==1)then
     end if
   end do
   
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)

--- a/GCEED/modules/copy_psi_mesh.f90
+++ b/GCEED/modules/copy_psi_mesh.f90
@@ -48,7 +48,7 @@ if(icopy_psi_mesh==1)then
     call check_corrkob(iob,icheck_corrkob)
     matbox=0.d0
     if(icheck_corrkob==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -60,7 +60,7 @@ if(icopy_psi_mesh==1)then
 
     call comm_summation(matbox,matbox2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_global)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -74,7 +74,7 @@ else if(icopy_psi_mesh==2)then
     call calc_myob(iob,iob_myob)
     call check_corrkob(iob,icheck_corrkob)
     matbox=0.d0
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -86,7 +86,7 @@ else if(icopy_psi_mesh==2)then
     call comm_summation(matbox,matbox2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
     if(icheck_corrkob==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -126,7 +126,7 @@ if(icopy_psi_mesh==1)then
     call check_corrkob(iob,icheck_corrkob)
     matbox=0.d0
     if(icheck_corrkob==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -138,7 +138,7 @@ if(icopy_psi_mesh==1)then
 
     call comm_summation(matbox,matbox2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_global)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -152,7 +152,7 @@ else if(icopy_psi_mesh==2)then
     call calc_myob(iob,iob_myob)
     call check_corrkob(iob,icheck_corrkob)
     matbox=0.d0
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -164,7 +164,7 @@ else if(icopy_psi_mesh==2)then
     call comm_summation(matbox,matbox2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
     if(icheck_corrkob==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)

--- a/GCEED/modules/copy_psi_mesh.f90
+++ b/GCEED/modules/copy_psi_mesh.f90
@@ -48,7 +48,7 @@ if(icopy_psi_mesh==1)then
     call check_corrkob(iob,icheck_corrkob)
     matbox=0.d0
     if(icheck_corrkob==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -60,7 +60,7 @@ if(icopy_psi_mesh==1)then
 
     call comm_summation(matbox,matbox2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_global)
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -74,7 +74,7 @@ else if(icopy_psi_mesh==2)then
     call calc_myob(iob,iob_myob)
     call check_corrkob(iob,icheck_corrkob)
     matbox=0.d0
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -86,7 +86,7 @@ else if(icopy_psi_mesh==2)then
     call comm_summation(matbox,matbox2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
     if(icheck_corrkob==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -126,7 +126,7 @@ if(icopy_psi_mesh==1)then
     call check_corrkob(iob,icheck_corrkob)
     matbox=0.d0
     if(icheck_corrkob==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -138,7 +138,7 @@ if(icopy_psi_mesh==1)then
 
     call comm_summation(matbox,matbox2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_global)
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -152,7 +152,7 @@ else if(icopy_psi_mesh==2)then
     call calc_myob(iob,iob_myob)
     call check_corrkob(iob,icheck_corrkob)
     matbox=0.d0
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -164,7 +164,7 @@ else if(icopy_psi_mesh==2)then
     call comm_summation(matbox,matbox2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_h)
 
     if(icheck_corrkob==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)

--- a/GCEED/modules/gradient.f90
+++ b/GCEED/modules/gradient.f90
@@ -42,7 +42,7 @@ integer :: ix,iy,iz
 
 if(iwk_size==1.or.iwk_size==11)then
   wk2=0.d0
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=iwksta(3),iwkend(3)
   do iy=iwksta(2),iwkend(2)
   do ix=iwksta(1),iwkend(1)
@@ -79,7 +79,7 @@ integer :: ix,iy,iz
 
 if(iwk_size==1.or.iwk_size==11)then
   wk2=0.d0
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=iwksta(3),iwkend(3)
   do iy=iwksta(2),iwkend(2)
   do ix=iwksta(1),iwkend(1)

--- a/GCEED/modules/gradient.f90
+++ b/GCEED/modules/gradient.f90
@@ -42,7 +42,7 @@ integer :: ix,iy,iz
 
 if(iwk_size==1.or.iwk_size==11)then
   wk2=0.d0
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwksta(3),iwkend(3)
   do iy=iwksta(2),iwkend(2)
   do ix=iwksta(1),iwkend(1)
@@ -79,7 +79,7 @@ integer :: ix,iy,iz
 
 if(iwk_size==1.or.iwk_size==11)then
   wk2=0.d0
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwksta(3),iwkend(3)
   do iy=iwksta(2),iwkend(2)
   do ix=iwksta(1),iwkend(1)

--- a/GCEED/modules/gradient2.f90
+++ b/GCEED/modules/gradient2.f90
@@ -36,7 +36,7 @@ real(8) :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end(3)
 real(8) :: grad_wk(3,iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
 if(Nd<=3)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -50,7 +50,7 @@ if(Nd<=3)then
   end do
   end do
 else if(Nd==4)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -88,7 +88,7 @@ complex(8) :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end
 complex(8) :: grad_wk(3,iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
 if(Nd<=3)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -102,7 +102,7 @@ if(Nd<=3)then
   end do
   end do
 else if(Nd==4)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/modules/gradient2.f90
+++ b/GCEED/modules/gradient2.f90
@@ -36,7 +36,7 @@ real(8) :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end(3)
 real(8) :: grad_wk(3,iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
 if(Nd<=3)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -50,7 +50,7 @@ if(Nd<=3)then
   end do
   end do
 else if(Nd==4)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -88,7 +88,7 @@ complex(8) :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end
 complex(8) :: grad_wk(3,iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
 if(Nd<=3)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -102,7 +102,7 @@ if(Nd<=3)then
   end do
   end do
 else if(Nd==4)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/modules/hpsi2.f90
+++ b/GCEED/modules/hpsi2.f90
@@ -149,7 +149,7 @@ end if
 
 ! Pseudo(local), Hartree, Exchange-Correlation potential
 if(ihpsieff==0)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -158,7 +158,7 @@ if(ihpsieff==0)then
   end do
   end do
 else if(ihpsieff==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -196,7 +196,7 @@ if(iflag_ps==1) then
 end if
 
 wk2=0.d0
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -207,7 +207,7 @@ end do
 call sendrecv(wk2)
 call calc_laplacian2(wk2,rlap_wk)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
@@ -264,7 +264,7 @@ integer :: j,ind
 call set_ispin(iob,ispin)
 
 if(nn<=1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -345,7 +345,7 @@ if(isub==0)then
   end do
 
   elp3(757)=get_wtime()
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -376,7 +376,7 @@ else if(isub==1)then
   call calc_gradient2(tpsi,grad_wk)
 
   if(nn==N_hamil)then
-!$OMP parallel do private(iz,iy,ix) collapse(2)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=iwk3sta(3),iwk3end(3)
     do iy=iwk3sta(2),iwk3end(2)
     do ix=iwk3sta(1),iwk3end(1)
@@ -389,7 +389,7 @@ else if(isub==1)then
     end do
     end do
   else
-!$OMP parallel do private(iz,iy,ix) collapse(2)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=iwk3sta(3),iwk3end(3)
     do iy=iwk3sta(2),iwk3end(2)
     do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/modules/hpsi2.f90
+++ b/GCEED/modules/hpsi2.f90
@@ -68,14 +68,14 @@ end if
 ! Pseudopotential 1 (non-local)
 if(iflag_ps.eq.1)then
   if(nproc_Mxin_mul==1)then
-!$OMP parallel do
+!$OMP parallel do private(iatom,lm)
     do iatom=1,MI
       do lm=1,maxlm
         uVpsibox2(lm,iatom)=0.d0
       end do
     end do
   else
-!$OMP parallel do
+!$OMP parallel do private(iatom,lm)
     do iatom=1,MI
       do lm=1,maxlm
         uVpsibox(lm,iatom)=0.d0
@@ -149,7 +149,7 @@ end if
 
 ! Pseudo(local), Hartree, Exchange-Correlation potential
 if(ihpsieff==0)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -158,7 +158,7 @@ if(ihpsieff==0)then
   end do
   end do
 else if(ihpsieff==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -196,7 +196,7 @@ if(iflag_ps==1) then
 end if
 
 wk2=0.d0
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -207,7 +207,7 @@ end do
 call sendrecv(wk2)
 call calc_laplacian2(wk2,rlap_wk)
 
-!$OMP parallel do              
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
@@ -264,7 +264,7 @@ integer :: j,ind
 call set_ispin(iob,ispin)
 
 if(nn<=1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -284,7 +284,7 @@ if(iflag_ps==1) then
 end if
 
 if(iflag_ps.eq.1)then
-!$OMP parallel do
+!$OMP parallel do private(iatom,lm)
   do iatom=1,MI
     do lm=1,maxlm
       uVpsibox(lm,iatom)=0.d0
@@ -345,7 +345,7 @@ if(isub==0)then
   end do
 
   elp3(757)=get_wtime()
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -376,7 +376,7 @@ else if(isub==1)then
   call calc_gradient2(tpsi,grad_wk)
 
   if(nn==N_hamil)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(2)
     do iz=iwk3sta(3),iwk3end(3)
     do iy=iwk3sta(2),iwk3end(2)
     do ix=iwk3sta(1),iwk3end(1)
@@ -389,7 +389,7 @@ else if(isub==1)then
     end do
     end do
   else
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(2)
     do iz=iwk3sta(3),iwk3end(3)
     do iy=iwk3sta(2),iwk3end(2)
     do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/modules/inner_product.f90
+++ b/GCEED/modules/inner_product.f90
@@ -38,7 +38,7 @@ real(8) :: matbox2(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3en
 real(8) :: rbox,rbox2
 
 rbox=0.d0
-!$omp parallel do reduction(+ : rbox) private(iz,iy,ix) collapse(3)
+!$omp parallel do reduction(+ : rbox) private(iz,iy,ix)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
@@ -69,7 +69,7 @@ complex(8) :: matbox2(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk
 complex(8) :: cbox,cbox2
 
 cbox=0.d0
-!$omp parallel do reduction(+ : cbox) private(iz,iy,ix) collapse(3)
+!$omp parallel do reduction(+ : cbox) private(iz,iy,ix) 
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/modules/inner_product.f90
+++ b/GCEED/modules/inner_product.f90
@@ -38,7 +38,7 @@ real(8) :: matbox2(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3en
 real(8) :: rbox,rbox2
 
 rbox=0.d0
-!$omp parallel do reduction(+ : rbox)
+!$omp parallel do reduction(+ : rbox) private(iz,iy,ix) collapse(3)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
@@ -69,7 +69,7 @@ complex(8) :: matbox2(iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk
 complex(8) :: cbox,cbox2
 
 cbox=0.d0
-!$omp parallel do reduction(+ : cbox)
+!$omp parallel do reduction(+ : cbox) private(iz,iy,ix) collapse(3)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/modules/laplacian2.f90
+++ b/GCEED/modules/laplacian2.f90
@@ -44,7 +44,7 @@ Hgs_i2(1) = 1d0/Hgs(1)**2
 Hgs_i2(2) = 1d0/Hgs(2)**2
 Hgs_i2(3) = 1d0/Hgs(3)**2
 
-!$OMP parallel do private(ist)
+!$OMP parallel do private(ist,iz,iy,ix) collapse(3)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
@@ -81,7 +81,7 @@ Hgs_i2(1) = 1d0/Hgs(1)**2
 Hgs_i2(2) = 1d0/Hgs(2)**2
 Hgs_i2(3) = 1d0/Hgs(3)**2
 
-!$OMP parallel do private(ist)
+!$OMP parallel do private(ist,iz,iy,ix) collapse(3)
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/modules/laplacian2.f90
+++ b/GCEED/modules/laplacian2.f90
@@ -44,7 +44,7 @@ Hgs_i2(1) = 1d0/Hgs(1)**2
 Hgs_i2(2) = 1d0/Hgs(2)**2
 Hgs_i2(3) = 1d0/Hgs(3)**2
 
-!$OMP parallel do private(ist,iz,iy,ix) collapse(3)
+!$OMP parallel do private(ist,iz,iy,ix) 
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)
@@ -81,7 +81,7 @@ Hgs_i2(1) = 1d0/Hgs(1)**2
 Hgs_i2(2) = 1d0/Hgs(2)**2
 Hgs_i2(3) = 1d0/Hgs(3)**2
 
-!$OMP parallel do private(ist,iz,iy,ix) collapse(3)
+!$OMP parallel do private(ist,iz,iy,ix) 
 do iz=iwk3sta(3),iwk3end(3)
 do iy=iwk3sta(2),iwk3end(2)
 do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/modules/sendrecv.f90
+++ b/GCEED/modules/sendrecv.f90
@@ -52,7 +52,7 @@ subroutine R_sendrecv(tpsi)
   !send from idw to iup
   
   if(iup/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -67,7 +67,7 @@ subroutine R_sendrecv(tpsi)
   !send from iup to idw
   
   if(idw/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -82,7 +82,7 @@ subroutine R_sendrecv(tpsi)
   !send from jdw to jup
   
   if(jup/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -97,7 +97,7 @@ subroutine R_sendrecv(tpsi)
   !send from jup to jdw
   
   if(jdw/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -113,7 +113,7 @@ subroutine R_sendrecv(tpsi)
   
   if(kup/=comm_proc_null)then
     do iz=1,Nd
-  !$OMP parallel do
+  !$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       srmatbox1_z_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz)
@@ -128,7 +128,7 @@ subroutine R_sendrecv(tpsi)
   
   if(kdw/=comm_proc_null)then
     do iz=1,Nd
-  !$OMP parallel do
+  !$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       srmatbox3_z_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1)
@@ -142,7 +142,7 @@ subroutine R_sendrecv(tpsi)
   
   call comm_wait_all(ireq(1:2))
   if(idw/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -154,7 +154,7 @@ subroutine R_sendrecv(tpsi)
   
   call comm_wait_all(ireq(3:4))
   if(iup/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -166,7 +166,7 @@ subroutine R_sendrecv(tpsi)
   
   call comm_wait_all(ireq(5:6))
   if(jdw/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -178,7 +178,7 @@ subroutine R_sendrecv(tpsi)
   
   call comm_wait_all(ireq(7:8))
   if(jup/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -191,7 +191,7 @@ subroutine R_sendrecv(tpsi)
   call comm_wait_all(ireq(9:10))
   if(kdw/=comm_proc_null)then
     do iz=1,Nd
-  !$OMP parallel do
+  !$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz)=srmatbox2_z_3d(ix,iy,iz)
@@ -203,7 +203,7 @@ subroutine R_sendrecv(tpsi)
   call comm_wait_all(ireq(11:12))
   if(kup/=comm_proc_null)then
     do iz=1,Nd
-  !$OMP parallel do
+  !$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz)=srmatbox4_z_3d(ix,iy,iz)
@@ -239,7 +239,7 @@ subroutine C_sendrecv(tpsi)
   !send from idw to iup
   
   if(iup/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -254,7 +254,7 @@ subroutine C_sendrecv(tpsi)
   !send from iup to idw
   
   if(idw/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -269,7 +269,7 @@ subroutine C_sendrecv(tpsi)
   !send from jdw to jup
   
   if(jup/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -284,7 +284,7 @@ subroutine C_sendrecv(tpsi)
   !send from jup to jdw
   
   if(jdw/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -300,7 +300,7 @@ subroutine C_sendrecv(tpsi)
   
   if(kup/=comm_proc_null)then
     do iz=1,Nd
-  !$OMP parallel do
+  !$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       scmatbox1_z_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz)
@@ -315,7 +315,7 @@ subroutine C_sendrecv(tpsi)
   
   if(kdw/=comm_proc_null)then
     do iz=1,Nd
-  !$OMP parallel do
+  !$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       scmatbox3_z_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1)
@@ -329,7 +329,7 @@ subroutine C_sendrecv(tpsi)
   
   call comm_wait_all(ireq(1:2))
   if(idw/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -341,7 +341,7 @@ subroutine C_sendrecv(tpsi)
   
   call comm_wait_all(ireq(3:4))
   if(iup/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -353,7 +353,7 @@ subroutine C_sendrecv(tpsi)
   
   call comm_wait_all(ireq(5:6))
   if(jdw/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -365,7 +365,7 @@ subroutine C_sendrecv(tpsi)
   
   call comm_wait_all(ireq(7:8))
   if(jup/=comm_proc_null)then
-  !$OMP parallel do
+  !$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -378,7 +378,7 @@ subroutine C_sendrecv(tpsi)
   call comm_wait_all(ireq(9:10))
   if(kdw/=comm_proc_null)then
     do iz=1,Nd
-  !$OMP parallel do
+  !$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz)=scmatbox2_z_3d(ix,iy,iz)
@@ -390,7 +390,7 @@ subroutine C_sendrecv(tpsi)
   call comm_wait_all(ireq(11:12))
   if(kup/=comm_proc_null)then
     do iz=1,Nd
-  !$OMP parallel do
+  !$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz)=scmatbox4_z_3d(ix,iy,iz)

--- a/GCEED/modules/sendrecv_groupob.f90
+++ b/GCEED/modules/sendrecv_groupob.f90
@@ -53,7 +53,7 @@ icomm=nproc_group_orbital
 
 if(iup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -70,7 +70,7 @@ ireq(2) = comm_irecv(srmatbox2_x_5d,idw,3,icomm)
 
 if(idw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -87,7 +87,7 @@ ireq(4) = comm_irecv(srmatbox4_x_5d,iup,4,icomm)
 
 if(jup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -104,7 +104,7 @@ ireq(6) = comm_irecv(srmatbox2_y_5d,jdw,5,icomm)
 
 if(jdw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -122,7 +122,7 @@ ireq(8) = comm_irecv(srmatbox4_y_5d,jup,6,icomm)
 if(kup/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do private(iy,ix) collapse(2)
+!$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       srmatbox1_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz,iob,1)
@@ -139,7 +139,7 @@ ireq(10) = comm_irecv(srmatbox2_z_5d,kdw,7,icomm)
 if(kdw/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do private(iy,ix) collapse(2)
+!$OMP parallel do private(iy,ix) 
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       srmatbox3_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1,iob,1)
@@ -155,7 +155,7 @@ ireq(12) = comm_irecv(srmatbox4_z_5d,kup,8,icomm)
 call comm_wait_all(ireq(1:2))
 if(idw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -264,7 +264,7 @@ icomm=nproc_group_orbital
 
 if(iup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -281,7 +281,7 @@ ireq(2) = comm_irecv(scmatbox2_x_5d,idw,3,icomm)
 
 if(idw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -298,7 +298,7 @@ ireq(4) = comm_irecv(scmatbox4_x_5d,iup,4,icomm)
 
 if(jup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -315,7 +315,7 @@ ireq(6) = comm_irecv(scmatbox2_y_5d,jdw,5,icomm)
 
 if(jdw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -333,7 +333,7 @@ ireq(8) = comm_irecv(scmatbox4_y_5d,jup,6,icomm)
 if(kup/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do private(iy,ix) collapse(2)
+!$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       scmatbox1_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz,iob,1)
@@ -350,7 +350,7 @@ ireq(10) = comm_irecv(scmatbox2_z_5d,kdw,7,icomm)
 if(kdw/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do private(iy,ix) collapse(2)
+!$OMP parallel do private(iy,ix) 
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       scmatbox3_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1,iob,1)

--- a/GCEED/modules/sendrecv_groupob.f90
+++ b/GCEED/modules/sendrecv_groupob.f90
@@ -53,7 +53,7 @@ icomm=nproc_group_orbital
 
 if(iup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -70,7 +70,7 @@ ireq(2) = comm_irecv(srmatbox2_x_5d,idw,3,icomm)
 
 if(idw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -87,7 +87,7 @@ ireq(4) = comm_irecv(srmatbox4_x_5d,iup,4,icomm)
 
 if(jup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -104,7 +104,7 @@ ireq(6) = comm_irecv(srmatbox2_y_5d,jdw,5,icomm)
 
 if(jdw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -122,7 +122,7 @@ ireq(8) = comm_irecv(srmatbox4_y_5d,jup,6,icomm)
 if(kup/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix) collapse(2)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       srmatbox1_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz,iob,1)
@@ -139,7 +139,7 @@ ireq(10) = comm_irecv(srmatbox2_z_5d,kdw,7,icomm)
 if(kdw/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix) collapse(2)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       srmatbox3_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1,iob,1)
@@ -155,7 +155,7 @@ ireq(12) = comm_irecv(srmatbox4_z_5d,kup,8,icomm)
 call comm_wait_all(ireq(1:2))
 if(idw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -169,7 +169,7 @@ end if
 call comm_wait_all(ireq(3:4))
 if(iup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -183,7 +183,7 @@ end if
 call comm_wait_all(ireq(5:6))
 if(jdw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -197,7 +197,7 @@ end if
 call comm_wait_all(ireq(7:8))
 if(jup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -212,7 +212,7 @@ call comm_wait_all(ireq(9:10))
 if(kdw/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix) 
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz,iob,1)=srmatbox2_z_5d(ix,iy,iz,iob,1)
@@ -226,7 +226,7 @@ call comm_wait_all(ireq(11:12))
 if(kup/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix) 
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz,iob,1)=srmatbox4_z_5d(ix,iy,iz,iob,1)
@@ -264,7 +264,7 @@ icomm=nproc_group_orbital
 
 if(iup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -281,7 +281,7 @@ ireq(2) = comm_irecv(scmatbox2_x_5d,idw,3,icomm)
 
 if(idw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -298,7 +298,7 @@ ireq(4) = comm_irecv(scmatbox4_x_5d,iup,4,icomm)
 
 if(jup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -315,7 +315,7 @@ ireq(6) = comm_irecv(scmatbox2_y_5d,jdw,5,icomm)
 
 if(jdw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -333,7 +333,7 @@ ireq(8) = comm_irecv(scmatbox4_y_5d,jup,6,icomm)
 if(kup/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix) collapse(2)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       scmatbox1_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz,iob,1)
@@ -350,7 +350,7 @@ ireq(10) = comm_irecv(scmatbox2_z_5d,kdw,7,icomm)
 if(kdw/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix) collapse(2)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       scmatbox3_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1,iob,1)
@@ -366,7 +366,7 @@ ireq(12) = comm_irecv(scmatbox4_z_5d,kup,8,icomm)
 call comm_wait_all(ireq(1:2))
 if(idw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -380,7 +380,7 @@ end if
 call comm_wait_all(ireq(3:4))
 if(iup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,mg_num(2)
     do ix=1,Nd
@@ -394,7 +394,7 @@ end if
 call comm_wait_all(ireq(5:6))
 if(jdw/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -408,7 +408,7 @@ end if
 call comm_wait_all(ireq(7:8))
 if(jup/=comm_proc_null)then
   do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) 
     do iz=1,mg_num(3)
     do iy=1,Nd
     do ix=1,mg_num(1)
@@ -423,7 +423,7 @@ call comm_wait_all(ireq(9:10))
 if(kdw/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix) 
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz,iob,1)=scmatbox2_z_5d(ix,iy,iz,iob,1)
@@ -437,7 +437,7 @@ call comm_wait_all(ireq(11:12))
 if(kup/=comm_proc_null)then
   do iob=1,iobnum
     do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
     do iy=1,mg_num(2)
     do ix=1,mg_num(1)
       tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz,iob,1)=scmatbox4_z_5d(ix,iy,iz,iob,1)

--- a/GCEED/modules/sendrecv_groupob_ngp.f90
+++ b/GCEED/modules/sendrecv_groupob_ngp.f90
@@ -34,7 +34,7 @@ real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
 integer :: ix,iy,iz,iob
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,mg_num(3)
   do iy=1,mg_num(2)
   do ix=1,Nd
@@ -48,7 +48,7 @@ end do
 !send from iup to idw
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,mg_num(3)
   do iy=1,mg_num(2)
   do ix=1,Nd
@@ -62,7 +62,7 @@ end do
 !send from jdw to jup
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,mg_num(3)
   do iy=1,Nd
   do ix=1,mg_num(1)
@@ -76,7 +76,7 @@ end do
 !send from jup to jdw
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,mg_num(3)
   do iy=1,Nd
   do ix=1,mg_num(1)
@@ -91,7 +91,7 @@ end do
 
 do iob=1,iobnum
   do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,mg_num(2)
   do ix=1,mg_num(1)
     tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz,iob,1)=  &
@@ -105,7 +105,7 @@ end do
 
 do iob=1,iobnum
   do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,mg_num(2)
   do ix=1,mg_num(1)
     tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz,iob,1)= &
@@ -126,7 +126,7 @@ complex(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
 integer :: ix,iy,iz,iob
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz, iy,ix)
   do iz=1,mg_num(3)
   do iy=1,mg_num(2)
   do ix=1,Nd
@@ -140,7 +140,7 @@ end do
 !send from iup to idw
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz, iy,ix)
   do iz=1,mg_num(3)
   do iy=1,mg_num(2)
   do ix=1,Nd
@@ -154,7 +154,7 @@ end do
 !send from jdw to jup
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz, iy,ix)
   do iz=1,mg_num(3)
   do iy=1,Nd
   do ix=1,mg_num(1)
@@ -168,7 +168,7 @@ end do
 !send from jup to jdw
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz, iy,ix)
   do iz=1,mg_num(3)
   do iy=1,Nd
   do ix=1,mg_num(1)
@@ -183,7 +183,7 @@ end do
 
 do iob=1,iobnum
   do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,mg_num(2)
   do ix=1,mg_num(1)
     tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz,iob,1)=  &
@@ -197,7 +197,7 @@ end do
 
 do iob=1,iobnum
   do iz=1,Nd
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,mg_num(2)
   do ix=1,mg_num(1)
     tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz,iob,1)= &

--- a/GCEED/modules/sendrecvh.f90
+++ b/GCEED/modules/sendrecvh.f90
@@ -88,7 +88,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
   ibox=13
 end if
 if(iup/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,iwk3num(2)
   do ix=1,Ndh
@@ -99,7 +99,7 @@ if(iup/=comm_proc_null)then
 end if
 call comm_exchange(rmatbox1_x_h,iup,rmatbox2_x_h,idw,1,icomm)
 if(idw/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,iwk3num(2)
   do ix=1,Ndh
@@ -117,7 +117,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
   ibox=15
 end if
 if(idw/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,iwk3num(2)
   do ix=1,Ndh
@@ -128,7 +128,7 @@ if(idw/=comm_proc_null)then
 end if
 call comm_exchange(rmatbox1_x_h,idw,rmatbox2_x_h,iup,1,icomm)
 if(iup/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,iwk3num(2)
   do ix=1,Ndh
@@ -147,7 +147,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
   ibox=17
 end if
 if(jup/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,Ndh
   do ix=1,iwk3num(1)
@@ -158,7 +158,7 @@ if(jup/=comm_proc_null)then
 end if
 call comm_exchange(rmatbox1_y_h,jup,rmatbox2_y_h,jdw,1,icomm)
 if(jdw/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,Ndh
   do ix=1,iwk3num(1)
@@ -176,7 +176,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
   ibox=19
 end if
 if(jdw/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,Ndh
   do ix=1,iwk3num(1)
@@ -187,7 +187,7 @@ if(jdw/=comm_proc_null)then
 end if
 call comm_exchange(rmatbox1_y_h,jdw,rmatbox2_y_h,jup,1,icomm)
 if(jup/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,Ndh
   do ix=1,iwk3num(1)
@@ -206,7 +206,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
 end if
 if(kup/=comm_proc_null)then
   do iz=1,Ndh
-!$OMP parallel do
+!$OMP parallel do  private(iy,ix)
   do iy=1,iwk3num(2)
   do ix=1,iwk3num(1)
     rmatbox1_z_h(ix,iy,iz)=wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3end(3)-Ndh+iz)
@@ -217,7 +217,7 @@ end if
 call comm_exchange(rmatbox1_z_h,kup,rmatbox2_z_h,kdw,1,icomm)
 if(kdw/=comm_proc_null)then
   do iz=1,Ndh
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,iwk3num(2)
   do ix=1,iwk3num(1)
     wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3sta(3)-1-Ndh+iz)=rmatbox2_z_h(ix,iy,iz)
@@ -235,7 +235,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
 end if
 if(kdw/=comm_proc_null)then
   do iz=1,Ndh
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,iwk3num(2)
   do ix=1,iwk3num(1)
     rmatbox1_z_h(ix,iy,iz)=wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3sta(3)+iz-1)
@@ -246,7 +246,7 @@ end if
 call comm_exchange(rmatbox1_z_h,kdw,rmatbox2_z_h,kup,1,icomm)
 if(kup/=comm_proc_null)then
   do iz=1,Ndh
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,iwk3num(2)
   do ix=1,iwk3num(1)
     wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3end(3)+iz)=rmatbox2_z_h(ix,iy,iz)
@@ -318,7 +318,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
   ibox=13
 end if
 if(iup/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,iwk3num(2)
   do ix=1,Ndh
@@ -329,7 +329,7 @@ if(iup/=comm_proc_null)then
 end if
 call comm_exchange(rmatbox1_x_h,iup,rmatbox2_x_h,idw,1,icomm)
 if(idw/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,iwk3num(2)
   do ix=1,Ndh
@@ -347,7 +347,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
   ibox=15
 end if
 if(idw/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,iwk3num(2)
   do ix=1,Ndh
@@ -358,7 +358,7 @@ if(idw/=comm_proc_null)then
 end if
 call comm_exchange(rmatbox1_x_h,idw,rmatbox2_x_h,iup,1,icomm)
 if(iup/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,iwk3num(2)
   do ix=1,Ndh
@@ -377,7 +377,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
   ibox=17
 end if
 if(jup/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,Ndh
   do ix=1,iwk3num(1)
@@ -388,7 +388,7 @@ if(jup/=comm_proc_null)then
 end if
 call comm_exchange(rmatbox1_y_h,jup,rmatbox2_y_h,jdw,1,icomm)
 if(jdw/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,Ndh
   do ix=1,iwk3num(1)
@@ -406,7 +406,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
   ibox=19
 end if
 if(jdw/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,Ndh
   do ix=1,iwk3num(1)
@@ -417,7 +417,7 @@ if(jdw/=comm_proc_null)then
 end if
 call comm_exchange(rmatbox1_y_h,jdw,rmatbox2_y_h,jup,1,icomm)
 if(jup/=comm_proc_null)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix)
   do iz=1,iwk3num(3)
   do iy=1,Ndh
   do ix=1,iwk3num(1)
@@ -436,7 +436,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
 end if
 if(kup/=comm_proc_null)then
   do iz=1,Ndh
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,iwk3num(2)
   do ix=1,iwk3num(1)
     cmatbox1_z_h(ix,iy,iz)=wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3end(3)-Ndh+iz)
@@ -447,7 +447,7 @@ end if
 call comm_exchange(rmatbox1_z_h,kup,rmatbox2_z_h,kdw,1,icomm)
 if(kdw/=comm_proc_null)then
   do iz=1,Ndh
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,iwk3num(2)
   do ix=1,iwk3num(1)
     wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3sta(3)-1-Ndh+iz)=cmatbox2_z_h(ix,iy,iz)
@@ -465,7 +465,7 @@ else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
 end if
 if(kdw/=comm_proc_null)then
   do iz=1,Ndh
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,iwk3num(2)
   do ix=1,iwk3num(1)
     cmatbox1_z_h(ix,iy,iz)=wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3sta(3)+iz-1)
@@ -476,7 +476,7 @@ end if
 call comm_exchange(rmatbox1_z_h,kdw,rmatbox2_z_h,kup,1,icomm)
 if(kup/=comm_proc_null)then
   do iz=1,Ndh
-!$OMP parallel do
+!$OMP parallel do private(iy,ix)
   do iy=1,iwk3num(2)
   do ix=1,iwk3num(1)
     wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3end(3)+iz)=cmatbox2_z_h(ix,iy,iz)

--- a/GCEED/modules/total_energy.f90
+++ b/GCEED/modules/total_energy.f90
@@ -53,7 +53,7 @@ ihpsieff=0
 
 esp=0.d0
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -65,7 +65,7 @@ end do
 do iob=1,iobnum
   call calc_allob(iob,iob_allob)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -77,7 +77,7 @@ do iob=1,iobnum
   call hpsi2(tpsi,htpsi,iob_allob,0,0)
 
   rbox=0.d0
-!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -164,7 +164,7 @@ ihpsieff=0
 
 esp2=0.d0
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -179,7 +179,7 @@ do iob=1,iobnum
   call calc_allob(iob,iob_allob)
   elp3(863)=get_wtime()
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -194,7 +194,7 @@ do iob=1,iobnum
   elp3(884)=elp3(884)+elp3(864)-elp3(863)
 
   cbox=0.d0
-!$OMP parallel do reduction ( + : cbox ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction ( + : cbox ) private(iz,iy,ix) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)

--- a/GCEED/modules/total_energy.f90
+++ b/GCEED/modules/total_energy.f90
@@ -53,7 +53,7 @@ ihpsieff=0
 
 esp=0.d0
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -65,7 +65,7 @@ end do
 do iob=1,iobnum
   call calc_allob(iob,iob_allob)
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -77,7 +77,7 @@ do iob=1,iobnum
   call hpsi2(tpsi,htpsi,iob_allob,0,0)
 
   rbox=0.d0
-!$OMP parallel do reduction ( + : rbox )
+!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -164,7 +164,7 @@ ihpsieff=0
 
 esp2=0.d0
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -179,7 +179,7 @@ do iob=1,iobnum
   call calc_allob(iob,iob_allob)
   elp3(863)=get_wtime()
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -194,7 +194,7 @@ do iob=1,iobnum
   elp3(884)=elp3(884)+elp3(864)-elp3(863)
 
   cbox=0.d0
-!$OMP parallel do reduction ( + : cbox )
+!$OMP parallel do reduction ( + : cbox ) private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)

--- a/GCEED/rt/add_polynomial.f90
+++ b/GCEED/rt/add_polynomial.f90
@@ -38,7 +38,7 @@ integer :: iob_allob
 
 if(ifunc==0)then
   do iob=1,iobmax
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -51,7 +51,7 @@ if(ifunc==0)then
 else if(ifunc==1)then
   do iob=1,iobmax
     cbox=0.d0
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -65,7 +65,7 @@ else if(ifunc==1)then
   end do
 else if(ifunc==2)then
   do iob=1,iobmax
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -78,7 +78,7 @@ else if(ifunc==2)then
 else if(ifunc==3)then
   do iob=1,iobmax
     cbox=0.d0
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -94,7 +94,7 @@ else if(ifunc==4)then
   if(ilsda==0)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -110,7 +110,7 @@ else if(ifunc==4)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
       if(iob_allob<=MST(1))then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -122,7 +122,7 @@ else if(ifunc==4)then
         end do
         end do
       else
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -141,7 +141,7 @@ else if(ifunc==5)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
       cbox=0.d0
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -160,7 +160,7 @@ else if(ifunc==5)then
       call calc_allob(iob,iob_allob)
       cbox=0.d0
       if(iob_allob<=MST(1))then
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -173,7 +173,7 @@ else if(ifunc==5)then
         end do
         end do
       else
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -193,7 +193,7 @@ else if(ifunc==6)then
   if(ilsda==0)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -209,7 +209,7 @@ else if(ifunc==6)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
       if(iob_allob<=MST(1))then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -221,7 +221,7 @@ else if(ifunc==6)then
         end do
         end do
       else
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -239,7 +239,7 @@ else if(ifunc==7)then
   if(ilsda==0)then
     do iob=1,iobmax
       cbox=0.d0
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -258,7 +258,7 @@ else if(ifunc==7)then
       call calc_allob(iob,iob_allob)
       cbox=0.d0
       if(iob_allob<=MST(1))then
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -271,7 +271,7 @@ else if(ifunc==7)then
         end do
         end do
       else
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) 
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -289,7 +289,7 @@ else if(ifunc==7)then
   end if
 else if(ifunc==-1)then
   do iob=1,iobmax
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/rt/add_polynomial.f90
+++ b/GCEED/rt/add_polynomial.f90
@@ -38,7 +38,7 @@ integer :: iob_allob
 
 if(ifunc==0)then
   do iob=1,iobmax
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -51,7 +51,7 @@ if(ifunc==0)then
 else if(ifunc==1)then
   do iob=1,iobmax
     cbox=0.d0
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -65,7 +65,7 @@ else if(ifunc==1)then
   end do
 else if(ifunc==2)then
   do iob=1,iobmax
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -78,7 +78,7 @@ else if(ifunc==2)then
 else if(ifunc==3)then
   do iob=1,iobmax
     cbox=0.d0
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -94,7 +94,7 @@ else if(ifunc==4)then
   if(ilsda==0)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -110,7 +110,7 @@ else if(ifunc==4)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
       if(iob_allob<=MST(1))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -122,7 +122,7 @@ else if(ifunc==4)then
         end do
         end do
       else
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -141,7 +141,7 @@ else if(ifunc==5)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
       cbox=0.d0
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -160,7 +160,7 @@ else if(ifunc==5)then
       call calc_allob(iob,iob_allob)
       cbox=0.d0
       if(iob_allob<=MST(1))then
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -173,7 +173,7 @@ else if(ifunc==5)then
         end do
         end do
       else
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -193,7 +193,7 @@ else if(ifunc==6)then
   if(ilsda==0)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -209,7 +209,7 @@ else if(ifunc==6)then
     do iob=1,iobmax
       call calc_allob(iob,iob_allob)
       if(iob_allob<=MST(1))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -221,7 +221,7 @@ else if(ifunc==6)then
         end do
         end do
       else
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -239,7 +239,7 @@ else if(ifunc==7)then
   if(ilsda==0)then
     do iob=1,iobmax
       cbox=0.d0
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -258,7 +258,7 @@ else if(ifunc==7)then
       call calc_allob(iob,iob_allob)
       cbox=0.d0
       if(iob_allob<=MST(1))then
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -271,7 +271,7 @@ else if(ifunc==7)then
         end do
         end do
       else
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -289,7 +289,7 @@ else if(ifunc==7)then
   end if
 else if(ifunc==-1)then
   do iob=1,iobmax
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/rt/calcEstatic.f90
+++ b/GCEED/rt/calcEstatic.f90
@@ -33,7 +33,7 @@ iwk_size=11
 call make_iwksta_iwkend
 
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
@@ -43,7 +43,7 @@ end do
 end do
 
 if(mod(itt,2)==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -53,7 +53,7 @@ if(mod(itt,2)==1)then
   end do
   end do
 else
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -67,7 +67,7 @@ end if
 call sendrecvh(Vh_wk)
 
 if(ng_sta(1)==lg_sta(1))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(2)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
     do ix=1,Ndh
@@ -78,7 +78,7 @@ if(ng_sta(1)==lg_sta(1))then
 end if
 
 if(ng_end(1)==lg_end(1))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(2)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
     do ix=1,Ndh
@@ -89,7 +89,7 @@ if(ng_end(1)==lg_end(1))then
 end if
 
 if(ng_sta(2)==lg_sta(2))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(2)
   do iz=ng_sta(3),ng_end(3)
   do ix=ng_sta(1),ng_end(1)
     do iy=1,Ndh
@@ -100,7 +100,7 @@ if(ng_sta(2)==lg_sta(2))then
 end if
 
 if(ng_end(2)==lg_end(2))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(2)
   do iz=ng_sta(3),ng_end(3)
   do ix=ng_sta(1),ng_end(1)
     do iy=1,Ndh
@@ -111,7 +111,7 @@ if(ng_end(2)==lg_end(2))then
 end if
 
 if(ng_sta(3)==lg_sta(3))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(2)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
     do iz=1,Ndh
@@ -122,7 +122,7 @@ if(ng_sta(3)==lg_sta(3))then
 end if
 
 if(ng_end(3)==lg_end(3))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(2)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
     do iz=1,Ndh
@@ -132,7 +132,7 @@ if(ng_end(3)==lg_end(3))then
   end do
 end if
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -143,7 +143,7 @@ end do
 end do
 end do
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix,ist) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/calcEstatic.f90
+++ b/GCEED/rt/calcEstatic.f90
@@ -33,7 +33,7 @@ iwk_size=11
 call make_iwksta_iwkend
 
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
@@ -43,7 +43,7 @@ end do
 end do
 
 if(mod(itt,2)==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -53,7 +53,7 @@ if(mod(itt,2)==1)then
   end do
   end do
 else
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -67,7 +67,7 @@ end if
 call sendrecvh(Vh_wk)
 
 if(ng_sta(1)==lg_sta(1))then
-!$OMP parallel do private(iz,iy,ix) collapse(2)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
     do ix=1,Ndh
@@ -78,7 +78,7 @@ if(ng_sta(1)==lg_sta(1))then
 end if
 
 if(ng_end(1)==lg_end(1))then
-!$OMP parallel do private(iz,iy,ix) collapse(2)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
     do ix=1,Ndh
@@ -89,7 +89,7 @@ if(ng_end(1)==lg_end(1))then
 end if
 
 if(ng_sta(2)==lg_sta(2))then
-!$OMP parallel do private(iz,iy,ix) collapse(2)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do ix=ng_sta(1),ng_end(1)
     do iy=1,Ndh
@@ -100,7 +100,7 @@ if(ng_sta(2)==lg_sta(2))then
 end if
 
 if(ng_end(2)==lg_end(2))then
-!$OMP parallel do private(iz,iy,ix) collapse(2)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do ix=ng_sta(1),ng_end(1)
     do iy=1,Ndh
@@ -111,7 +111,7 @@ if(ng_end(2)==lg_end(2))then
 end if
 
 if(ng_sta(3)==lg_sta(3))then
-!$OMP parallel do private(iz,iy,ix) collapse(2)
+!$OMP parallel do private(iz,iy,ix)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
     do iz=1,Ndh
@@ -122,7 +122,7 @@ if(ng_sta(3)==lg_sta(3))then
 end if
 
 if(ng_end(3)==lg_end(3))then
-!$OMP parallel do private(iz,iy,ix) collapse(2)
+!$OMP parallel do private(iz,iy,ix)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
     do iz=1,Ndh
@@ -132,7 +132,7 @@ if(ng_end(3)==lg_end(3))then
   end do
 end if
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -143,7 +143,7 @@ end do
 end do
 end do
 
-!$OMP parallel do private(iz,iy,ix,ist) collapse(3)
+!$OMP parallel do private(iz,iy,ix,ist) 
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/dip.f90
+++ b/GCEED/rt/dip.f90
@@ -38,7 +38,7 @@ real(8) :: absr2
    end do
    do i1=1,3
      rbox1=0.d0
-!$OMP parallel do reduction( + : rbox1 )
+!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix) collapse(3)
      do iz=ng_sta(3),ng_end(3)
      do iy=ng_sta(2),ng_end(2)
      do ix=ng_sta(1),ng_end(1)
@@ -50,7 +50,7 @@ real(8) :: absr2
    end do
    
    rbox1=0.d0
-!$OMP parallel do reduction( + : rbox1 )
+!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix) collapse(3)
    do iz=ng_sta(3),ng_end(3)
    do iy=ng_sta(2),ng_end(2)
    do ix=ng_sta(1),ng_end(1)
@@ -65,7 +65,7 @@ real(8) :: absr2
 if(quadrupole=='y')then
    rho_diff(:,:,:) = rho(:,:,:)-rho0(:,:,:)
 
-!$OMP parallel do
+!$OMP parallel do private(i1,i2)
    do i1=1,3
      do i2=1,3
        rbox_arrayq(i1, i2)=0.d0
@@ -76,7 +76,7 @@ if(quadrupole=='y')then
 
    do i1=1,3
      rbox1q=0.d0
-!$OMP parallel do reduction( + : rbox1q ) private(absr2)
+!$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix) collapse(3)
      do iz=ng_sta(3),ng_end(3)
      do iy=ng_sta(2),ng_end(2)
      do ix=ng_sta(1),ng_end(1)
@@ -93,7 +93,7 @@ if(quadrupole=='y')then
      rbox1q12=0.d0
      rbox1q23=0.d0
      rbox1q31=0.d0
-!$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 )
+!$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix) collapse(3)
      do iz=ng_sta(3),ng_end(3)
      do iy=ng_sta(2),ng_end(2)
      do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/dip.f90
+++ b/GCEED/rt/dip.f90
@@ -38,7 +38,7 @@ real(8) :: absr2
    end do
    do i1=1,3
      rbox1=0.d0
-!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix)
      do iz=ng_sta(3),ng_end(3)
      do iy=ng_sta(2),ng_end(2)
      do ix=ng_sta(1),ng_end(1)
@@ -50,7 +50,7 @@ real(8) :: absr2
    end do
    
    rbox1=0.d0
-!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix)
    do iz=ng_sta(3),ng_end(3)
    do iy=ng_sta(2),ng_end(2)
    do ix=ng_sta(1),ng_end(1)
@@ -76,7 +76,7 @@ if(quadrupole=='y')then
 
    do i1=1,3
      rbox1q=0.d0
-!$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix) collapse(3)
+!$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix)
      do iz=ng_sta(3),ng_end(3)
      do iy=ng_sta(2),ng_end(2)
      do ix=ng_sta(1),ng_end(1)
@@ -93,7 +93,7 @@ if(quadrupole=='y')then
      rbox1q12=0.d0
      rbox1q23=0.d0
      rbox1q31=0.d0
-!$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix)
      do iz=ng_sta(3),ng_end(3)
      do iy=ng_sta(2),ng_end(2)
      do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/gradient_ex.f90
+++ b/GCEED/rt/gradient_ex.f90
@@ -24,7 +24,7 @@ complex(8) :: wk2(iwk2sta(1):iwk2end(1)+1,iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2e
 complex(8) :: grad_wk(3,iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
 if(Nd<=3)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -38,7 +38,7 @@ if(Nd<=3)then
   end do
   end do
 else if(Nd==4)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/rt/gradient_ex.f90
+++ b/GCEED/rt/gradient_ex.f90
@@ -24,7 +24,7 @@ complex(8) :: wk2(iwk2sta(1):iwk2end(1)+1,iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2e
 complex(8) :: grad_wk(3,iwk3sta(1):iwk3end(1),iwk3sta(2):iwk3end(2),iwk3sta(3):iwk3end(3))
 
 if(Nd<=3)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)
@@ -38,7 +38,7 @@ if(Nd<=3)then
   end do
   end do
 else if(Nd==4)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=iwk3sta(3),iwk3end(3)
   do iy=iwk3sta(2),iwk3end(2)
   do ix=iwk3sta(1),iwk3end(1)

--- a/GCEED/rt/hpsi_groupob.f90
+++ b/GCEED/rt/hpsi_groupob.f90
@@ -88,7 +88,7 @@ if(Nd==4)then
     call set_ispin(iob_allob,jspin)
 !$OMP parallel private(iz)
     do iz=iwk3sta(3),iwk3end(3)
-!$OMP do private(iy,ix) collapse(2)
+!$OMP do private(iy,ix)
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         htpsi(ix,iy,iz,iob,1) =   &
@@ -104,7 +104,7 @@ if(Nd==4)then
       end do
       end do
 !$OMP end do nowait
-!$OMP do private(iy,ix) collapse(2)
+!$OMP do private(iy,ix)
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         htpsi(ix,iy,iz,iob,1) = htpsi(ix,iy,iz,iob,1)  &
@@ -130,7 +130,7 @@ else
     end do
 !$OMP parallel private(iz,ist)
     do iz=iwk3sta(3),iwk3end(3)
-!$OMP do private(iy,ix) collapse(2)
+!$OMP do private(iy,ix)
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         htpsi(ix,iy,iz,iob,1) = (tVlocal(ix,iy,iz,jspin)+fdN0) *tpsi(ix,iy,iz,iob,1)  
@@ -142,7 +142,7 @@ else
       end do
       end do
 !$OMP end do nowait
-!$OMP do private(iy,ix) collapse(2)
+!$OMP do private(iy,ix)
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         do ist=1,Nd  

--- a/GCEED/rt/hpsi_groupob.f90
+++ b/GCEED/rt/hpsi_groupob.f90
@@ -88,7 +88,7 @@ if(Nd==4)then
     call set_ispin(iob_allob,jspin)
 !$OMP parallel private(iz)
     do iz=iwk3sta(3),iwk3end(3)
-!$OMP do
+!$OMP do private(iy,ix) collapse(2)
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         htpsi(ix,iy,iz,iob,1) =   &
@@ -104,7 +104,7 @@ if(Nd==4)then
       end do
       end do
 !$OMP end do nowait
-!$OMP do
+!$OMP do private(iy,ix) collapse(2)
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         htpsi(ix,iy,iz,iob,1) = htpsi(ix,iy,iz,iob,1)  &
@@ -130,7 +130,7 @@ else
     end do
 !$OMP parallel private(iz,ist)
     do iz=iwk3sta(3),iwk3end(3)
-!$OMP do
+!$OMP do private(iy,ix) collapse(2)
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         htpsi(ix,iy,iz,iob,1) = (tVlocal(ix,iy,iz,jspin)+fdN0) *tpsi(ix,iy,iz,iob,1)  
@@ -142,7 +142,7 @@ else
       end do
       end do
 !$OMP end do nowait
-!$OMP do
+!$OMP do private(iy,ix) collapse(2)
       do iy=iwk3sta(2),iwk3end(2)
       do ix=iwk3sta(1),iwk3end(1)
         do ist=1,Nd  

--- a/GCEED/rt/projection.f90
+++ b/GCEED/rt/projection.f90
@@ -50,7 +50,7 @@ do iob=1,itotMST0
   call calc_myob(iob,iob_myob)
   call check_corrkob(iob,icorr_p)
   if(icorr_p==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -63,7 +63,7 @@ do iob=1,itotMST0
   call comm_bcast(cmatbox_m,nproc_group_grid,iroot)
   do job=1,iobmax
     cbox=0.d0
-!$OMP parallel do reduction(+:cbox)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/rt/projection.f90
+++ b/GCEED/rt/projection.f90
@@ -50,7 +50,7 @@ do iob=1,itotMST0
   call calc_myob(iob,iob_myob)
   call check_corrkob(iob,icorr_p)
   if(icorr_p==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -63,7 +63,7 @@ do iob=1,itotMST0
   call comm_bcast(cmatbox_m,nproc_group_grid,iroot)
   do job=1,iobmax
     cbox=0.d0
-!$OMP parallel do reduction(+:cbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:cbox) private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/rt/real_time_dft.f90
+++ b/GCEED/rt/real_time_dft.f90
@@ -237,7 +237,7 @@ elp3(404)=get_wtime()
 allocate(Ex_fast(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
 allocate(Ec_fast(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -252,7 +252,7 @@ allocate( Ex_static(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
 allocate( Ey_static(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))) 
 allocate( Ez_static(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))) 
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -699,7 +699,7 @@ if(ilsda==1)then
   allocate(rhobox_s(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),2))
 end if
 if(ilsda==0)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -710,7 +710,7 @@ if(ilsda==0)then
   
   do iob=1,iobnum
     call calc_allob(iob,iob_allob)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -721,7 +721,7 @@ if(ilsda==0)then
   end do
   call comm_summation(rhobox,rho,mg_num(1)*mg_num(2)*mg_num(3),nproc_group_grid)
 else if(ilsda==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -734,7 +734,7 @@ else if(ilsda==1)then
   do iob=1,iobnum
     call calc_allob(iob,iob_allob)
     if(iob_allob<=MST(1))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -743,7 +743,7 @@ else if(ilsda==1)then
       end do
       end do
     else
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -754,7 +754,7 @@ else if(ilsda==1)then
     end if
   end do
   call comm_summation(rhobox_s,rho_s,mg_num(1)*mg_num(2)*mg_num(3)*2,nproc_group_grid)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -764,7 +764,7 @@ else if(ilsda==1)then
   end do
 end if
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -831,7 +831,7 @@ end select
 
 if(quadrupole=='y')then
   if(quadrupole_pot=='sum')then
-    !$OMP parallel do collapse(2)
+    !$OMP parallel do collapse(2) private(iz,iy,ix)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)
@@ -845,7 +845,7 @@ if(quadrupole=='y')then
     end do 
     end do 
   else if(quadrupole_pot=='product')then
-    !$OMP parallel do collapse(2)
+    !$OMP parallel do collapse(2) private(iz,iy,ix)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)
@@ -860,7 +860,7 @@ if(quadrupole=='y')then
     end do 
   end if
 else
-  !$OMP parallel do collapse(2)
+  !$OMP parallel do collapse(2) private(iz,iy,ix)
   do iz=lg_sta(3),lg_end(3)
   do iy=lg_sta(2),lg_end(2)
   do ix=lg_sta(1),lg_end(1)
@@ -922,7 +922,7 @@ if(IC_rt==0)then
   if(quadrupole=='y')then
     do i1=1,3
       rbox1q=0.d0
- !$OMP parallel do reduction( + : rbox1q ) private(absr2)
+ !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix) collapse(3)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)
@@ -937,7 +937,7 @@ if(IC_rt==0)then
     rbox1q12=0.d0
     rbox1q23=0.d0
     rbox1q31=0.d0
- !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 )
+ !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -993,7 +993,7 @@ if(IC_rt==0)then
         vecR_tmp(1,:,:,:)=vecR_tmp(1,:,:,:)-dip2center(jj)
         do i1=1,3
           rbox1q=0.d0
- !$OMP parallel do reduction( + : rbox1q ) private(absr2)
+ !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix) collapse(3)
           do iz=ng_sta(3),ng_end(3)
           do iy=ng_sta(2),ng_end(2)
           do ix=ng_sta(1),ng_end(1)
@@ -1010,7 +1010,7 @@ if(IC_rt==0)then
         rbox1q12=0.d0
         rbox1q23=0.d0
         rbox1q31=0.d0
- !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 )
+ !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix) collapse(3)
         do iz=ng_sta(3),ng_end(3)
         do iy=ng_sta(2),ng_end(2)
         do ix=ng_sta(1),ng_end(1)
@@ -1079,7 +1079,7 @@ if(iflag_dip2==1)then
 end if
 
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -1106,7 +1106,7 @@ allocate (shtpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd,mg_sta(3)
                  1:iobnum,1))
 
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3)-Nd,mg_end(3)+Nd
   do iy=mg_sta(2)-Nd,mg_end(2)+Nd
   do ix=mg_sta(1)-Nd,mg_end(1)+Nd+1
@@ -1119,7 +1119,7 @@ end do
 if(iflag_comm_rho==2)then
   allocate(rhobox1_all(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3))) 
   allocate(rhobox2_all(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3))) 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=lg_sta(3),lg_end(3)
   do iy=lg_sta(2),lg_end(2)
   do ix=lg_sta(1),lg_end(1)
@@ -1132,7 +1132,7 @@ end if
 
 if(iflag_fourier_omega==1)then
   do mm=1,num_fourier_omega
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)

--- a/GCEED/rt/real_time_dft.f90
+++ b/GCEED/rt/real_time_dft.f90
@@ -237,7 +237,7 @@ elp3(404)=get_wtime()
 allocate(Ex_fast(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
 allocate(Ec_fast(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -252,7 +252,7 @@ allocate( Ex_static(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
 allocate( Ey_static(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))) 
 allocate( Ez_static(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))) 
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -699,7 +699,7 @@ if(ilsda==1)then
   allocate(rhobox_s(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),2))
 end if
 if(ilsda==0)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -710,7 +710,7 @@ if(ilsda==0)then
   
   do iob=1,iobnum
     call calc_allob(iob,iob_allob)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -721,7 +721,7 @@ if(ilsda==0)then
   end do
   call comm_summation(rhobox,rho,mg_num(1)*mg_num(2)*mg_num(3),nproc_group_grid)
 else if(ilsda==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -734,7 +734,7 @@ else if(ilsda==1)then
   do iob=1,iobnum
     call calc_allob(iob,iob_allob)
     if(iob_allob<=MST(1))then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -743,7 +743,7 @@ else if(ilsda==1)then
       end do
       end do
     else
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -754,7 +754,7 @@ else if(ilsda==1)then
     end if
   end do
   call comm_summation(rhobox_s,rho_s,mg_num(1)*mg_num(2)*mg_num(3)*2,nproc_group_grid)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -764,7 +764,7 @@ else if(ilsda==1)then
   end do
 end if
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -922,7 +922,7 @@ if(IC_rt==0)then
   if(quadrupole=='y')then
     do i1=1,3
       rbox1q=0.d0
- !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix) collapse(3)
+ !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)
@@ -937,7 +937,7 @@ if(IC_rt==0)then
     rbox1q12=0.d0
     rbox1q23=0.d0
     rbox1q31=0.d0
- !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix) collapse(3)
+ !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -993,7 +993,7 @@ if(IC_rt==0)then
         vecR_tmp(1,:,:,:)=vecR_tmp(1,:,:,:)-dip2center(jj)
         do i1=1,3
           rbox1q=0.d0
- !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix) collapse(3)
+ !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix)
           do iz=ng_sta(3),ng_end(3)
           do iy=ng_sta(2),ng_end(2)
           do ix=ng_sta(1),ng_end(1)
@@ -1010,7 +1010,7 @@ if(IC_rt==0)then
         rbox1q12=0.d0
         rbox1q23=0.d0
         rbox1q31=0.d0
- !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix) collapse(3)
+ !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix)
         do iz=ng_sta(3),ng_end(3)
         do iy=ng_sta(2),ng_end(2)
         do ix=ng_sta(1),ng_end(1)
@@ -1079,7 +1079,7 @@ if(iflag_dip2==1)then
 end if
 
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -1106,7 +1106,7 @@ allocate (shtpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd,mg_sta(3)
                  1:iobnum,1))
 
 do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3)-Nd,mg_end(3)+Nd
   do iy=mg_sta(2)-Nd,mg_end(2)+Nd
   do ix=mg_sta(1)-Nd,mg_end(1)+Nd+1
@@ -1119,7 +1119,7 @@ end do
 if(iflag_comm_rho==2)then
   allocate(rhobox1_all(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3))) 
   allocate(rhobox2_all(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3))) 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=lg_sta(3),lg_end(3)
   do iy=lg_sta(2),lg_end(2)
   do ix=lg_sta(1),lg_end(1)
@@ -1132,7 +1132,7 @@ end if
 
 if(iflag_fourier_omega==1)then
   do mm=1,num_fourier_omega
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)

--- a/GCEED/rt/taylor.f90
+++ b/GCEED/rt/taylor.f90
@@ -35,7 +35,7 @@ iwk_size=2
 call make_iwksta_iwkend
 
 if(ilsda==0)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -44,7 +44,7 @@ if(ilsda==0)then
   end do
   end do
 else if(ilsda==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -57,7 +57,7 @@ end if
 
 if(ihpsieff==1)then
   if(ilsda==0)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -66,7 +66,7 @@ if(ihpsieff==1)then
     end do
     end do
   else if(ilsda==1)then 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/rt/taylor.f90
+++ b/GCEED/rt/taylor.f90
@@ -35,7 +35,7 @@ iwk_size=2
 call make_iwksta_iwkend
 
 if(ilsda==0)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -44,7 +44,7 @@ if(ilsda==0)then
   end do
   end do
 else if(ilsda==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -57,7 +57,7 @@ end if
 
 if(ihpsieff==1)then
   if(ilsda==0)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -66,7 +66,7 @@ if(ihpsieff==1)then
     end do
     end do
   else if(ilsda==1)then 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/rt/time_evolution_step.f90
+++ b/GCEED/rt/time_evolution_step.f90
@@ -92,7 +92,7 @@ else if(ilsda==1)then
 
   elp3(761)=get_wtime()
   call comm_summation(rhobox_s,rho_s,mg_num(1)*mg_num(2)*mg_num(3)*2,nproc_group_grid)
-!$OMP parallel do private(iz,iy,ix) collapse(3) 
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -107,7 +107,7 @@ end if
   elp3(515)=get_wtime()
    if(itt/=1)then
      if(mod(itt,2)==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
        do iz=ng_sta(3),ng_end(3)
        do iy=ng_sta(2),ng_end(2)
        do ix=ng_sta(1),ng_end(1)
@@ -116,7 +116,7 @@ end if
        end do
        end do
      else
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
        do iz=ng_sta(3),ng_end(3)
        do iy=ng_sta(2),ng_end(2)
        do ix=ng_sta(1),ng_end(1)
@@ -181,7 +181,7 @@ end if
     do jj=1,num_dip2
       do i1=1,3
         rbox1=0.d0
-!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix)
         do iz=ng_sta(3),ng_end(3)
         do iy=ng_sta(2),ng_end(2)
         do ix=ng_sta(1),ng_end(1)
@@ -208,7 +208,7 @@ end if
         vecR_tmp(1,:,:,:)=vecR_tmp(1,:,:,:)-dip2center(jj)/Hgs(1)
         do i1=1,3
           rbox1q=0.d0
- !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix) collapse(3)
+ !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix)
           do iz=ng_sta(3),ng_end(3)
           do iy=ng_sta(2),ng_end(2)
           do ix=ng_sta(1),ng_end(1)
@@ -225,7 +225,7 @@ end if
         rbox1q12=0.d0
         rbox1q23=0.d0
         rbox1q31=0.d0
- !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix) collapse(3)
+ !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix)
         do iz=ng_sta(3),ng_end(3)
         do iy=ng_sta(2),ng_end(2)
         do ix=ng_sta(1),ng_end(1)
@@ -254,7 +254,7 @@ end if
     if(iflag_intelectron==1)then
     do jj=1,num_dip2
         rbox1e=0.d0
-!$OMP parallel do reduction( + : rbox1e ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction( + : rbox1e ) private(iz,iy,ix)
         do iz=ng_sta(3),ng_end(3)
         do iy=ng_sta(2),ng_end(2)
         do ix=ng_sta(1),ng_end(1)
@@ -303,7 +303,7 @@ end if
     allocate(cmatbox1(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3)))
     allocate(cmatbox2(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3)))
     
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)
@@ -315,7 +315,7 @@ end if
 
     do iob=1,iobnum
       if(mod(itt,2)==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -324,7 +324,7 @@ end if
         end do
         end do
       else
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -377,7 +377,7 @@ end if
 
   if(iflag_fourier_omega==1)then
     do mm=1,num_fourier_omega
-!$OMP parallel do  private(iz,iy,ix) collapse(3)
+!$OMP parallel do  private(iz,iy,ix)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/time_evolution_step.f90
+++ b/GCEED/rt/time_evolution_step.f90
@@ -92,7 +92,7 @@ else if(ilsda==1)then
 
   elp3(761)=get_wtime()
   call comm_summation(rhobox_s,rho_s,mg_num(1)*mg_num(2)*mg_num(3)*2,nproc_group_grid)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3) 
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -107,7 +107,7 @@ end if
   elp3(515)=get_wtime()
    if(itt/=1)then
      if(mod(itt,2)==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
        do iz=ng_sta(3),ng_end(3)
        do iy=ng_sta(2),ng_end(2)
        do ix=ng_sta(1),ng_end(1)
@@ -116,7 +116,7 @@ end if
        end do
        end do
      else
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
        do iz=ng_sta(3),ng_end(3)
        do iy=ng_sta(2),ng_end(2)
        do ix=ng_sta(1),ng_end(1)
@@ -181,7 +181,7 @@ end if
     do jj=1,num_dip2
       do i1=1,3
         rbox1=0.d0
-!$OMP parallel do reduction( + : rbox1 )
+!$OMP parallel do reduction( + : rbox1 ) private(iz,iy,ix) collapse(3)
         do iz=ng_sta(3),ng_end(3)
         do iy=ng_sta(2),ng_end(2)
         do ix=ng_sta(1),ng_end(1)
@@ -208,7 +208,7 @@ end if
         vecR_tmp(1,:,:,:)=vecR_tmp(1,:,:,:)-dip2center(jj)/Hgs(1)
         do i1=1,3
           rbox1q=0.d0
- !$OMP parallel do reduction( + : rbox1q ) private(absr2)
+ !$OMP parallel do reduction( + : rbox1q ) private(absr2,iz,iy,ix) collapse(3)
           do iz=ng_sta(3),ng_end(3)
           do iy=ng_sta(2),ng_end(2)
           do ix=ng_sta(1),ng_end(1)
@@ -225,7 +225,7 @@ end if
         rbox1q12=0.d0
         rbox1q23=0.d0
         rbox1q31=0.d0
- !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 )
+ !$OMP parallel do reduction( + : rbox1q12,rbox1q23,rbox1q31 ) private(iz,iy,ix) collapse(3)
         do iz=ng_sta(3),ng_end(3)
         do iy=ng_sta(2),ng_end(2)
         do ix=ng_sta(1),ng_end(1)
@@ -254,7 +254,7 @@ end if
     if(iflag_intelectron==1)then
     do jj=1,num_dip2
         rbox1e=0.d0
-!$OMP parallel do reduction( + : rbox1e )
+!$OMP parallel do reduction( + : rbox1e ) private(iz,iy,ix) collapse(3)
         do iz=ng_sta(3),ng_end(3)
         do iy=ng_sta(2),ng_end(2)
         do ix=ng_sta(1),ng_end(1)
@@ -303,7 +303,7 @@ end if
     allocate(cmatbox1(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3)))
     allocate(cmatbox2(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3)))
     
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=lg_sta(3),lg_end(3)
     do iy=lg_sta(2),lg_end(2)
     do ix=lg_sta(1),lg_end(1)
@@ -315,7 +315,7 @@ end if
 
     do iob=1,iobnum
       if(mod(itt,2)==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -324,7 +324,7 @@ end if
         end do
         end do
       else
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -377,7 +377,7 @@ end if
 
   if(iflag_fourier_omega==1)then
     do mm=1,num_fourier_omega
-!$OMP parallel do 
+!$OMP parallel do  private(iz,iy,ix) collapse(3)
       do iz=ng_sta(3),ng_end(3)
       do iy=ng_sta(2),ng_end(2)
       do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/total_energy_groupob.f90
+++ b/GCEED/rt/total_energy_groupob.f90
@@ -47,7 +47,7 @@ if(ifunc==1)then
   esp2=0.d0
   
   if(ilsda==1)then 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -64,7 +64,7 @@ if(ifunc==1)then
   
   do iob=1,iobnum
     cbox=0.d0
-!$OMP parallel do reduction ( + : cbox ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction ( + : cbox ) private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -121,7 +121,7 @@ Etot=Etot+rbox
 if(ilsda == 0)then
   if((ifunc==1.and.mod(itt,2)==1).or.(ifunc==2.and.mod(itt,2)==0))then
     sum1=0.d0
-!$OMP parallel do reduction (+ : sum1 ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction (+ : sum1 ) private(iz,iy,ix)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -131,7 +131,7 @@ if(ilsda == 0)then
     end do
   else
     sum1=0.d0
-!$OMP parallel do reduction (+ : sum1 ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction (+ : sum1 ) private(iz,iy,ix)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/total_energy_groupob.f90
+++ b/GCEED/rt/total_energy_groupob.f90
@@ -47,7 +47,7 @@ if(ifunc==1)then
   esp2=0.d0
   
   if(ilsda==1)then 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -64,7 +64,7 @@ if(ifunc==1)then
   
   do iob=1,iobnum
     cbox=0.d0
-!$OMP parallel do reduction ( + : cbox )
+!$OMP parallel do reduction ( + : cbox ) private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -121,7 +121,7 @@ Etot=Etot+rbox
 if(ilsda == 0)then
   if((ifunc==1.and.mod(itt,2)==1).or.(ifunc==2.and.mod(itt,2)==0))then
     sum1=0.d0
-!$OMP parallel do reduction (+ : sum1 )
+!$OMP parallel do reduction (+ : sum1 ) private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -131,7 +131,7 @@ if(ilsda == 0)then
     end do
   else
     sum1=0.d0
-!$OMP parallel do reduction (+ : sum1 )
+!$OMP parallel do reduction (+ : sum1 ) private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3)
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/xc_fast.f90
+++ b/GCEED/rt/xc_fast.f90
@@ -31,7 +31,7 @@ real(8) :: Ex(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),  &
 real(8) :: Ec(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),  &
              mg_sta(3):mg_end(3))
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -86,7 +86,7 @@ real(8) :: Ec(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),  &
              mg_sta(3):mg_end(3))
 
 !$OMP parallel do &
-!$OMP private(Cx,rs,zeta,sf,dsf)
+!$OMP private(Cx,rs,zeta,sf,dsf,iz,iy,ix)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -123,7 +123,7 @@ end do
 end do
 
 sum1=0.d0
-!$omp parallel do reduction(+ : sum1)
+!$omp parallel do reduction(+ : sum1) private(iz,iy,ix) collapse(3)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)

--- a/GCEED/rt/xc_fast.f90
+++ b/GCEED/rt/xc_fast.f90
@@ -31,7 +31,7 @@ real(8) :: Ex(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),  &
 real(8) :: Ec(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),  &
              mg_sta(3):mg_end(3))
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -123,7 +123,7 @@ end do
 end do
 
 sum1=0.d0
-!$omp parallel do reduction(+ : sum1) private(iz,iy,ix) collapse(3)
+!$omp parallel do reduction(+ : sum1) private(iz,iy,ix)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)

--- a/GCEED/scf/calc_rho_in.f90
+++ b/GCEED/scf/calc_rho_in.f90
@@ -19,7 +19,7 @@ use scf_data
 implicit none
 integer :: ix,iy,iz,is
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -30,7 +30,7 @@ end do
 
 if(ilsda==1)then
   do is=1,2
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/calc_rho_in.f90
+++ b/GCEED/scf/calc_rho_in.f90
@@ -19,7 +19,7 @@ use scf_data
 implicit none
 integer :: ix,iy,iz,is
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3),mg_end(3)
 do iy=mg_sta(2),mg_end(2)
 do ix=mg_sta(1),mg_end(1)
@@ -30,7 +30,7 @@ end do
 
 if(ilsda==1)then
   do is=1,2
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/gram_schmidt.f90
+++ b/GCEED/scf/gram_schmidt.f90
@@ -49,7 +49,7 @@ do iob=pstart(is),pend(is)
   call calc_myob(iob,iob_myob)
   call check_corrkob(iob,icorr_p)
   if(icorr_p==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -66,7 +66,7 @@ do iob=pstart(is),pend(is)
     call calc_allob(job,job_allob)
     if(job_allob >= pstart(is) .and. job_allob <= iob-1)then
       rbox=0.d0
-!$OMP parallel do reduction ( + : rbox )
+!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -84,7 +84,7 @@ do iob=pstart(is),pend(is)
   do job=1,iobnum
     call calc_allob(job,job_allob)
     if(job_allob >= pstart(is) .and. job_allob <= iob-1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -100,7 +100,7 @@ do iob=pstart(is),pend(is)
   rbox=0.d0
   call check_corrkob(iob,icorr_p)
   if(icorr_p==1)then
-!$OMP parallel do reduction ( + : rbox )
+!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -114,7 +114,7 @@ do iob=pstart(is),pend(is)
   call comm_summation(rbox,rbox2,nproc_group_global)
 
   if(icorr_p==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/gram_schmidt.f90
+++ b/GCEED/scf/gram_schmidt.f90
@@ -49,7 +49,7 @@ do iob=pstart(is),pend(is)
   call calc_myob(iob,iob_myob)
   call check_corrkob(iob,icorr_p)
   if(icorr_p==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -66,7 +66,7 @@ do iob=pstart(is),pend(is)
     call calc_allob(job,job_allob)
     if(job_allob >= pstart(is) .and. job_allob <= iob-1)then
       rbox=0.d0
-!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -84,7 +84,7 @@ do iob=pstart(is),pend(is)
   do job=1,iobnum
     call calc_allob(job,job_allob)
     if(job_allob >= pstart(is) .and. job_allob <= iob-1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -100,7 +100,7 @@ do iob=pstart(is),pend(is)
   rbox=0.d0
   call check_corrkob(iob,icorr_p)
   if(icorr_p==1)then
-!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction ( + : rbox ) private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -114,7 +114,7 @@ do iob=pstart(is),pend(is)
   call comm_summation(rbox,rbox2,nproc_group_global)
 
   if(icorr_p==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/real_space_dft.f90
+++ b/GCEED/scf/real_space_dft.f90
@@ -256,7 +256,7 @@ else
 end if
 
 if(ilsda==0)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -414,7 +414,7 @@ DFT_Iteration : do iter=1,iDiter(img)
 
   if(iflag_convergence==2)then
     sum0=0.d0
-!$OMP parallel do reduction(+:sum0)
+!$OMP parallel do reduction(+:sum0) private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3) 
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -426,7 +426,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     sum1=sum1*Hvol/dble(lg_num(1)*lg_num(2)*lg_num(3))
   else if(iflag_convergence==3)then
     sum0=0.d0
-!$OMP parallel do reduction(+:sum0)
+!$OMP parallel do reduction(+:sum0) private(iz,iy,ix) collapse(3)
     do iz=ng_sta(3),ng_end(3) 
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -457,7 +457,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     end if
   end if 
   rNebox1=0.d0 
-!$OMP parallel do reduction(+:rNebox1)
+!$OMP parallel do reduction(+:rNebox1) private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -475,7 +475,7 @@ DFT_Iteration : do iter=1,iDiter(img)
   elp3(130)=elp3(130)+elp3(119)-elp3(111)
 
 if(ilsda==0)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -485,7 +485,7 @@ if(ilsda==0)then
   end do
   end do
 else if(ilsda==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)

--- a/GCEED/scf/real_space_dft.f90
+++ b/GCEED/scf/real_space_dft.f90
@@ -256,7 +256,7 @@ else
 end if
 
 if(ilsda==0)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -414,7 +414,7 @@ DFT_Iteration : do iter=1,iDiter(img)
 
   if(iflag_convergence==2)then
     sum0=0.d0
-!$OMP parallel do reduction(+:sum0) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:sum0) private(iz,iy,ix)
     do iz=ng_sta(3),ng_end(3) 
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -426,7 +426,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     sum1=sum1*Hvol/dble(lg_num(1)*lg_num(2)*lg_num(3))
   else if(iflag_convergence==3)then
     sum0=0.d0
-!$OMP parallel do reduction(+:sum0) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:sum0) private(iz,iy,ix)
     do iz=ng_sta(3),ng_end(3) 
     do iy=ng_sta(2),ng_end(2)
     do ix=ng_sta(1),ng_end(1)
@@ -457,7 +457,7 @@ DFT_Iteration : do iter=1,iDiter(img)
     end if
   end if 
   rNebox1=0.d0 
-!$OMP parallel do reduction(+:rNebox1) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:rNebox1) private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -475,7 +475,7 @@ DFT_Iteration : do iter=1,iDiter(img)
   elp3(130)=elp3(130)+elp3(119)-elp3(111)
 
 if(ilsda==0)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -485,7 +485,7 @@ if(ilsda==0)then
   end do
   end do
 else if(ilsda==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)

--- a/GCEED/scf/rmmdiis.f90
+++ b/GCEED/scf/rmmdiis.f90
@@ -60,7 +60,7 @@ iwk_size=2
 call make_iwksta_iwkend
 
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -95,7 +95,7 @@ do iob=1,iobnum
     do iz=mg_sta(3),mg_end(3)
       phi(:,:,iz,0)=psi_in(:,:,iz,iob,1)
     end do
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -144,7 +144,7 @@ do iob=1,iobnum
       phi(:,:,iz,iter)=phi(:,:,iz,iter)/sqrt(rbox1*Hvol)
     end do
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -198,7 +198,7 @@ do iob=1,iobnum
       end do
     end if
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -218,7 +218,7 @@ end do        ! loop for iob
 
 iflag_diisjump=0
 do iob=1,iobnum
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -243,7 +243,7 @@ else if(iflag_diisjump==1)then
     do iz=mg_sta(3),mg_end(3)
       phi(:,:,iz,0)=psi_in(:,:,iz,iob,1)
     end do
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/rmmdiis.f90
+++ b/GCEED/scf/rmmdiis.f90
@@ -60,7 +60,7 @@ iwk_size=2
 call make_iwksta_iwkend
 
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -95,7 +95,7 @@ do iob=1,iobnum
     do iz=mg_sta(3),mg_end(3)
       phi(:,:,iz,0)=psi_in(:,:,iz,iob,1)
     end do
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -144,7 +144,7 @@ do iob=1,iobnum
       phi(:,:,iz,iter)=phi(:,:,iz,iter)/sqrt(rbox1*Hvol)
     end do
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -198,7 +198,7 @@ do iob=1,iobnum
       end do
     end if
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -218,7 +218,7 @@ end do        ! loop for iob
 
 iflag_diisjump=0
 do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -243,7 +243,7 @@ else if(iflag_diisjump==1)then
     do iz=mg_sta(3),mg_end(3)
       phi(:,:,iz,0)=psi_in(:,:,iz,iob,1)
     end do
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/rmmdiis_eigen.f90
+++ b/GCEED/scf/rmmdiis_eigen.f90
@@ -87,7 +87,7 @@ end do
 if(icount == iter)then
 ! if phibar is estimated to be equal mixture of previous phis,
 ! update phibar by newest phi
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -98,7 +98,7 @@ if(icount == iter)then
     
   call inner_product(phibar(:,:,:,iter-1),phibar(:,:,:,iter-1),rbox)
   rnorm=sqrt(rbox*Hvol)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -115,7 +115,7 @@ else
   if(ier2 .ne. 0) then
 ! if Smat is not positive-definite,
 ! update phibar by newest phi
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -126,7 +126,7 @@ else
     call inner_product(phibar(:,:,:,iter-1),phibar(:,:,:,iter-1),rbox)
  
     rnorm=sqrt(rbox*Hvol)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -149,7 +149,7 @@ else
       end if
     end do
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -158,7 +158,7 @@ else
     end do
     end do
     do ii=1,iter
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -171,7 +171,7 @@ else
 
     call inner_product(phibar(:,:,:,iter-1),phibar(:,:,:,iter-1),rbox)
     rnorm=sqrt(rbox*Hvol)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -180,7 +180,7 @@ else
     end do
     end do
      
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -189,7 +189,7 @@ else
     end do
     end do
     do ii=1,iter
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/rmmdiis_eigen.f90
+++ b/GCEED/scf/rmmdiis_eigen.f90
@@ -87,7 +87,7 @@ end do
 if(icount == iter)then
 ! if phibar is estimated to be equal mixture of previous phis,
 ! update phibar by newest phi
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -98,7 +98,7 @@ if(icount == iter)then
     
   call inner_product(phibar(:,:,:,iter-1),phibar(:,:,:,iter-1),rbox)
   rnorm=sqrt(rbox*Hvol)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -115,7 +115,7 @@ else
   if(ier2 .ne. 0) then
 ! if Smat is not positive-definite,
 ! update phibar by newest phi
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -126,7 +126,7 @@ else
     call inner_product(phibar(:,:,:,iter-1),phibar(:,:,:,iter-1),rbox)
  
     rnorm=sqrt(rbox*Hvol)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -149,7 +149,7 @@ else
       end if
     end do
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -158,7 +158,7 @@ else
     end do
     end do
     do ii=1,iter
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -171,7 +171,7 @@ else
 
     call inner_product(phibar(:,:,:,iter-1),phibar(:,:,:,iter-1),rbox)
     rnorm=sqrt(rbox*Hvol)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -180,7 +180,7 @@ else
     end do
     end do
      
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -189,7 +189,7 @@ else
     end do
     end do
     do ii=1,iter
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/subspace_diag.f90
+++ b/GCEED/scf/subspace_diag.f90
@@ -59,7 +59,7 @@ else if(ilsda == 1)then
   iobend(2)=itotMST
 end if
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -77,7 +77,7 @@ do is=is_sta,is_end
   allocate(Smat(iter,iter))
 
   do jj=1,iter
-!$OMP parallel do
+!$OMP parallel do 
     do ii=1,iter
       Amat2(ii,jj)=0.d0
     end do
@@ -87,7 +87,7 @@ do is=is_sta,is_end
     call calc_myob(job,job_myob)
     call check_corrkob(job,icorr_j)
     if(icorr_j==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -104,7 +104,7 @@ do is=is_sta,is_end
       call calc_allob(iob,iob_allob)
       if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
         rbox=0.d0
-!$OMP parallel do reduction(+:rbox)
+!$OMP parallel do reduction(+:rbox) private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -124,7 +124,7 @@ do is=is_sta,is_end
   do job=1,iobnum
     call calc_allob(job,job_allob)
     if(job_allob>=iobsta(is).and.job_allob<=iobend(is))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -140,7 +140,7 @@ do is=is_sta,is_end
     call calc_myob(job,job_myob)
     call check_corrkob(job,icorr_j)
     if(icorr_j==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -154,7 +154,7 @@ do is=is_sta,is_end
     do iob=1,iobnum
       call calc_allob(iob,iob_allob)
       if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -170,7 +170,7 @@ do is=is_sta,is_end
     call calc_allob(iob,iob_allob)
     if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
       rbox=0.d0
-!$OMP parallel do reduction(+:rbox)
+!$OMP parallel do reduction(+:rbox) private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -179,7 +179,7 @@ do is=is_sta,is_end
       end do
       end do
       call comm_summation(rbox,rbox1,nproc_group_orbital)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/subspace_diag.f90
+++ b/GCEED/scf/subspace_diag.f90
@@ -59,7 +59,7 @@ else if(ilsda == 1)then
   iobend(2)=itotMST
 end if
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -87,7 +87,7 @@ do is=is_sta,is_end
     call calc_myob(job,job_myob)
     call check_corrkob(job,icorr_j)
     if(icorr_j==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -104,7 +104,7 @@ do is=is_sta,is_end
       call calc_allob(iob,iob_allob)
       if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
         rbox=0.d0
-!$OMP parallel do reduction(+:rbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:rbox) private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -124,7 +124,7 @@ do is=is_sta,is_end
   do job=1,iobnum
     call calc_allob(job,job_allob)
     if(job_allob>=iobsta(is).and.job_allob<=iobend(is))then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -140,7 +140,7 @@ do is=is_sta,is_end
     call calc_myob(job,job_myob)
     call check_corrkob(job,icorr_j)
     if(icorr_j==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -154,7 +154,7 @@ do is=is_sta,is_end
     do iob=1,iobnum
       call calc_allob(iob,iob_allob)
       if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -170,7 +170,7 @@ do is=is_sta,is_end
     call calc_allob(iob,iob_allob)
     if(iob_allob>=iobsta(is).and.iob_allob<=iobend(is))then
       rbox=0.d0
-!$OMP parallel do reduction(+:rbox) private(iz,iy,ix) collapse(3)
+!$OMP parallel do reduction(+:rbox) private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -179,7 +179,7 @@ do is=is_sta,is_end
       end do
       end do
       call comm_summation(rbox,rbox1,nproc_group_orbital)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/ybcg.f90
+++ b/GCEED/scf/ybcg.f90
@@ -54,7 +54,7 @@ call make_iwksta_iwkend
 
 call set_isstaend(is_sta,is_end)
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -86,7 +86,7 @@ orbital : do iob=iobsta(is),iobend(is)
 
   if(icorr==1)then
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -95,7 +95,7 @@ orbital : do iob=iobsta(is),iobend(is)
     end do
     end do
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -115,7 +115,7 @@ orbital : do iob=iobsta(is),iobend(is)
   Iteration : do iter=1,Ncg
 
     if(icorr==1)then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -134,7 +134,7 @@ orbital : do iob=iobsta(is),iobend(is)
       if(jcorr==1)then
         call inner_product(psi_in(:,:,:,job_myob,1),gk(:,:,:),sum0)
         sum0=sum0*Hvol
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -154,7 +154,7 @@ orbital : do iob=iobsta(is),iobend(is)
       sum0=sum0*Hvol
 
       if ( iter==1 ) then
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -164,7 +164,7 @@ orbital : do iob=iobsta(is),iobend(is)
         end do
       else
         uk=sum0/gkgk 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -186,7 +186,7 @@ orbital : do iob=iobsta(is),iobend(is)
       call inner_product(pk,hxk,pkHxk)
       pkHxk = pkHxk*Hvol
 
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -221,7 +221,7 @@ orbital : do iob=iobsta(is),iobend(is)
 
   if(icorr==1)then
     call inner_product(xk,xk,sum0)
-!$OMP parallel do
+!$OMP parallel do private(iz,iy,ix) collapse(3)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)

--- a/GCEED/scf/ybcg.f90
+++ b/GCEED/scf/ybcg.f90
@@ -54,7 +54,7 @@ call make_iwksta_iwkend
 
 call set_isstaend(is_sta,is_end)
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
 do iz=mg_sta(3)-Nd,mg_end(3)+Nd
 do iy=mg_sta(2)-Nd,mg_end(2)+Nd
 do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -86,7 +86,7 @@ orbital : do iob=iobsta(is),iobend(is)
 
   if(icorr==1)then
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -95,7 +95,7 @@ orbital : do iob=iobsta(is),iobend(is)
     end do
     end do
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)
@@ -115,7 +115,7 @@ orbital : do iob=iobsta(is),iobend(is)
   Iteration : do iter=1,Ncg
 
     if(icorr==1)then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix) 
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -134,7 +134,7 @@ orbital : do iob=iobsta(is),iobend(is)
       if(jcorr==1)then
         call inner_product(psi_in(:,:,:,job_myob,1),gk(:,:,:),sum0)
         sum0=sum0*Hvol
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -154,7 +154,7 @@ orbital : do iob=iobsta(is),iobend(is)
       sum0=sum0*Hvol
 
       if ( iter==1 ) then
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -164,7 +164,7 @@ orbital : do iob=iobsta(is),iobend(is)
         end do
       else
         uk=sum0/gkgk 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
         do iz=mg_sta(3),mg_end(3)
         do iy=mg_sta(2),mg_end(2)
         do ix=mg_sta(1),mg_end(1)
@@ -186,7 +186,7 @@ orbital : do iob=iobsta(is),iobend(is)
       call inner_product(pk,hxk,pkHxk)
       pkHxk = pkHxk*Hvol
 
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
       do iz=mg_sta(3),mg_end(3)
       do iy=mg_sta(2),mg_end(2)
       do ix=mg_sta(1),mg_end(1)
@@ -221,7 +221,7 @@ orbital : do iob=iobsta(is),iobend(is)
 
   if(icorr==1)then
     call inner_product(xk,xk,sum0)
-!$OMP parallel do private(iz,iy,ix) collapse(3)
+!$OMP parallel do private(iz,iy,ix)
     do iz=mg_sta(3),mg_end(3)
     do iy=mg_sta(2),mg_end(2)
     do ix=mg_sta(1),mg_end(1)


### PR DESCRIPTION
If I understand correctly, loop counters of inner loops are not guaranteed to be `private` with the OMP parallelization. Thus, I added explicit `private` statement accordingly.

Probably, my statement is not correct. It seems that the inner loop counters are implicitly declared as `private` by Fortran default. But, nevertheless, I would say that the explicit declaration would be desirable.