### PR TITLE
Implemented 'GS' and 'RT' modes in addition to 'GS_RT' mode in ARTED part

### DIFF
--- a/ARTED/GS/CMakeLists.txt
+++ b/ARTED/GS/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    io_gs_wfn_k.f90
     Gram_Schmidt.f90
     diag.f90
     sp_energy.f90

--- a/ARTED/GS/io_gs_wfn_k.f90
+++ b/ARTED/GS/io_gs_wfn_k.f90
@@ -1,0 +1,106 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+!This file is "io_gs_wfn_k.f90"
+!This file contains I/O routines for ground state wavefunctions
+!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
+module io_gs_wfn_k
+  use salmon_global
+  use salmon_communication
+  use salmon_parallel
+  use global_variables
+  use misc_routines
+  implicit none
+
+  character(256) :: gs_wfn_directory
+  character(256) :: gs_wfn_file, occ_file
+  integer,parameter :: nfile_gs_wfn = 41
+  integer,parameter :: nfile_occ = 42
+
+  integer,parameter :: iflag_read = 0
+  integer,parameter :: iflag_write = 1
+
+contains
+  subroutine read_write_gs_wfn_k(iflag_read_write)
+    implicit none
+    integer,intent(in) :: iflag_read_write
+    integer :: ik
+  ! temporal communicator for multi-scale (same k-points at different macro point)
+    integer :: nproc_group_kpoint_ms
+    integer :: nproc_id_kpoint_ms
+    integer :: nproc_size_kpoint_ms
+
+#ifdef ARTED_USE_FORTRAN2008
+    write (gs_wfn_directory,'(A,A)') trim(directory),'/gs_wfn_k/'
+    if(iflag_read_write == iflag_write)call create_directory(gs_wfn_directory)
+#else
+    gs_wfn_directory = trim(directory)
+#endif
+
+
+    if(comm_is_root(nproc_id_global))then
+      occ_file = trim(gs_wfn_directory)//'occupation'
+      open(nfile_occ,file=trim(occ_file),form='unformatted')
+      select case(iflag_read_write)
+      case(iflag_write); write(nfile_occ)occ
+      case(iflag_read ); read(nfile_occ)occ
+      end select
+      close(nfile_occ)
+    end if
+
+    if(use_ms_maxwell == 'n' .or. (use_ms_maxwell == 'y'.and. NXY_s == 0))then
+      do ik=NK_s,NK_e
+        
+        write (gs_wfn_file,'(A,A,I7.7,A)') trim(directory),'/wfn_gs_k',ik,'.wfn'
+        open(nfile_gs_wfn,file=trim(gs_wfn_file),form='unformatted')
+        select case(iflag_read_write)
+        case(iflag_write); write(nfile_gs_wfn)zu_GS(:,:,ik)
+        case(iflag_read ); read(nfile_gs_wfn)zu_GS(:,:,ik)
+        end select
+        close(nfile_gs_wfn)
+
+      end do
+
+    end if
+
+    if(iflag_read_write==iflag_write)return
+
+    if(use_ms_maxwell == 'y')then
+      nproc_group_kpoint_ms = comm_create_group(nproc_group_global, NK_s, NXY_s)
+      call comm_get_groupinfo(nproc_group_kpoint_ms, nproc_id_kpoint_ms, nproc_size_kpoint_ms)
+      call comm_bcast(zu_GS,nproc_group_kpoint_ms)
+    end if
+
+
+    zu_GS0(:,:,:)=zu_GS(:,:,:)
+    
+    zu_t(:,:,:)=zu_GS(:,1:NBoccmax,:)
+    Rion_eq=Rion
+    dRion(:,:,-1)=0.d0; dRion(:,:,0)=0.d0
+    call psi_rho_GS
+    call Hartree
+    call Exc_Cor(calc_mode_gs,NBoccmax,zu_t)
+
+    Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
+    Vloc_GS(:)=Vloc(:)
+    call Total_Energy_omp(rion_update_on,calc_mode_gs)
+    call Ion_Force_omp(rion_update_on,calc_mode_gs)
+    Eall0=Eall
+    if(comm_is_root(nproc_id_global)) write(*,*) 'Eall =',Eall
+
+
+  end subroutine read_write_gs_wfn_k
+end module io_gs_wfn_k
+

--- a/ARTED/GS/io_gs_wfn_k.f90
+++ b/ARTED/GS/io_gs_wfn_k.f90
@@ -60,6 +60,12 @@ contains
       close(nfile_occ)
     end if
 
+    select case(iflag_read_write)
+    case(iflag_read )
+      call comm_bcast(occ,nproc_group_global)
+    end select
+
+
     if(use_ms_maxwell == 'n' .or. (use_ms_maxwell == 'y'.and. NXY_s == 0))then
       do ik=NK_s,NK_e
         

--- a/ARTED/control/control_sc.f90
+++ b/ARTED/control/control_sc.f90
@@ -33,14 +33,14 @@ subroutine tddft_sc
 
   implicit none
   integer :: iter,ik,ib,ia,i,ixyz
