### PR TITLE
add descriptions "0d/3d" in the developer's manual

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -22,35 +22,35 @@
 
 ## &calculation
 <dl>
-<dt>calc_mode; <code>Character</code>;</dt> 0d/3d
+<dt>calc_mode; <code>Character</code>; 0d/3d</dt>
 <dd>Choice of Calculation modes. <code>'GS'</code>,
 <code>'RTLR'</code>,<code>'RTPulse'</code>, <code>'GS_RTLR'</code>, 
 and <code>'GS_RTPulse'</code>
 can be chosen.
 </dd>
 
-<dt>use_ehrenfest_md; <code>Character</code>;</dt> 0d/3d
+<dt>use_ehrenfest_md; <code>Character</code>; 0d/3d</dt>
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 Ehrenfest dynamics.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>use_ms_maxwell; <code>Character</code>;</dt> 3d
+<dt>use_ms_maxwell; <code>Character</code>; 3d</dt>
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 Multi-scale Maxwell-Kohn-Sham coupling. 
 Default is <code>'n'</code> 
 </dd>
 
-<dt>use_force; <code>Character</code>;</dt> 0d
+<dt>use_force; <code>Character</code>; 0d</dt>
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 force calculation.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>use_geometry_opt; <code>Character</code>;</dt> 0d
+<dt>use_geometry_opt; <code>Character</code>; 0d</dt>
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 geometry optimization.
@@ -62,26 +62,26 @@ Default is <code>'n'</code>.
 ## &control
 <dl>
 
-<dt>restart_option; <code>Character</code>;</dt> 3d
+<dt>restart_option; <code>Character</code>; 3d</dt>
 <dd>Flag for restart. <code>'new'</code> or 
 <code>'restart'</code> can be chosen.
 <code>'new'</code> is default.
 </dd>
 
-<dt>backup_frequency; <code>Integer</code>;</dt> 3d
+<dt>backup_frequency; <code>Integer</code>; 3d</dt>
 <dd>Frequency of backup during the time-propagation. 
 If <code>0</code> is set, the backup is not performed.
 Default is <code>0</code>.
 </dd>
 
 
-<dt>time_shutdown; <code>Real(8)</code>;</dt> 3d
+<dt>time_shutdown; <code>Real(8)</code>; 3d</dt>
 <dd>Timer for automatic shutdown. The unit is always second.
 If negative time is chosen, the automatic shutdown is not performed.
 Default is <code>-1</code> sec.
 </dd>
 
-<dt>sysname; <code>Character</code>;</dt> 0d/3d
+<dt>sysname; <code>Character</code>; 0d/3d</dt>
 <dd>Name of calculation. This is used for a prefix of output files.
 Default is <code>default</code>.
 </dd>
@@ -93,21 +93,21 @@ Default is <code>default</code>.
 ## &units
 <dl>
 
-<dt>unit_time; <code>Character</code>;</dt> 0d/3d
+<dt>unit_time; <code>Character</code>; 0d/3d</dt>
 <dd>Unit of time for input variables. 
 Atomic unit <code>'a.u.'</code> and 
 femtosecond <code>'fs'</code> can be chosen.
 Default is <code>'a.u.'</code>.
 </dd>
 
-<dt>unit_length; <code>Character</code>;</dt> 0d/3d
+<dt>unit_length; <code>Character</code>; 0d/3d</dt>
 <dd>Unit of length for input variables. 
 Atomic unit <code>'a.u.'</code> and 
 Aungstrom <code>angstrom</code> can be chosen.
 Default is <code>'a.u.'</code>.
 </dd>
 
-<dt>unit_energy; <code>Character</code>;</dt> 0d/3d
+<dt>unit_energy; <code>Character</code>; 0d/3d</dt>
 <dd>Unit of energy for input variables. 
 Atomic unit <code>'a.u.'</code> and 
 electron-volt <code>'ev'</code> can be chosen.
@@ -126,18 +126,18 @@ domain parallelization.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>nproc_ob; <code>Integer</code>;</dt> 0d
+<dt>nproc_ob; <code>Integer</code>; 0d</dt>
 <dd>Number of MPI parallelization for orbitals.
 Default is <code>0</code>.
 </dd>
 
-<dt>nproc_domain(3); <code>Integer</code>;</dt> 0d
+<dt>nproc_domain(3); <code>Integer</code>; 0d</dt>
 <dd>Number of MPI parallelization for each direction in 
 real-space.
 Default is <code>(0,0,0)</code>.
 </dd>
 
-<dt>nproc_domain_s(3); <code>Integer</code>;</dt> 0d
+<dt>nproc_domain_s(3); <code>Integer</code>; 0d</dt>
 <dd>Number of MPI parallelization for each direction in 
 real-space.
 Default is <code>(0,0,0)</code>.
@@ -159,67 +159,67 @@ Default is <code>0</code>.
 ## &system 
 <dl>
 
-<dt>iperiodic; <code>Integer</code>;</dt> 0d/3d
+<dt>iperiodic; <code>Integer</code>; 0d/3d</dt>
 <dd>Dimension for periodic boundary condition.
 <code>0</code> is for isolated systems, and 
 <code>3</code> is for solids.
 Default is <code>0</code>.
 </dd>
 
-<dt>ispin; <code>Integer</code>;</dt> 0d
+<dt>ispin; <code>Integer</code>; 0d</dt>
 <dd>Variable for classification of closed shell systems and open shell systems.
 <code>0</code> is for closed shell systems, and
 <code>1</code> is for open shell systems.
 Default is <code>0</code>
 </dd>
 
-<dt>al(3); <code>Real(8)</code>;</dt> 0d/3d
+<dt>al(3); <code>Real(8)</code>; 0d/3d</dt>
 <dd>Lattice constants. Unit of the length can be 
 chosen by <code>&units/unit_length</code>.
 </dd>
 
-<dt>isym; <code>Integer</code>;</dt> 3d
+<dt>isym; <code>Integer</code>; 3d</dt>
 <dd>Number of symmetries that can be used for 
 reduction of k-points.
 Default is <code>0</code>.
 </dd>
 
-<dt>crystal_structure; <code>Character</code>;</dt> 3d
+<dt>crystal_structure; <code>Character</code>; 3d</dt>
 <dd>Name of symmetry that can be used for the resuction of # of k-points.
 Default is <code>'none'</code>.
 </dd>
 
-<dt>nstate; <code>Integer</code>;</dt> 0d/3d
+<dt>nstate; <code>Integer</code>;</dt>0d/3d
 <dd>Number of states/bands.
 </dd>
 
-<dt>nstate_spin(2); <code>Integer</code>;</dt> 0d
+<dt>nstate_spin(2); <code>Integer</code>; 0d</dt>
 <dd>Number of states/bands can be specified independently
 by <code>nstate_spin(1)/nstate_spin(2)</code>.
 This option is incompatible with <code>nstate</code>
 </dd>
 
-<dt>nelec; <code>Integer</code>;</dt> 0d/3d
+<dt>nelec; <code>Integer</code>; 0d/3d</dt>
 <dd>Number of valence electrons.
 </dd>
 
