### PR TITLE
add the variable numfiles_out_3d

### DIFF
--- a/GCEED/common/CMakeLists.txt
+++ b/GCEED/common/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES
     setcN.f90
     set_filename.f90
     set_gridcoo.f90
+    set_icoo1d.f90
     set_imesh_oddeven.f90
     set_ispin.f90
     set_isstaend.f90

--- a/GCEED/common/OUT_IN_data.f90
+++ b/GCEED/common/OUT_IN_data.f90
@@ -645,7 +645,10 @@ else if(ilsda==1)then
   end if
 end if
 
-if(iSCFRT==2) call allocate_mat
+if(iSCFRT==2)then
+  call allocate_mat
+  call set_icoo1d
+end if
 
 allocate( matbox(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3)) )
 allocate( cmatbox(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),lg_sta(3):lg_end(3)) )
@@ -1190,19 +1193,6 @@ if(iSCFRT==2)then
   end do
   end do
 end if
-
-allocate(icoo1d(3,lg_num(1)*lg_num(2)*lg_num(3)))
-icount=0
-do iz=lg_sta(3),lg_end(3),1
-do iy=lg_sta(2),lg_end(2),1
-do ix=lg_sta(1),lg_end(1),1
-  icount=icount+1
-  icoo1d(1,icount)=ix
-  icoo1d(2,icount)=iy
-  icoo1d(3,icount)=iz
-end do
-end do
-end do
 
 call allgatherv_vlocal
 

--- a/GCEED/common/set_icoo1d.f90
+++ b/GCEED/common/set_icoo1d.f90
@@ -1,0 +1,35 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine set_icoo1d
+  use scf_data
+!$ use omp_lib
+  implicit none
+  integer :: ix,iy,iz
+  integer :: icount
+
+!$OMP parallel do private(iz,iy,ix,icount) 
+  do iz=lg_sta(3),lg_end(3)
+  do iy=lg_sta(2),lg_end(2)
+  do ix=lg_sta(1),lg_end(1)
+    icount=(iz-lg_sta(3))*lg_num(2)*lg_num(1)+(iy-lg_sta(2))*lg_num(1)+ix-lg_sta(1)+1
+    icoo1d(1,icount)=ix
+    icoo1d(2,icount)=iy
+    icoo1d(3,icount)=iz
+  end do
+  end do
+  end do
+
+end subroutine set_icoo1d 

--- a/GCEED/common/writeavs.f90
+++ b/GCEED/common/writeavs.f90
@@ -28,13 +28,13 @@ subroutine writeavs(fp,suffix,tmatbox_l)
   integer::jsta,jend
   character(8)  :: filenumber_data
   
-  if(numfile_movie>=2)then
-    if(nproc_id_global<numfile_movie)then
+  if(numfiles_out_3d>=2)then
+    if(nproc_id_global<numfiles_out_3d)then
       write(filenumber_data, '(i8)') nproc_id_global
       filename = trim(suffix)//"."//adjustl(filenumber_data)
       open(fp,file=filename)
-      jsta=nproc_id_global*(lg_num(1)*lg_num(2)*lg_num(3))/numfile_movie+1
-      jend=(nproc_id_global+1)*(lg_num(1)*lg_num(2)*lg_num(3))/numfile_movie
+      jsta=nproc_id_global*(lg_num(1)*lg_num(2)*lg_num(3))/numfiles_out_3d+1
+      jend=(nproc_id_global+1)*(lg_num(1)*lg_num(2)*lg_num(3))/numfiles_out_3d
       do jj=jsta,jend
         if(abs(tmatbox_l(icoo1d(1,jj),icoo1d(2,jj),icoo1d(3,jj)))>=1.0d-10)then
           write(fp,'(e20.8)') tmatbox_l(icoo1d(1,jj),icoo1d(2,jj),icoo1d(3,jj))

--- a/GCEED/modules/allocate_mat.f90
+++ b/GCEED/modules/allocate_mat.f90
@@ -136,6 +136,8 @@ allocate (exc_dummy(ng_num(1), ng_num(2), ng_num(3)))
 allocate (exc_dummy2(ng_num(1), ng_num(2), ng_num(3),2))
 allocate (exc_dummy3(ng_num(1), ng_num(2), ng_num(3),3))
 
+allocate(icoo1d(3,lg_num(1)*lg_num(2)*lg_num(3)))
+
 END SUBROUTINE allocate_mat
 
 !======================================================================

--- a/GCEED/modules/deallocate_mat.f90
+++ b/GCEED/modules/deallocate_mat.f90
@@ -63,6 +63,8 @@ deallocate (exc_dummy)
 deallocate (exc_dummy2)
 deallocate (exc_dummy3)
 
+deallocate (icoo1d)
+
 END SUBROUTINE deallocate_mat
 
 !======================================================================

--- a/GCEED/modules/scf_data.f90
+++ b/GCEED/modules/scf_data.f90
@@ -349,7 +349,6 @@ integer       :: idensum   ! whether density is summed up along direction
                            ! (0: not summed, 1: summed)
 real(8)       :: posplane  ! position of the plane
                            ! (only for idensum = 0)
-integer       :: numfile_movie
 
 character(1) :: circular
 