-  logical :: Rion_update
+
 
 
   select case(use_ehrenfest_md)
   case('y')
-     Rion_update = rion_update_on
+     Rion_update_rt = rion_update_on
   case('n')
-     Rion_update = rion_update_off
+     Rion_update_rt = rion_update_off
   end select
 
 
@@ -145,15 +145,15 @@ subroutine tddft_sc
     javt(iter+1,:)=jav(:)
     if (use_ehrenfest_md == 'y') then
 !$acc update self(zu)
-      call Ion_Force_omp(Rion_update,calc_mode_rt)
+      call Ion_Force_omp(Rion_update_rt,calc_mode_rt)
       if (iter/10*10 == iter) then
-        call Total_Energy_omp(Rion_update,calc_mode_rt)
+        call Total_Energy_omp(Rion_update_rt,calc_mode_rt)
       end if
     else
       if (iter/10*10 == iter) then
 !$acc update self(zu)
-        call Total_Energy_omp(Rion_update,calc_mode_rt)
-        call Ion_Force_omp(Rion_update,calc_mode_rt)
+        call Total_Energy_omp(Rion_update_rt,calc_mode_rt)
+        call Ion_Force_omp(Rion_update_rt,calc_mode_rt)
       end if
     end if
 
@@ -270,7 +270,7 @@ subroutine tddft_sc
     end if
 !Adiabatic evolution
     if (projection_option /= 'no' .and. iter/100*100 == iter) then
-      call k_shift_wf(Rion_update,5,zu_t)
+      call k_shift_wf(Rion_update_rt,5,zu_t)
       if (comm_is_root(nproc_id_global)) then
         do ia=1,NI
           write(*,'(1x,i7,3f15.6)') ia,force(1,ia),force(2,ia),force(3,ia)
@@ -372,7 +372,7 @@ subroutine tddft_sc
 !====Analyzing calculation====================
 
 !Adiabatic evolution
-  call k_shift_wf_last(Rion_update,10,zu_t)
+  call k_shift_wf_last(Rion_update_rt,10,zu_t)
 
   call Fourier_tr
 

--- a/ARTED/control/ground_state.f90
+++ b/ARTED/control/ground_state.f90
@@ -26,10 +26,7 @@ contains
     use salmon_communication, only: comm_bcast, comm_sync_all, comm_is_root
     implicit none
     integer :: iter, ik, ib, ia
-    logical :: Rion_update
     character(10) :: functional_t
-
-    Rion_update = rion_update_on
 
     allocate(rho_in(1:NL,1:Nscf+1),rho_out(1:NL,1:Nscf+1))
     rho_in(1:NL,1:Nscf+1)=0.d0; rho_out(1:NL,1:Nscf+1)=0.d0
@@ -50,9 +47,8 @@ contains
     if(functional_t == 'BJ_PW') functional = 'BJ_PW'
 
     Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
-    call Total_Energy_omp(Rion_update,calc_mode_gs)
-    call Ion_Force_omp(Rion_update,calc_mode_gs)
-    if (use_ehrenfest_md /= 'y') Rion_update = rion_update_off
+    call Total_Energy_omp(rion_update_on,calc_mode_gs)
+    call Ion_Force_omp(rion_update_on,calc_mode_gs)
     Eall_GS(0)=Eall
 
     if(comm_is_root(nproc_id_global)) then
@@ -115,8 +111,8 @@ contains
        if(functional_t == 'BJ_PW' .and. iter < 20) functional = 'BJ_PW'
 
        Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
-       call Total_Energy_omp(Rion_update,calc_mode_gs)
-       call Ion_Force_omp(Rion_update,calc_mode_gs)
+       call Total_Energy_omp(rion_update_off,calc_mode_gs)
+       call Ion_Force_omp(rion_update_off,calc_mode_gs)
        call sp_energy_omp
        call current_GS
        Eall_GS(iter)=Eall
@@ -176,7 +172,7 @@ contains
 
     Vloc(1:NL)=Vh(1:NL)+Vpsl(1:NL)+Vexc(1:NL)
     Vloc_GS(:)=Vloc(:)
-    call Total_Energy_omp(Rion_update,calc_mode_gs)
+    call Total_Energy_omp(rion_update_off,calc_mode_gs)
     Eall0=Eall
     if(comm_is_root(nproc_id_global)) write(*,*) 'Eall =',Eall
     

--- a/ARTED/control/initialization.f90
+++ b/ARTED/control/initialization.f90
@@ -26,7 +26,7 @@ contains
     use salmon_parallel
     use salmon_communication
     use environment
-    use misc_routines, only: get_wtime
+    use misc_routines
     implicit none
 !$ integer :: omp_get_max_threads  
 

--- a/ARTED/control/inputfile.f90
+++ b/ARTED/control/inputfile.f90
@@ -22,7 +22,7 @@ module inputfile
 contains
 
   
-  subroutine read_namelist()
+  subroutine transfer_basic_input()
     use salmon_global
     use salmon_communication, only: comm_sync_all
     use Global_Variables