-<dt>nelec_spin(2); <code>Integer</code>;</dt> 0d
+<dt>nelec_spin(2); <code>Integer</code>; 0d</dt>
 <dd>Number of up/down-spin electrons can be specified independently
 by <code>nelec_spin(1)/nelec_spin(2)</code>.
 This option is incompatible with <code>nelec</code>
 </dd>
 
-<dt>temperature; <code>Real(8)</code>;</dt> 3d
+<dt>temperature; <code>Real(8)</code>; 3d</dt>
 <dd>Temperature of electrons.
 Unit of the energy can be chosen <code>&units/unit_energy</code>.
 </dd>
 
 
-<dt>nelem; <code>Integer</code>;</dt> 0d/3d
+<dt>nelem; <code>Integer</code>; 0d/3d</dt>
 <dd>Number of elements that will be used in calculations.
 </dd>
 
-<dt>natom; <code>Integer</code>;</dt> 0d/3d
+<dt>natom; <code>Integer</code>; 0d/3d</dt>
 <dd>Number of atoms in a calculation cell.
 </dd>
 
@@ -232,7 +232,7 @@ This option is incompatible with
 <code>&atomic_red_coor</code>.
 </dd>
 
-<dt>file_atom_coor; <code>Character</code>;</dt> 0d
+<dt>file_atom_coor; <code>Character</code>; 0d</dt>
 <dd>File name of atomic positions. In this file, 
 the atomic coordinates can be written in Cartesian cooridnates.
 The unit of the length can be chosen by 
@@ -280,35 +280,35 @@ This option is incompatible with
 ## &pseudo
 <dl>
 
-<dt>pseudo_file(:); <code>Character</code>;</dt> 0d/3d
+<dt>pseudo_file(:); <code>Character</code>; 0d/3d</dt>
 <dd>Name of pseudopotential files.
 </dd>
 
-<dt>Lmax_ps(:); <code>Integer</code>;</dt> 0d/3d
+<dt>Lmax_ps(:); <code>Integer</code>; 0d/3d</dt>
 <dd>Maximum angular momentum of pseudopotential projectors.
 </dd>
 
-<dt>Lloc_ps(:); <code>Integer</code>;</dt> 0d/3d
+<dt>Lloc_ps(:); <code>Integer</code>; 0d/3d</dt>
 <dd>Angular momentum of pseudopotential thant will be treated as local.
 </dd>
 
-<dt>iZatom(:); <code>Integer</code>;</dt> 0d/3d
+<dt>iZatom(:); <code>Integer</code>; 0d/3d</dt>
 <dd>Atomic number.
 </dd>
 
 
-<dt>psmask_option(:); <code>Character</code>;</dt> 3d
+<dt>psmask_option(:); <code>Character</code>; 3d</dt>
 <dd>Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 Fourier filtering for pseudopotentials. 
 Default is <code>'n'</code>.
 </dd>
 
-<dt>alpha_mask(:); <code>Real(8)</code>;</dt> 3d
+<dt>alpha_mask(:); <code>Real(8)</code>; 3d</dt>
 <dd>Parameter for the Fourier filtering for pseudopotential.
 Default is <code>'0.8'</code>.
 </dd>
 
-<dt>gamma_mask(:); <code>Real(8)</code>;</dt> 3d
+<dt>gamma_mask(:); <code>Real(8)</code>; 3d</dt>
 <dd>Parameter for the Fourier filtering for pseudopotential.
 Default is <code>'1.8'</code>.
 </dd>
@@ -323,7 +323,7 @@ Default is <code>'15.0'</code>.
 ## &functional
 <dl>
 
-<dt>xc; <code>Character</code>;</dt> 3d
+<dt>xc; <code>Character</code>; 3d</dt>
 <dd>
 Exchange-correlation functionals.
 At the moment, the following functionals are avelable.
@@ -347,7 +347,7 @@ John P. Perdew and Yue Wang, Phys. Rev. B 45, 13244 (1992).
 </ul>
 </dd>
 
-<dt>cval(:); <code>Real(8)</code>;</dt> 3d
+<dt>cval(:); <code>Real(8)</code>; 3d</dt>
 <dd>Mixing parameter in Tran-Blaha meta-GGA exchange potential. If <code>cval</code> is set to a minus value, the mixing-parameter computed
 by the formula in the original paper [Phys. Rev. Lett. 102, 226401 (2008)].
 Default is <code>'1.0'</code>.
@@ -357,7 +357,7 @@ Default is <code>'1.0'</code>.
 ## &rgrid
 <dl>
 
-<dt>dl(3); <code>Real(8)</code>;</dt> 0d
+<dt>dl(3); <code>Real(8)</code>; 0d</dt>
 <dd>Spacing of real-space grids. Unit of length can be chosen by
 <code>&units/unit_length</code>.
 This valiable cannot be set with 
@@ -365,7 +365,7 @@ This valiable cannot be set with
 </dd>
 
 
-<dt>num_rgrid(3); <code>Integer</code>;</dt> 3d
+<dt>num_rgrid(3); <code>Integer</code>; 3d</dt>
 <dd>Number of real-space grids.
 This valiable cannot be set with 
 <code>&rgrid/dl</code>.
@@ -376,12 +376,12 @@ This valiable cannot be set with
 ## &kgrid
 <dl>
 
-<dt>num_kgrid(3); <code>Integer</code>;</dt> 3d
+<dt>num_kgrid(3); <code>Integer</code>; 3d</dt>
 <dd>Number of grids discretizing
 the Brillouin zone.
 </dd>
 
-<dt>file_kw; <code>Character</code>;</dt> 3d
+<dt>file_kw; <code>Character</code>; 3d</dt>
 <dd>
 Name of a file for flexible k-point sampling.
 This file will be read if <code>num_kgrid</code> are
@@ -394,12 +394,12 @@ all negative.
 ## &tgrid
 <dl>
 
-<dt>nt; <code>Integer</code>;</dt> 0d/3d
+<dt>nt; <code>Integer</code>; 0d/3d</dt>
 <dd>
 Number of total time steps for real-time propagation.
 </dd>
 
-<dt>dt; <code>Real(8)</code>;</dt> 0d/3d
+<dt>dt; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Time step. Unit of time can be chosen by <code>
 &units/unit_time
@@ -412,13 +412,13 @@ Time step. Unit of time can be chosen by <code>
 ## &propagation
 <dl>
 
-<dt>n_hamil; <code>Integer</code>;</dt> 0d
+<dt>n_hamil; <code>Integer</code>; 0d</dt>
 <dd>
 Order of Taylor expansion of a propagation operator.
 Default is <code>4</code>.
 </dd>
 
-<dt>propagator; <code>Character</code>;</dt> 3d
+<dt>propagator; <code>Character</code>; 3d</dt>
 <dd>
 Choice of Propagator.
 <code>middlepoint</code> is an propagator
@@ -436,61 +436,61 @@ Default is <code>middlepoint</code>.
 ## &scf
 <dl>
 
-<dt>amin_routine; <code>Character</code>;</dt> 0d
+<dt>amin_routine; <code>Character</code>; 0d</dt>
 <dd>
 Minimization routine for the ground state calculation. 
 <code>'cg'</code>, <code>'diis'</code>, and <code>'cg-diis'</code> can be chosen.
 Default is <code>'cg'</code>.
 </dd>
 