--- a/GCEED/rt/read_input_rt.f90
+++ b/GCEED/rt/read_input_rt.f90
@@ -39,7 +39,7 @@ namelist / group_others / iparaway_ob,num_projection,iwrite_projection_ob,iwrite
                           filename_pot, &
     & iwrite_external,iflag_dip2,iflag_intelectron,num_dip2, dip2boundary, dip2center,& 
     & iflag_fourier_omega, num_fourier_omega, fourier_omega, itotNtime2, &
-    & iwdenoption,iwdenstep, numfile_movie, iflag_Estatic
+    & iwdenoption,iwdenstep, iflag_Estatic
 
 if(comm_is_root(nproc_id_global))then
    open(fh_namelist, file='.namelist.tmp', status='old')
@@ -238,7 +238,6 @@ fourier_omega(:)=0.d0
 itotNtime2=Ntime
 iwdenoption=0
 iwdenstep=0
-numfile_movie=1
 iflag_Estatic=0
 if(comm_is_root(nproc_id_global))then
   read(fh_namelist,NML=group_others, iostat=inml_group_others)
@@ -264,7 +263,6 @@ fourier_omega = fourier_omega*uenergy_to_au
 call comm_bcast(itotNtime2,           nproc_group_global)
 call comm_bcast(iwdenoption,          nproc_group_global)
 call comm_bcast(iwdenstep,            nproc_group_global)
-call comm_bcast(numfile_movie,        nproc_group_global)
 call comm_bcast(iflag_Estatic,        nproc_group_global)
 
 if(iflag_dip2==0)then

--- a/GCEED/scf/real_space_dft.f90
+++ b/GCEED/scf/real_space_dft.f90
@@ -113,6 +113,7 @@ if(istopt==1)then
     call make_icoobox_bound
         
     call allocate_mat
+    call set_icoo1d
     call allocate_sendrecv
     allocate( Vpsl(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)) )
     if(icalcforce==1)then
@@ -194,6 +195,7 @@ if(istopt==1)then
     call IN_data
 
     call allocate_mat
+    call set_icoo1d
     call allocate_sendrecv
 
     if(iflag_ps/=0) then

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -813,6 +813,14 @@ can be chosen.
 Default is <code>'cube'</code>.
 </dd>
 
+<dt>numfiles_out_3d; <code>Integer</code>; 0d</dt>
+<dd>
+Number of separated files for three dimensional data.
+Effective only when <code>format3d</code> is <code>'avs'</code>.
+<code>numfiles_out_3d</code> must be less than or equal to number of processes.
+Default is <code>1</code>.
+</dd>
+
 </dl>
 
 ## &hartree

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -339,7 +339,8 @@ contains
       & out_elf_rt_step, &
       & out_estatic_rt, &
       & out_estatic_rt_step, &
-      & format3d
+      & format3d, &
+      & numfiles_out_3d
 
     namelist/hartree/ &
       & meo, &
@@ -505,6 +506,7 @@ contains
     out_estatic_rt      = 'n'
     out_estatic_rt_step = 50
     format3d            = 'cube'
+    numfiles_out_3d     = 1
 !! == default for &hartree
     meo          = 3
     num_pole_xyz = 0
@@ -714,6 +716,7 @@ contains
     call comm_bcast(out_estatic_rt     ,nproc_group_global)
     call comm_bcast(out_estatic_rt_step,nproc_group_global)
     call comm_bcast(format3d           ,nproc_group_global)
+    call comm_bcast(numfiles_out_3d    ,nproc_group_global)
 !! == bcast for &hartree
     call comm_bcast(meo         ,nproc_group_global)
     call comm_bcast(num_pole_xyz,nproc_group_global)
@@ -1136,6 +1139,7 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_estatic_rt', out_estatic_rt
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_estatic_rt_step', out_estatic_rt_step
       write(fh_variables_log, '("#",4X,A,"=",A)') 'format3d', format3d
+      write(fh_variables_log, '("#",4X,A,"=",I6)') 'numfiles_out_3d', numfiles_out_3d
 
       if(inml_hartree >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'hartree', inml_hartree

--- a/modules/salmon_global.f90
+++ b/modules/salmon_global.f90
@@ -185,6 +185,7 @@ module salmon_global
   character(1)   :: out_estatic_rt
   integer        :: out_estatic_rt_step
   character(16)  :: format3d
+  integer        :: numfiles_out_3d
 
 !! &hartree
   integer        :: meo


### PR DESCRIPTION
I add the variable "numfiles_out_3d" in inputoutput.f90 instead of picking up the variable "numfile_movie" in read_input_rt.f90. Using FX10 12nodes, I checked the GS calculation with following condition
<pre>
&parallel (<- parallel, somehow it is not appropriately displayed)
  domain_parallel = 'y'
  nproc_ob = 1
  nproc_domain = 3,4,1
  nproc_domain_s = 3,4,1
/
...
&analysis
  out_psi = 'y'
  format3d = 'avs'
  numfiles_out_3d = 2
/
</pre>
and confirmed that it certainly produces two files for each psi. I used AVS/express combining files for psi and confirmed that HOMO was displayed. 

This PR is what I planned to give tomorrow, so I will not give other PRs tomorrow. 