@@ -134,10 +134,10 @@ contains
       
     call comm_sync_all()
     return
-  end subroutine read_namelist
+  end subroutine transfer_basic_input
 
 
-  subroutine read_atomic_spiecies()
+  subroutine transfer_atomic_data()
     use salmon_global
     use salmon_parallel, only: nproc_group_global, nproc_id_global
     use salmon_communication, only: comm_is_root, comm_bcast, comm_sync_all
@@ -177,7 +177,7 @@ contains
 
     call comm_sync_all()
     return
-  end subroutine
+  end subroutine transfer_atomic_data
 
 
   subroutine transfer_input()
@@ -185,9 +185,9 @@ contains
     implicit none
     
 !    call extract_stdin()
-    call read_namelist()
+    call transfer_basic_input()
     if(entrance_option == 'reentrance')return
-    call read_atomic_spiecies()
+    call transfer_atomic_data()
 
     return
   end subroutine transfer_input

--- a/ARTED/control/inputfile.f90
+++ b/ARTED/control/inputfile.f90
@@ -31,6 +31,14 @@ contains
 ! Be careful for backup!!
     entrance_iter = 0
 
+    select case(calc_mode)
+    case('GS_RT','gs_rt')
+      iflag_calc_mode = iflag_calc_mode_gs_rt
+    case('GS','gs')
+      iflag_calc_mode = iflag_calc_mode_gs
+    case('RT','rt')
+      iflag_calc_mode = iflag_calc_mode_rt
+    end select
     
 !    namelist/control/ &
     entrance_option = trim(restart_option)

--- a/ARTED/main.f90
+++ b/ARTED/main.f90
@@ -41,6 +41,7 @@ subroutine arted
   use salmon_parallel
   use initialization
   use ground_state
+  use io_gs_wfn_k
   
   implicit none
 
@@ -49,9 +50,18 @@ subroutine arted
   nproc_size_tdks  = nproc_size_global
 
   call read_arted()
-
   call initialize
-  call calc_ground_state
+
+  select case(iflag_calc_mode)
+  case(iflag_calc_mode_gs_rt)
+    call calc_ground_state
+  case(iflag_calc_mode_gs)
+    call calc_ground_state
+    call read_write_gs_wfn_k(iflag_write)
+    return
+  case(iflag_calc_mode_rt)
+    call read_write_gs_wfn_k(iflag_read)
+  end select
 
   select case(use_ms_maxwell)
   case ('y')

--- a/ARTED/modules/global_variables.f90
+++ b/ARTED/modules/global_variables.f90
@@ -67,6 +67,7 @@ Module Global_Variables
   integer,allocatable :: Zatom(:)
   real(8),allocatable :: Mass(:),Rion_eq(:,:),dRion(:,:,:)
   real(8),allocatable :: occ(:,:),wk(:)
+  logical :: Rion_update_rt
 
 ! physical quantities
   real(8) :: Eall,Eall0,jav(3),Tion

--- a/ARTED/modules/global_variables.f90
+++ b/ARTED/modules/global_variables.f90
@@ -67,7 +67,6 @@ Module Global_Variables
   integer,allocatable :: Zatom(:)
   real(8),allocatable :: Mass(:),Rion_eq(:,:),dRion(:,:,:)
   real(8),allocatable :: occ(:,:),wk(:)
-  logical :: Rion_update_rt
 
 ! physical quantities
   real(8) :: Eall,Eall0,jav(3),Tion
@@ -214,12 +213,18 @@ Module Global_Variables
 
   logical :: need_backup      = .FALSE.
 
+  ! calculation mode flag
+  integer :: iflag_calc_mode
+  integer,parameter :: iflag_calc_mode_gs_rt = 0
+  integer,parameter :: iflag_calc_mode_gs    = 1
+  integer,parameter :: iflag_calc_mode_rt    = 2
 
-  ! calculation mode
+  ! calculation mode 
   integer, parameter :: calc_mode_gs = 1000
   integer, parameter :: calc_mode_rt = 1100
 
   ! Rion update flag
+  logical :: Rion_update_rt
   logical, parameter :: rion_update_on  = .true.
   logical, parameter :: rion_update_off = .false.
 


### PR DESCRIPTION
To reduce functional difference between ARTED and GCEED, I implemented new calculation modes (`calc_mode`): `GS`  and `RT` in addition to `GS_RT`.

- `GS` mode computes the ground state and writes the ground state wavefunctions.
- `RT` mode reads the ground state wavefunctions, which are computed in `GS` mode, and then computes the electron dynamics, 
- Now, the multi-scale simulation with `RT` mode can start based on the ground state wavefunctions from the single-cell calculation with `GS` mode.
- In the present implementation, `GS` mode writes the ground state wavefunction in `&control/directory`. Because the number of the files can be huge (as many as k-points), we should prepare an additional directory for the wavefunction data, at the latest, until the first official release. A simple solution would be to allow to use `CUTE_COMMAND_LINE`, which is supported by Fortran2008 and later.