-<dt>ncg; <code>Integer</code>;</dt> 0d/3d
+<dt>ncg; <code>Integer</code>; 0d/3d</dt>
 <dd>
 Number of interation of Conjugate-Gradient method for each scf-cycle.
 Default is <code>5</code>.
 </dd>
 
-<dt>nmemory_mb; <code>Integer</code>;</dt> 3d
+<dt>nmemory_mb; <code>Integer</code>; 3d</dt>
 <dd>
 Number of stored densities at previous scf-cycles for 
 the modified-Broyden method.
 Default is <code>8</code>.
 </dd>
 
-<dt>alpha_mb; <code>Integer</code>;</dt> 3d
+<dt>alpha_mb; <code>Integer</code>; 3d</dt>
 <dd>
 Parameter of the modified-Broyden method.
 Default is <code>0.75</code>.
 </dd>
 
-<dt>fsset_option; <code>Character</code>;</dt> 3d
+<dt>fsset_option; <code>Character</code>; 3d</dt>
 <dd>
 Probably, we should remove this function
 since we can replace it with occupaion smoothing with temepratre.
 </dd>
 
-<dt>nfsset_start; <code>Integer</code>;</dt> 3d
+<dt>nfsset_start; <code>Integer</code>; 3d</dt>
 <dd>
 Probably, we should remove this function
 since we can replace it with occupaion smoothing with temepratre.
 </dd>
 
-<dt>nfsset_every; <code>Integer</code>;</dt> 3d
+<dt>nfsset_every; <code>Integer</code>; 3d</dt>
 <dd>
 Probably, we should remove this function
 since we can replace it with occupaion smoothing with temepratre.
 </dd>
 
-<dt>nscf; <code>Integer</code>;</dt> 0d/3d
+<dt>nscf; <code>Integer</code>; 0d/3d</dt>
 <dd>
 Number of maximum scf cycle.
 </dd>
 
-<dt>ngeometry_opt; <code>Integer</code>;</dt> 0d
+<dt>ngeometry_opt; <code>Integer</code>; 0d</dt>
 <dd>
 Number of iteration of geometry optimization.
 </dd>
 
-<dt>subspace_diagonalization; <code>Character</code>;</dt> 0d
+<dt>subspace_diagonalization; <code>Character</code>; 0d</dt>
 <dd>
 <dd>Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 subspace diagonalization during scf cycle.
@@ -502,12 +502,12 @@ Methods for densiy/potential mixing for scf cycle.
 Default is <code>broyden</code>.
 </dd>
 
-<dt>rmixrate; <code>Real(8)</code>;</dt> 0d
+<dt>rmixrate; <code>Real(8)</code>; 0d</dt>
 <dd>
 Mixing ratio. Default is <code>0.5</code>
 </dd>
 
-<dt>convergence; <code>Character</code>;</dt> 0d
+<dt>convergence; <code>Character</code>; 0d</dt>
 <dd>
 Choice of quantity that will be used for convergence check in scf calculation.
 <code>'rho'</code> and <code>'vh'</code> can be chosen.
@@ -525,7 +525,7 @@ Default is <code>1d-6</code>
 ## &emfield
 <dl>
 
-<dt>trans_longi; <code>Character</code>;</dt> 3d
+<dt>trans_longi; <code>Character</code>; 3d</dt>
 <dd>
 Geometry of solid-state calculations.
 Transverse <code>'tr'</code> and longitudinal <code>'lo'</code>
@@ -533,7 +533,7 @@ can be chosen.
 Default is <code>'tr'</code>.
 </dd>
 
-<dt>ae_shape1/ae_shape2; <code>Character</code>;</dt> 0d/3d
+<dt>ae_shape1/ae_shape2; <code>Character</code>; 0d/3d</dt>
 <dd>
 Shape of the first/second pulse.
 <ul>
@@ -566,70 +566,70 @@ cos<sup>6</sup>, and cos<sup>8</sup> for a vector potential.
 </dd>
 
 
-<dt>amplitude1/amplitude2; <code>Real(8)</code>;</dt> 0d/3d
+<dt>amplitude1/amplitude2; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Amplitude of electric fields for the first/second pulse.
 This valiable has the dimension of electric field, energy/(length*charge).
 </dd>
 
-<dt>rlaser_int1/rlaser_int2; <code>Real(8)</code>;</dt> 0d/3d
+<dt>rlaser_int1/rlaser_int2; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Peak laser intensity (W/cm^2) the first/second pulse.
 </dd>
 
-<dt>pulse_tw1/pulse_tw2; <code>Real(8)</code>;</dt> 0d/3d
+<dt>pulse_tw1/pulse_tw2; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Duration of the first/second pulse. Unit of time can be chosend 
 by <code>&units/unit_time</code>.
 </dd>
 
-<dt>omega1/omega2; <code>Real(8)</code>;</dt> 0d/3d
+<dt>omega1/omega2; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Mean photon energy of the first/second pulse. Unit of energy can be chosend 
 by <code>&units/unit_energy</code>.
 </dd>
 
-<dt>epdir_re1(3)/epdir_re2(3); <code>Real(8)</code>;</dt> 0d/3d
+<dt>epdir_re1(3)/epdir_re2(3); <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Real part of polarization vector the first/second pulse.
 </dd>
 
-<dt>epdir_im1(3)/epdir_im2(3); <code>Real(8)</code>;</dt> 0d/3d
+<dt>epdir_im1(3)/epdir_im2(3); <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Imaginary part of polarization vector the first/second pulse.
 </dd>
 
-<dt>phi_cep1/phi_cep2; <code>Real(8)</code>;</dt> 0d/3d
+<dt>phi_cep1/phi_cep2; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Carrier emvelope phase of the first/second pulse.
 Default is <code>0d0/0d0</code>.
 </dd>
 
-<dt>t1_t2; <code>Real(8)</code>;</dt> 0d/3d
+<dt>t1_t2; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Time-delay between the first and the second pulses.
 Unit of time can be chosen by <code>&units/unit_time</code>.
 </dd>
 
-<dt>quadrupole; <code>Character</code>;</dt> 0d
+<dt>quadrupole; <code>Character</code>; 0d</dt>
 <dd>
 Quadrupole potential can be employed if 
 <code>quadrupole</code> is set to <code>'y'</code>.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>quadrupole_pot; <code>Character</code>;</dt> 0d
+<dt>quadrupole_pot; <code>Character</code>; 0d</dt>
 <dd>
 Form of a quadrupole potential.
 </dd>
 
-<dt>alocal_laser; <code>Character</code>;</dt> 0d
+<dt>alocal_laser; <code>Character</code>; 0d</dt>
 <dd>
 The pulse is applied to a specific domain.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>rlaserbound_sta(3)/rlaserbound_end(3); <code>Real(8)</code>;</dt> 0d
+<dt>rlaserbound_sta(3)/rlaserbound_end(3); <code>Real(8)</code>; 0d</dt>
 <dd>
 The edge of the domain where the pulse is applied.
 These parameters are effective only when <code>alocal_laser</code> is <code>'y'</code>.
@@ -642,7 +642,7 @@ Unit of length can be chosen by <code>&units/unit_length</code>.
 ## &linear_response
 <dl>
 
-<dt>e_impulse; <code>Real(8)</code>;</dt> 0d/3d
+<dt>e_impulse; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Momentum of impulsive perturbation.
 This valiable has the dimention of momentum, energy*time/length.
@@ -654,42 +654,42 @@ Defalt value is <code>1d-2</code> a.u.
 <dl>
 
 
-<dt>fdtddim; <code>Character</code>;</dt> 3d
+<dt>fdtddim; <code>Character</code>; 3d</dt>
 <dd>
 Dimension of FDTD calculation for multi-scale Maxwell-Kohn-Sham method.
 Defalt value is <code>'1D'</code>.
 </dd>
 
-<dt>twod_shape; <code>Character</code>;</dt> 3d
+<dt>twod_shape; <code>Character</code>; 3d</dt>
 <dd>
 Boundary condision of the second dimension for FDTD calculation with 
 multi-scale Maxwell-Kohn-Sham method.
 Defalt value is <code>'periodic'</code>.
 </dd>
 
-<dt>nx_m/ny_m/nz_m; <code>Integer</code>;</dt> 3d
+<dt>nx_m/ny_m/nz_m; <code>Integer</code>; 3d</dt>
 <dd>
 Number of macroscopic grid points inside materials for (x/y/z)-direction.
 </dd>
 
-<dt>hx_m/hy_m/hz_m; <code>Real(8)</code>;</dt> 3d
+<dt>hx_m/hy_m/hz_m; <code>Real(8)</code>; 3d</dt>
 <dd>
 Spacing of macroscopic grid points inside materials for (x/y/z)-direction.
 Unit of length can be chosen by <code>&units/unit_length</code>.
 </dd>
 
-<dt>nksplit; <code>Integer</code>;</dt> 3d
+<dt>nksplit; <code>Integer</code>; 3d</dt>
 <dd>
 Number of MPI processers that take care electron dynamics at each single macroscopic 
 point. 
 </dd>
 
-<dt>nxysplit; <code>Integer</code>;</dt> 3d
+<dt>nxysplit; <code>Integer</code>; 3d</dt>
 <dd>
 Number of macroscopic points that will be taken care by a single MPI processer.
 </dd>
 
-<dt>nxvacl_m/nxvacr_m; <code>Integer</code>;</dt> 3d
+<dt>nxvacl_m/nxvacr_m; <code>Integer</code>; 3d</dt>
 <dd>
 Number of macroscopic grid points for vacumm region.
 <code>nxvacl_m</code> gives the number for negative x-direction in front of material,
@@ -701,7 +701,7 @@ while
 
 ## &analysis
 <dl>
-<dt>projection_option; <code>Character</code>;</dt> 3d
+<dt>projection_option; <code>Character</code>; 3d</dt>
 <dd>
 Methods of projection.
 <ul>
@@ -719,55 +719,55 @@ Methods of projection.
 </ul>
 </dd>
 
-<dt>nenergy; <code>Integer</code>;</dt> 0d/3d
+<dt>nenergy; <code>Integer</code>; 0d/3d</dt>
 <dd>
 Number of energy grids for analysis.
 </dd>
 
-<dt>de; <code>Real(8)</code>;</dt> 0d/3d
+<dt>de; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Energy spacing for analysis.
 Unit of energy can be chosen by <code>&units/unit_energy</code>
 </dd>
 
-<dt>out_psi; <code>Character</code>;</dt> 0d
+<dt>out_psi; <code>Character</code>; 0d</dt>
 <dd>
 If <code>'y'</code>, wavefunctions are output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_dos; <code>Character</code>;</dt> 0d/3d
+<dt>out_dos; <code>Character</code>; 0d/3d</dt>
 <dd>
 If <code>'y'</code>, density of state is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_pdos; <code>Character</code>;</dt> 0d
+<dt>out_pdos; <code>Character</code>; 0d</dt>
 <dd>
 If <code>'y'</code>, projected density of state is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_dns; <code>Character</code>;</dt> 0d/3d
+<dt>out_dns; <code>Character</code>; 0d/3d</dt>
 <dd>
 If <code>'y'</code>, density is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_elf; <code>Character</code>;</dt> 0d
+<dt>out_elf; <code>Character</code>; 0d</dt>
 <dd>
 If <code>'y'</code>, electron localization function is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_dns_rt/out_dns_rt_step; <code>Character/Integer</code>;</dt> 0d/3d
+<dt>out_dns_rt/out_dns_rt_step; <code>Character/Integer</code>; 0d/3d</dt>
 <dd>
 If <code>'y'</code>, density during real-time time-propagation is output
 every <code>outdns_rt_step</code> time steps.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_elf_rt/out_elf_rt_step; <code>Character/Integer</code>;</dt> 0d
+<dt>out_elf_rt/out_elf_rt_step; <code>Character/Integer</code>; 0d</dt>
 <dd>
 If <code>'y'</code>, electron localization function 
 during real-time time-propagation is output
@@ -775,7 +775,7 @@ every <code>out_elf_rt_step</code> time steps.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_estatic_rt/out_estatic_rt_step; <code>Character/Integer</code>;</dt> 0d
+<dt>out_estatic_rt/out_estatic_rt_step; <code>Character/Integer</code>; 0d</dt>
 <dd>
 If <code>'y'</code>, static electric field
 during real-time time-propagation is output
@@ -783,7 +783,7 @@ every <code>out_estatic_rt_step</code> time steps.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>format3d; <code>Character</code>;</dt> 0d/3d
+<dt>format3d; <code>Character</code>; 0d/3d</dt>
 <dd>
 Format for three dimensional data.
 <code>'avs'</code>, <code>'cube'</code>, and <code>'vtk'</code>
@@ -796,13 +796,13 @@ Default is <code>'cube'</code>.
 ## &hartree
 <dl>
 
-<dt>meo; <code>Integer</code>;</dt> 0d
+<dt>meo; <code>Integer</code>; 0d</dt>
 <dd>
 Order of multi-pole expansion for calculation of Hartree potential.
 Default is <code>3</code>.
 </dd>
 
-<dt>num_pole_xyz(3); <code>Integer</code>;</dt> 0d
+<dt>num_pole_xyz(3); <code>Integer</code>; 0d</dt>
 <dd>
 Number of multi-poles.
 </dd>
@@ -811,7 +811,7 @@ Number of multi-poles.
 
 ## &ewald
 <dl>
-<dt>newald; <code>Integer</code>;</dt> 3d
+<dt>newald; <code>Integer</code>; 3d</dt>
 <dd>
 Parameter for Ewald method. 
 Short-range part of Ewald sum is calculated within <code>newald</code>th
@@ -819,7 +819,7 @@ nearlist neighbor cells.
 Default is <code>4</code>.
 </dd>
 
-<dt>aewald; <code>Real(8)</code>;</dt> 3d
+<dt>aewald; <code>Real(8)</code>; 3d</dt>
 <dd>
 Range separation parameter for Ewald method. 
 Default is <code>0.5</code>.

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -22,35 +22,35 @@
 
 ## &calculation
 <dl>
-<dt>calc_mode; <code>Character</code></dt>
+<dt>calc_mode; <code>Character</code>;</dt> 0d/3d
 <dd>Choice of Calculation modes. <code>'GS'</code>,
 <code>'RTLR'</code>,<code>'RTPulse'</code>, <code>'GS_RTLR'</code>, 
 and <code>'GS_RTPulse'</code>
 can be chosen.
 </dd>
 
-<dt>use_ehrenfest_md; <code>Character</code></dt>
+<dt>use_ehrenfest_md; <code>Character</code>;</dt> 0d/3d
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 Ehrenfest dynamics.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>use_ms_maxwell; <code>Character</code></dt>
+<dt>use_ms_maxwell; <code>Character</code>;</dt> 3d
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 Multi-scale Maxwell-Kohn-Sham coupling. 
 Default is <code>'n'</code> 
 </dd>
 
-<dt>use_force; <code>Character</code></dt>
+<dt>use_force; <code>Character</code>;</dt> 0d
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 force calculation.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>use_geometry_opt; <code>Character</code></dt>
+<dt>use_geometry_opt; <code>Character</code>;</dt> 0d
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 geometry optimization.
@@ -62,26 +62,26 @@ Default is <code>'n'</code>.
 ## &control
 <dl>
 
-<dt>restart_option; <code>Character</code></dt>
+<dt>restart_option; <code>Character</code>;</dt> 3d
 <dd>Flag for restart. <code>'new'</code> or 
 <code>'restart'</code> can be chosen.
 <code>'new'</code> is default.
 </dd>
 
-<dt>backup_frequency; <code>Integer</code></dt>
+<dt>backup_frequency; <code>Integer</code>;</dt> 3d
 <dd>Frequency of backup during the time-propagation. 
 If <code>0</code> is set, the backup is not performed.
 Default is <code>0</code>.
 </dd>
 
 
-<dt>time_shutdown; <code>Real(8)</code></dt>
+<dt>time_shutdown; <code>Real(8)</code>;</dt> 3d
 <dd>Timer for automatic shutdown. The unit is always second.
 If negative time is chosen, the automatic shutdown is not performed.
 Default is <code>-1</code> sec.
 </dd>
 
-<dt>sysname; <code>Character</code></dt>
+<dt>sysname; <code>Character</code>;</dt> 0d/3d
 <dd>Name of calculation. This is used for a prefix of output files.
 Default is <code>default</code>.
 </dd>
@@ -93,30 +93,25 @@ Default is <code>default</code>.
 ## &units
 <dl>
 
-<dt>unit_time; <code>Character</code></dt>
+<dt>unit_time; <code>Character</code>;</dt> 0d/3d
 <dd>Unit of time for input variables. 
 Atomic unit <code>'a.u.'</code> and 
 femtosecond <code>'fs'</code> can be chosen.
 Default is <code>'a.u.'</code>.
 </dd>
 
-<dt>unit_length; <code>Character</code></dt>
+<dt>unit_length; <code>Character</code>;</dt> 0d/3d
 <dd>Unit of length for input variables. 
 Atomic unit <code>'a.u.'</code> and 
 Aungstrom <code>angstrom</code> can be chosen.
 Default is <code>'a.u.'</code>.
 </dd>
 
-<dt>unit_energy; <code>Character</code></dt>
+<dt>unit_energy; <code>Character</code>;</dt> 0d/3d
 <dd>Unit of energy for input variables. 
 Atomic unit <code>'a.u.'</code> and 
 electron-volt <code>'ev'</code> can be chosen.
 Default is <code>'a.u.'</code>.
-</dd>
-
-<dt>unit_energy; <code>Character</code></dt>
-<dd>Unit of charge for input variables. 
-Atomic unit <code>'a.u.'</code> is only available.
 </dd>
 
 </dl>
@@ -131,18 +126,18 @@ domain parallelization.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>nproc_ob; <code>Integer</code></dt>
+<dt>nproc_ob; <code>Integer</code>;</dt> 0d
 <dd>Number of MPI parallelization for orbitals.
 Default is <code>0</code>.
 </dd>
 
-<dt>nproc_domain(3); <code>Integer</code></dt>
+<dt>nproc_domain(3); <code>Integer</code>;</dt> 0d
 <dd>Number of MPI parallelization for each direction in 
 real-space.
 Default is <code>(0,0,0)</code>.
 </dd>
 
-<dt>nproc_domain_s(3); <code>Integer</code></dt>
+<dt>nproc_domain_s(3); <code>Integer</code>;</dt> 0d
 <dd>Number of MPI parallelization for each direction in 
 real-space.
 Default is <code>(0,0,0)</code>.
@@ -164,67 +159,67 @@ Default is <code>0</code>.
 ## &system 
 <dl>
 
-<dt>iperiodic; <code>Integer</code></dt>
+<dt>iperiodic; <code>Integer</code>;</dt> 0d/3d
 <dd>Dimension for periodic boundary condition.
 <code>0</code> is for isolated systems, and 
 <code>3</code> is for solids.
 Default is <code>0</code>.
 </dd>
 
-<dt>ispin; <code>Integer</code></dt>
+<dt>ispin; <code>Integer</code>;</dt> 0d
 <dd>Variable for classification of closed shell systems and open shell systems.
 <code>0</code> is for closed shell systems, and
 <code>1</code> is for open shell systems.
 Default is <code>0</code>
 </dd>
 
-<dt>al(3); <code>Real(8)</code></dt>
+<dt>al(3); <code>Real(8)</code>;</dt> 0d/3d
 <dd>Lattice constants. Unit of the length can be 
 chosen by <code>&units/unit_length</code>.
 </dd>
 
-<dt>isym; <code>Integer</code></dt>
+<dt>isym; <code>Integer</code>;</dt> 3d
 <dd>Number of symmetries that can be used for 
 reduction of k-points.
 Default is <code>0</code>.
 </dd>
 
-<dt>crystal_structure; <code>Character</code></dt>
+<dt>crystal_structure; <code>Character</code>;</dt> 3d
 <dd>Name of symmetry that can be used for the resuction of # of k-points.
 Default is <code>'none'</code>.
 </dd>
 
-<dt>nstate; <code>Integer</code></dt>
+<dt>nstate; <code>Integer</code>;</dt> 0d/3d
 <dd>Number of states/bands.
 </dd>
 
-<dt>nstate_spin(2); <code>Integer</code></dt>
+<dt>nstate_spin(2); <code>Integer</code>;</dt> 0d
 <dd>Number of states/bands can be specified independently
 by <code>nstate_spin(1)/nstate_spin(2)</code>.
 This option is incompatible with <code>nstate</code>
 </dd>
 
-<dt>nelec; <code>Integer</code></dt>
+<dt>nelec; <code>Integer</code>;</dt> 0d/3d
 <dd>Number of valence electrons.
 </dd>
 
-<dt>nelec_spin(2); <code>Integer</code></dt>
+<dt>nelec_spin(2); <code>Integer</code>;</dt> 0d
 <dd>Number of up/down-spin electrons can be specified independently
 by <code>nelec_spin(1)/nelec_spin(2)</code>.
 This option is incompatible with <code>nelec</code>
 </dd>
 
-<dt>temperature; <code>Real(8)</code></dt>
+<dt>temperature; <code>Real(8)</code>;</dt> 3d
 <dd>Temperature of electrons.
 Unit of the energy can be chosen <code>&units/unit_energy</code>.
 </dd>
 
 
-<dt>nelem; <code>Integer</code></dt>
+<dt>nelem; <code>Integer</code>;</dt> 0d/3d
 <dd>Number of elements that will be used in calculations.
 </dd>
 
-<dt>natom; <code>Integer</code></dt>
+<dt>natom; <code>Integer</code>;</dt> 0d/3d
 <dd>Number of atoms in a calculation cell.
 </dd>
 
@@ -237,7 +232,7 @@ This option is incompatible with
 <code>&atomic_red_coor</code>.
 </dd>
 
-<dt>file_atom_coor; <code>Character</code></dt>
+<dt>file_atom_coor; <code>Character</code>;</dt> 0d
 <dd>File name of atomic positions. In this file, 
 the atomic coordinates can be written in Cartesian cooridnates.
 The unit of the length can be chosen by 
@@ -285,35 +280,35 @@ This option is incompatible with
 ## &pseudo
 <dl>
 
-<dt>pseudo_file(:); <code>Character</code></dt>
+<dt>pseudo_file(:); <code>Character</code>;</dt> 0d/3d
 <dd>Name of pseudopotential files.
 </dd>
 
-<dt>Lmax_ps(:); <code>Integer</code></dt>
+<dt>Lmax_ps(:); <code>Integer</code>;</dt> 0d/3d
 <dd>Maximum angular momentum of pseudopotential projectors.
 </dd>
 
-<dt>Lloc_ps(:); <code>Integer</code></dt>
+<dt>Lloc_ps(:); <code>Integer</code>;</dt> 0d/3d
 <dd>Angular momentum of pseudopotential thant will be treated as local.
 </dd>
 
-<dt>iZatom(:); <code>Integer</code></dt>
+<dt>iZatom(:); <code>Integer</code>;</dt> 0d/3d
 <dd>Atomic number.
 </dd>
 
 
-<dt>psmask_option(:); <code>Character</code></dt>
+<dt>psmask_option(:); <code>Character</code>;</dt> 3d
 <dd>Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 Fourier filtering for pseudopotentials. 
 Default is <code>'n'</code>.
 </dd>
 
-<dt>alpha_mask(:); <code>Real(8)</code></dt>
+<dt>alpha_mask(:); <code>Real(8)</code>;</dt> 3d
 <dd>Parameter for the Fourier filtering for pseudopotential.
 Default is <code>'0.8'</code>.
 </dd>
 
-<dt>gamma_mask(:); <code>Real(8)</code></dt>
+<dt>gamma_mask(:); <code>Real(8)</code>;</dt> 3d
 <dd>Parameter for the Fourier filtering for pseudopotential.
 Default is <code>'1.8'</code>.
 </dd>
@@ -328,10 +323,8 @@ Default is <code>'15.0'</code>.
 ## &functional
 <dl>
 
-<dt>eta_maskk(:); <code>Real(8)</code></dt>
-<dd>Parameter for the Fourier filtering for pseudopotential.
-Default is <code>'15.0'</code>.
-</dd>
+<dt>xc; <code>Character</code>;</dt> 3d
+<dd>
 Exchange-correlation functionals.
 At the moment, the following functionals are avelable.
 <ul>
@@ -352,8 +345,9 @@ improve sooth connection between high density form and low density one.
 John P. Perdew and Yue Wang, Phys. Rev. B 45, 13244 (1992).
 </li>
 </ul>
+</dd>
 
-<dt>cval(:); <code>Real(8)</code></dt>
+<dt>cval(:); <code>Real(8)</code>;</dt> 3d
 <dd>Mixing parameter in Tran-Blaha meta-GGA exchange potential. If <code>cval</code> is set to a minus value, the mixing-parameter computed
 by the formula in the original paper [Phys. Rev. Lett. 102, 226401 (2008)].
 Default is <code>'1.0'</code>.
@@ -363,7 +357,7 @@ Default is <code>'1.0'</code>.
 ## &rgrid
 <dl>
 
-<dt>dl(3); <code>Real(8)</code></dt>
+<dt>dl(3); <code>Real(8)</code>;</dt> 0d
 <dd>Spacing of real-space grids. Unit of length can be chosen by
 <code>&units/unit_length</code>.
 This valiable cannot be set with 
@@ -371,7 +365,7 @@ This valiable cannot be set with
 </dd>
 
 
-<dt>num_rgrid(3); <code>Integer</code></dt>
+<dt>num_rgrid(3); <code>Integer</code>;</dt> 3d
 <dd>Number of real-space grids.
 This valiable cannot be set with 
 <code>&rgrid/dl</code>.
@@ -382,12 +376,12 @@ This valiable cannot be set with
 ## &kgrid
 <dl>
 
-<dt>num_kgrid(3); <code>Integer</code></dt>
+<dt>num_kgrid(3); <code>Integer</code>;</dt> 3d
 <dd>Number of grids discretizing
 the Brillouin zone.
 </dd>
 
-<dt>file_kw; <code>Character</code></dt>
+<dt>file_kw; <code>Character</code>;</dt> 3d
 <dd>
 Name of a file for flexible k-point sampling.
 This file will be read if <code>num_kgrid</code> are
@@ -400,12 +394,12 @@ all negative.
 ## &tgrid
 <dl>
 
-<dt>nt; <code>Integer</code></dt>
+<dt>nt; <code>Integer</code>;</dt> 0d/3d
 <dd>
 Number of total time steps for real-time propagation.
 </dd>
 
-<dt>dt; <code>Real(8)</code></dt>
+<dt>dt; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Time step. Unit of time can be chosen by <code>
 &units/unit_time
@@ -418,13 +412,13 @@ Time step. Unit of time can be chosen by <code>
 ## &propagation
 <dl>
 
-<dt>n_hamil; <code>Integer</code></dt>
+<dt>n_hamil; <code>Integer</code>;</dt> 0d
 <dd>
 Order of Taylor expansion of a propagation operator.
 Default is <code>4</code>.
 </dd>
 
-<dt>propagator; <code>Character</code></dt>
+<dt>propagator; <code>Character</code>;</dt> 3d
 <dd>
 Choice of Propagator.
 <code>middlepoint</code> is an propagator
@@ -442,61 +436,61 @@ Default is <code>middlepoint</code>.
 ## &scf
 <dl>
 
-<dt>amin_routine; <code>Character</code></dt>
+<dt>amin_routine; <code>Character</code>;</dt> 0d
 <dd>
 Minimization routine for the ground state calculation. 
 <code>'cg'</code>, <code>'diis'</code>, and <code>'cg-diis'</code> can be chosen.
 Default is <code>'cg'</code>.
 </dd>
 
-<dt>ncg; <code>Integer</code></dt>
+<dt>ncg; <code>Integer</code>;</dt> 0d/3d
 <dd>
 Number of interation of Conjugate-Gradient method for each scf-cycle.
 Default is <code>5</code>.
 </dd>
 
-<dt>nmemory_mb; <code>Integer</code></dt>
+<dt>nmemory_mb; <code>Integer</code>;</dt> 3d
 <dd>
 Number of stored densities at previous scf-cycles for 
 the modified-Broyden method.
 Default is <code>8</code>.
 </dd>
 
-<dt>nmemory_mb; <code>Integer</code></dt>
+<dt>alpha_mb; <code>Integer</code>;</dt> 3d
 <dd>
 Parameter of the modified-Broyden method.
 Default is <code>0.75</code>.
 </dd>
 
-<dt>fsset_option; <code>Character</code></dt>
+<dt>fsset_option; <code>Character</code>;</dt> 3d
 <dd>
 Probably, we should remove this function
 since we can replace it with occupaion smoothing with temepratre.
 </dd>
 
-<dt>nfsset_start; <code>Integer</code></dt>
+<dt>nfsset_start; <code>Integer</code>;</dt> 3d
 <dd>
 Probably, we should remove this function
 since we can replace it with occupaion smoothing with temepratre.
 </dd>
 
-<dt>nfsset_every; <code>Integer</code></dt>
+<dt>nfsset_every; <code>Integer</code>;</dt> 3d
 <dd>
 Probably, we should remove this function
 since we can replace it with occupaion smoothing with temepratre.
 </dd>
 
-<dt>nscf; <code>Integer</code></dt>
+<dt>nscf; <code>Integer</code>;</dt> 0d/3d
 <dd>
 Number of maximum scf cycle.
 </dd>
 
-<dt>ngeometry_opt; <code>Integer</code></dt>
+<dt>ngeometry_opt; <code>Integer</code>;</dt> 0d
 <dd>
 Number of iteration of geometry optimization.
 </dd>
 
-<dt>subspace_diagonalization; <code>Character</code></dt>
+<dt>subspace_diagonalization; <code>Character</code>;</dt> 0d
 <dd>
 <dd>Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
 subspace diagonalization during scf cycle.
@@ -508,12 +502,12 @@ Methods for densiy/potential mixing for scf cycle.
 Default is <code>broyden</code>.
 </dd>
 
-<dt>rmixrate; <code>Real(8)</code></dt>
+<dt>rmixrate; <code>Real(8)</code>;</dt> 0d
 <dd>
-Mixingratio. Default is <code>0.5</code>
+Mixing ratio. Default is <code>0.5</code>
 </dd>
 
-<dt>convergence; <code>Character</code></dt>
+<dt>convergence; <code>Character</code>;</dt> 0d
 <dd>
 Choice of quantity that will be used for convergence check in scf calculation.
 <code>'rho'</code> and <code>'vh'</code> can be chosen.
@@ -531,7 +525,7 @@ Default is <code>1d-6</code>
 ## &emfield
 <dl>
 
-<dt>trans_longi; <code>Character</code></dt>
+<dt>trans_longi; <code>Character</code>;</dt> 3d
 <dd>
 Geometry of solid-state calculations.
 Transverse <code>'tr'</code> and longitudinal <code>'lo'</code>
@@ -539,7 +533,7 @@ can be chosen.
 Default is <code>'tr'</code>.
 </dd>
 
-<dt>ae_shape1/ae_shape2; <code>Character</code></dt>
+<dt>ae_shape1/ae_shape2; <code>Character</code>;</dt> 0d/3d
 <dd>
 Shape of the first/second pulse.
 <ul>
@@ -557,7 +551,7 @@ cos<sup>6</sup>, and cos<sup>8</sup> for a vector potential.
 </li>
 
 <li>
-<code>'Esin2sin'</code>:
+<code>'Esin2cos'</code>:
 </li>
 
 <li>
@@ -572,70 +566,70 @@ cos<sup>6</sup>, and cos<sup>8</sup> for a vector potential.
 </dd>
 
 
-<dt>amplitude1/amplitude2; <code>Real(8)</code></dt>
+<dt>amplitude1/amplitude2; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Amplitude of electric fields for the first/second pulse.
 This valiable has the dimension of electric field, energy/(length*charge).
 </dd>
 
-<dt>rlaser_int1/rlaser_int2; <code>Real(8)</code></dt>
+<dt>rlaser_int1/rlaser_int2; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Peak laser intensity (W/cm^2) the first/second pulse.
 </dd>
 
-<dt>pulse_tw1/pulse_tw2; <code>Real(8)</code></dt>
+<dt>pulse_tw1/pulse_tw2; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Duration of the first/second pulse. Unit of time can be chosend 
 by <code>&units/unit_time</code>.
 </dd>
 
-<dt>omega1/omega2; <code>Real(8)</code></dt>
+<dt>omega1/omega2; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Mean photon energy of the first/second pulse. Unit of energy can be chosend 
 by <code>&units/unit_energy</code>.
 </dd>
 
-<dt>epdir_re1(3)/epdir_re2(3); <code>Real(8)</code></dt>
+<dt>epdir_re1(3)/epdir_re2(3); <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Real part of polarization vector the first/second pulse.
 </dd>
 
-<dt>epdir_im1(3)/epdir_im2(3); <code>Real(8)</code></dt>
+<dt>epdir_im1(3)/epdir_im2(3); <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Imaginary part of polarization vector the first/second pulse.
 </dd>
 
-<dt>phi_cep1/phi_cep2; <code>Real(8)</code></dt>
+<dt>phi_cep1/phi_cep2; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Carrier emvelope phase of the first/second pulse.
 Default is <code>0d0/0d0</code>.
 </dd>
 
-<dt>t1_t2; <code>Real(8)</code></dt>
+<dt>t1_t2; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Time-delay between the first and the second pulses.
 Unit of time can be chosen by <code>&units/unit_time</code>.
 </dd>
 
-<dt>quadrupole; <code>Character</code></dt>
+<dt>quadrupole; <code>Character</code>;</dt> 0d
 <dd>
 Quadrupole potential can be employed if 
 <code>quadrupole</code> is set to <code>'y'</code>.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>quadrupole_pot; <code>Character</code></dt>
+<dt>quadrupole_pot; <code>Character</code>;</dt> 0d
 <dd>
 Form of a quadrupole potential.
 </dd>
 
-<dt>alocal_laser; <code>Character</code></dt>
+<dt>alocal_laser; <code>Character</code>;</dt> 0d
 <dd>
 The pulse is applied to a specific domain.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>rlaserbound_sta(3)/rlaserbound_end(3); <code>Real(8)</code></dt>
+<dt>rlaserbound_sta(3)/rlaserbound_end(3); <code>Real(8)</code>;</dt> 0d
 <dd>
 The edge of the domain where the pulse is applied.
 These parameters are effective only when <code>alocal_laser</code> is <code>'y'</code>.
@@ -648,7 +642,7 @@ Unit of length can be chosen by <code>&units/unit_length</code>.
 ## &linear_response
 <dl>
 
-<dt>e_impulse; <code>Real(8)</code></dt>
+<dt>e_impulse; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Momentum of impulsive perturbation.
 This valiable has the dimention of momentum, energy*time/length.
@@ -660,42 +654,42 @@ Defalt value is <code>1d-2</code> a.u.
 <dl>
 
 
-<dt>fdtddim; <code>Character</code></dt>
+<dt>fdtddim; <code>Character</code>;</dt> 3d
 <dd>
 Dimension of FDTD calculation for multi-scale Maxwell-Kohn-Sham method.
 Defalt value is <code>'1D'</code>.
 </dd>
 
-<dt>twod_shape; <code>Character</code></dt>
+<dt>twod_shape; <code>Character</code>;</dt> 3d
 <dd>
 Boundary condision of the second dimension for FDTD calculation with 
 multi-scale Maxwell-Kohn-Sham method.
 Defalt value is <code>'periodic'</code>.
 </dd>
 
-<dt>nx_m/ny_m/nz_m; <code>Integer</code></dt>
+<dt>nx_m/ny_m/nz_m; <code>Integer</code>;</dt> 3d
 <dd>
 Number of macroscopic grid points inside materials for (x/y/z)-direction.
 </dd>
 
-<dt>hx_m/hy_m/hz_m; <code>Real(8)</code></dt>
+<dt>hx_m/hy_m/hz_m; <code>Real(8)</code>;</dt> 3d
 <dd>
 Spacing of macroscopic grid points inside materials for (x/y/z)-direction.
 Unit of length can be chosen by <code>&units/unit_length</code>.
 </dd>
 
-<dt>nksplit; <code>Integer</code></dt>
+<dt>nksplit; <code>Integer</code>;</dt> 3d
 <dd>
 Number of MPI processers that take care electron dynamics at each single macroscopic 
 point. 
 </dd>
 
-<dt>nxysplit; <code>Integer</code></dt>
+<dt>nxysplit; <code>Integer</code>;</dt> 3d
 <dd>
 Number of macroscopic points that will be taken care by a single MPI processer.
 </dd>
 
-<dt>nxvacl_m/nxvacr_m; <code>Integer</code></dt>
+<dt>nxvacl_m/nxvacr_m; <code>Integer</code>;</dt> 3d
 <dd>
 Number of macroscopic grid points for vacumm region.
 <code>nxvacl_m</code> gives the number for negative x-direction in front of material,
@@ -707,7 +701,7 @@ while
 
 ## &analysis
 <dl>
-<dt>projection_option; <code>Character</code></dt>
+<dt>projection_option; <code>Character</code>;</dt> 3d
 <dd>
 Methods of projection.
 <ul>
@@ -725,55 +719,55 @@ Methods of projection.
 </ul>
 </dd>
 
-<dt>nenergy; <code>Integer</code></dt>
+<dt>nenergy; <code>Integer</code>;</dt> 0d/3d
 <dd>
 Number of energy grids for analysis.
 </dd>
 
-<dt>de; <code>Real(8)</code></dt>
+<dt>de; <code>Real(8)</code>;</dt> 0d/3d
 <dd>
 Energy spacing for analysis.
 Unit of energy can be chosen by <code>&units/unit_energy</code>
 </dd>
 
-<dt>out_psi; <code>Character</code></dt>
+<dt>out_psi; <code>Character</code>;</dt> 0d
 <dd>
 If <code>'y'</code>, wavefunctions are output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_dos; <code>Character</code></dt>
+<dt>out_dos; <code>Character</code>;</dt> 0d/3d
 <dd>
 If <code>'y'</code>, density of state is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_pdos; <code>Character</code></dt>
+<dt>out_pdos; <code>Character</code>;</dt> 0d
 <dd>
 If <code>'y'</code>, projected density of state is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_dns; <code>Character</code></dt>
+<dt>out_dns; <code>Character</code>;</dt> 0d/3d
 <dd>
 If <code>'y'</code>, density is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_elf; <code>Character</code></dt>
+<dt>out_elf; <code>Character</code>;</dt> 0d
 <dd>
 If <code>'y'</code>, electron localization function is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_dns_rt/out_dns_rt_step; <code>Character/Integer</code></dt>
+<dt>out_dns_rt/out_dns_rt_step; <code>Character/Integer</code>;</dt> 0d/3d
 <dd>
 If <code>'y'</code>, density during real-time time-propagation is output
 every <code>outdns_rt_step</code> time steps.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_elf_rt/out_elf_rt_step; <code>Character/Integer</code></dt>
+<dt>out_elf_rt/out_elf_rt_step; <code>Character/Integer</code>;</dt> 0d
 <dd>
 If <code>'y'</code>, electron localization function 
 during real-time time-propagation is output
@@ -781,7 +775,7 @@ every <code>out_elf_rt_step</code> time steps.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_estatic_rt/out_estatic_rt_step; <code>Character/Integer</code></dt>
+<dt>out_estatic_rt/out_estatic_rt_step; <code>Character/Integer</code>;</dt> 0d
 <dd>
 If <code>'y'</code>, static electric field
 during real-time time-propagation is output
@@ -789,7 +783,7 @@ every <code>out_estatic_rt_step</code> time steps.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>format3d; <code>Character</code></dt>
+<dt>format3d; <code>Character</code>;</dt> 0d/3d
 <dd>
 Format for three dimensional data.
 <code>'avs'</code>, <code>'cube'</code>, and <code>'vtk'</code>
@@ -802,13 +796,13 @@ Default is <code>'cube'</code>.
 ## &hartree
 <dl>
 
-<dt>meo; <code>Integer</code></dt>
+<dt>meo; <code>Integer</code>;</dt> 0d
 <dd>
 Order of multi-pole expansion for calculation of Hartree potential.
 Default is <code>3</code>.
 </dd>
 
-<dt>num_pole_xyz(3); <code>Integer</code></dt>
+<dt>num_pole_xyz(3); <code>Integer</code>;</dt> 0d
 <dd>
 Number of multi-poles.
 </dd>
@@ -817,7 +811,7 @@ Number of multi-poles.
 
 ## &ewald
 <dl>
-<dt>newald; <code>Integer</code></dt>
+<dt>newald; <code>Integer</code>;</dt> 3d
 <dd>
 Parameter for Ewald method. 
 Short-range part of Ewald sum is calculated within <code>newald</code>th
@@ -825,7 +819,7 @@ nearlist neighbor cells.
 Default is <code>4</code>.
 </dd>
 
-<dt>aewald; <code>Real(8)</code></dt>
+<dt>aewald; <code>Real(8)</code>;</dt> 3d
 <dd>
 Range separation parameter for Ewald method. 
 Default is <code>0.5</code>.

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -456,7 +456,7 @@ the modified-Broyden method.
 Default is <code>8</code>.
 </dd>
 
-<dt>alpha_mb; <code>Integer</code>; 3d</dt>
+<dt>alpha_mb; <code>Real(8)</code>; 3d</dt>
 <dd>
 Parameter of the modified-Broyden method.
 Default is <code>0.75</code>.

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -189,7 +189,7 @@ Default is <code>0</code>.
 Default is <code>'none'</code>.
 </dd>
 
-<dt>nstate; <code>Integer</code>;</dt>0d/3d
+<dt>nstate; <code>Integer</code>; 0d/3d</dt>
 <dd>Number of states/bands.
 </dd>
 


### PR DESCRIPTION
I add descriptions "0d/3d" in the developer's manual. In this work, I used a grep command in GCEED and ARTED directories. So if variables are not used in each directory, I don't write neither "0d" nor "3d". I havn't finished the work in which I pick up variables from read_input_scf.f90 or read_input_rt.f90. Could you leave variables without "0d/3d" in the developer's manual? If you leave, I can simply add "0d" in the future. 