### PR TITLE
make calculate nproc_ob etc automatically

### DIFF
--- a/GCEED/rt/CMakeLists.txt
+++ b/GCEED/rt/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
     read_input_rt.f90
     read_rt.f90
     real_time_dft.f90
+    set_numcpu_rt.f90
     taylor_coe.f90
     taylor.f90
     time_evolution_step.f90

--- a/GCEED/rt/read_input_rt.f90
+++ b/GCEED/rt/read_input_rt.f90
@@ -97,9 +97,6 @@ if(iwrite_projection==1.and.itwproj==-1)then
 end if
 
 !===== namelist for group_parallel =====
-!nproc_ob=0
-nproc_Mxin(1:3)=0
-nproc_Mxin_s(1:3)=0
 isequential=2
 imesh_s_all=1
 iflag_comm_rho=1
@@ -112,28 +109,21 @@ if(comm_is_root(nproc_id_global))then
   end if
 end if
 
-nproc_Mxin = nproc_domain
-nproc_Mxin_s = nproc_domain_s
-
-call comm_bcast(nproc_ob,          nproc_group_global)
-call comm_bcast(nproc_Mxin,        nproc_group_global)
-call comm_bcast(nproc_Mxin_s,      nproc_group_global)
 call comm_bcast(isequential,       nproc_group_global)
 call comm_bcast(num_datafiles_IN,  nproc_group_global)
 call comm_bcast(num_datafiles_OUT, nproc_group_global)
 call comm_bcast(imesh_s_all,       nproc_group_global)
 call comm_bcast(iflag_comm_rho,    nproc_group_global)
-if(comm_is_root(nproc_id_global).and.nproc_ob==0)then
-  write(*,*) "set nproc_ob."
-  stop
-else if(comm_is_root(nproc_id_global).and.nproc_Mxin(1)*nproc_Mxin(2)*nproc_Mxin(3)==0)then
-  write(*,*) "set nproc_Mxin."
-  stop
-else if(comm_is_root(nproc_id_global).and.nproc_Mxin_s(1)*nproc_Mxin_s(2)*nproc_Mxin_s(3)==0)then
-  write(*,*) "set nproc_Mxin_s."
-  stop
+
+nproc_Mxin = nproc_domain
+nproc_Mxin_s = nproc_domain_s
+
+if(nproc_ob==0.and.nproc_mxin(1)==0.and.nproc_mxin(2)==0.and.nproc_mxin(3)==0.and.  &
+                   nproc_mxin_s(1)==0.and.nproc_mxin_s(2)==0.and.nproc_mxin_s(3)==0) then
+  call set_numcpu_rt
+else
+  call check_numcpu
 end if
-call check_numcpu
 
 nproc_Mxin_mul=nproc_Mxin(1)*nproc_Mxin(2)*nproc_Mxin(3)
 nproc_Mxin_mul_s_dm=nproc_Mxin_s_dm(1)*nproc_Mxin_s_dm(2)*nproc_Mxin_s_dm(3)

--- a/GCEED/rt/set_numcpu_rt.f90
+++ b/GCEED/rt/set_numcpu_rt.f90
@@ -1,0 +1,137 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine set_numcpu_rt
+  use salmon_parallel, only: nproc_size_global
+  use scf_data
+  use new_world_sub
+  implicit none
+  integer :: ii
+  integer :: nproc_size_global_tmp
+  integer :: nproc_ob_tmp
+  integer :: nproc_mxin_tmp(3)
+  integer :: nproc_mxin_s_tmp(3)
+  
+  integer :: num_factor2
+  integer :: ir_num_factor2  ! ir means ireduced
+  integer :: num_factor3
+  integer :: num_factor5
+
+  integer :: icount
+ 
+  nproc_size_global_tmp=nproc_size_global
+  
+  ! this code treats the situation that nproc_size_global is less than or equal to 48,828,125
+
+  num_factor2=0  
+  do ii=1,26
+    if(mod(nproc_size_global_tmp,2)==0)then
+      num_factor2=num_factor2+1
+      nproc_size_global_tmp=nproc_size_global_tmp/2
+    end if
+  end do
+  
+  num_factor3=0  
+  do ii=1,17
+    if(mod(nproc_size_global_tmp,3)==0)then
+      num_factor3=num_factor3+1
+      nproc_size_global_tmp=nproc_size_global_tmp/3
+    end if
+  end do
+  
+  num_factor5=0  
+  do ii=1,11
+    if(mod(nproc_size_global_tmp,5)==0)then
+      num_factor5=num_factor5+1
+      nproc_size_global_tmp=nproc_size_global_tmp/5
+    end if
+  end do
+  
+  if(nproc_size_global_tmp/=1)then
+    stop "In automatic process assignment, prime factors for number of processes must be combination of 2, 3 or 5."
+  end if
+
+
+  if(num_factor2>=3)then
+    nproc_ob_tmp=nproc_size_global/8
+    nproc_mxin_tmp(1)=2 
+    nproc_mxin_tmp(2)=2 
+    nproc_mxin_tmp(3)=2 
+    icount=0
+    ir_num_factor2=num_factor2-3
+  else if(num_factor2==2)then
+    nproc_ob_tmp=nproc_size_global/4
+    nproc_mxin_tmp(1)=1 
+    nproc_mxin_tmp(2)=2 
+    nproc_mxin_tmp(3)=2 
+    icount=2
+    ir_num_factor2=num_factor2-2
+  else if(num_factor2==1)then
+    nproc_ob_tmp=nproc_size_global/2
+    nproc_mxin_tmp(1)=1 
+    nproc_mxin_tmp(2)=1 
+    nproc_mxin_tmp(3)=2 
+    icount=1
+    ir_num_factor2=num_factor2-1
+  else
+    nproc_ob_tmp=nproc_size_global
+    nproc_mxin_tmp(1)=1 
+    nproc_mxin_tmp(2)=1 
+    nproc_mxin_tmp(3)=1 
+    icount=0
+    ir_num_factor2=num_factor2
+  end if
+
+  nproc_mxin_s_tmp(1:3)=nproc_mxin_tmp(1:3)
+
+  do ii=1,num_factor5
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_s_tmp(3)=nproc_mxin_s_tmp(3)*5
+    else if(mod(icount,3)==2)then
+      nproc_mxin_s_tmp(2)=nproc_mxin_s_tmp(2)*5
+    else
+      nproc_mxin_s_tmp(1)=nproc_mxin_s_tmp(1)*5
+    end if
+  end do
+
+  do ii=1,num_factor3
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_s_tmp(3)=nproc_mxin_s_tmp(3)*3
+    else if(mod(icount,3)==2)then
+      nproc_mxin_s_tmp(2)=nproc_mxin_s_tmp(2)*3
+    else
+      nproc_mxin_s_tmp(1)=nproc_mxin_s_tmp(1)*3
+    end if
+  end do
+
+  do ii=1,ir_num_factor2
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_s_tmp(3)=nproc_mxin_s_tmp(3)*2
+    else if(mod(icount,3)==2)then
+      nproc_mxin_s_tmp(2)=nproc_mxin_s_tmp(2)*2
+    else
+      nproc_mxin_s_tmp(1)=nproc_mxin_s_tmp(1)*2
+    end if
+  end do
+
+  nproc_ob=nproc_ob_tmp
+  nproc_mxin(1:3)=nproc_mxin_tmp(1:3)
+  nproc_mxin_s(1:3)=nproc_mxin_s_tmp(1:3)
+  nproc_mxin_s_dm(1:3)=nproc_mxin_s(1:3)/nproc_mxin(1:3)
+  
+end subroutine set_numcpu_rt

--- a/GCEED/scf/CMakeLists.txt
+++ b/GCEED/scf/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     real_space_dft.f90
     rmmdiis_eigen.f90
     rmmdiis.f90
+    set_numcpu_scf.f90
     simple_mixing.f90
     structure_opt.f90
     subdgemm_lapack.f90

--- a/GCEED/scf/read_input_scf.f90
+++ b/GCEED/scf/read_input_scf.f90
@@ -206,9 +206,6 @@ else if(ilsda == 1) then
 end if
 
 !===== namelist for group_parallel =====
-!nproc_ob=0
-nproc_Mxin(1:3)=0
-nproc_Mxin_s(1:3)=0
 isequential=2
 imesh_s_all=1
 if(comm_is_root(nproc_id_global))then
@@ -228,28 +225,20 @@ if(comm_is_root(nproc_id_global))then
   end if
 end if
 
-nproc_Mxin = nproc_domain
-nproc_Mxin_s = nproc_domain_s
-
-call comm_bcast(nproc_ob,          nproc_group_global)
-call comm_bcast(nproc_Mxin,        nproc_group_global)
-call comm_bcast(nproc_Mxin_s,      nproc_group_global)
 call comm_bcast(isequential,       nproc_group_global)
 call comm_bcast(num_datafiles_IN,  nproc_group_global)
 call comm_bcast(num_datafiles_OUT, nproc_group_global)
 call comm_bcast(imesh_s_all,       nproc_group_global)
-if(comm_is_root(nproc_id_global).and.nproc_ob==0)then
-  write(*,*) "set nproc_ob."
-  stop
-else if(comm_is_root(nproc_id_global).and.nproc_Mxin(1)*nproc_Mxin(2)*nproc_Mxin(3)==0)then
-  write(*,*) "set nproc_Mxin."
-  stop
-else if(comm_is_root(nproc_id_global).and.nproc_Mxin_s(1)*nproc_Mxin_s(2)*nproc_Mxin_s(3)==0)then
-  write(*,*) "set nproc_Mxin_s."
-  stop
-end if
 
-call check_numcpu
+nproc_Mxin = nproc_domain
+nproc_Mxin_s = nproc_domain_s
+
+if(nproc_ob==0.and.nproc_mxin(1)==0.and.nproc_mxin(2)==0.and.nproc_mxin(3)==0.and.  &
+                   nproc_mxin_s(1)==0.and.nproc_mxin_s(2)==0.and.nproc_mxin_s(3)==0) then
+  call set_numcpu_scf
+else
+  call check_numcpu
+end if
 
 nproc_Mxin_mul=nproc_Mxin(1)*nproc_Mxin(2)*nproc_Mxin(3)
 nproc_Mxin_mul_s_dm=nproc_Mxin_s_dm(1)*nproc_Mxin_s_dm(2)*nproc_Mxin_s_dm(3)

--- a/GCEED/scf/set_numcpu_scf.f90
+++ b/GCEED/scf/set_numcpu_scf.f90
@@ -1,0 +1,105 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine set_numcpu_scf
+  use salmon_parallel, only: nproc_size_global
+  use scf_data
+  use new_world_sub
+  implicit none
+  integer :: ii
+  integer :: nproc_size_global_tmp
+  integer :: nproc_mxin_tmp(3)
+  
+  integer :: num_factor2
+  integer :: num_factor3
+  integer :: num_factor5
+
+  integer :: icount
+ 
+  nproc_size_global_tmp=nproc_size_global
+  
+  ! this code treats the situation that nproc_size_global is less than or equal to 48,828,125
+  
+  num_factor2=0
+  do ii=1,26
+    if(mod(nproc_size_global_tmp,2)==0)then
+      num_factor2=num_factor2+1
+      nproc_size_global_tmp=nproc_size_global_tmp/2
+    end if
+  end do
+  
+  num_factor3=0
+  do ii=1,17
+    if(mod(nproc_size_global_tmp,3)==0)then
+      num_factor3=num_factor3+1
+      nproc_size_global_tmp=nproc_size_global_tmp/3
+    end if
+  end do
+  
+  num_factor5=0
+  do ii=1,11
+    if(mod(nproc_size_global_tmp,5)==0)then
+      num_factor5=num_factor5+1
+      nproc_size_global_tmp=nproc_size_global_tmp/5
+    end if
+  end do
+  
+  if(nproc_size_global_tmp/=1)then
+    stop "In automatic process assignment, prime factors for number of processes must be combination of 2, 3 or 5."
+  end if
+
+  nproc_mxin_tmp(1:3)=1
+ 
+  icount=0
+
+  do ii=1,num_factor5
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_tmp(3)=nproc_mxin_tmp(3)*5
+    else if(mod(icount,3)==2)then
+      nproc_mxin_tmp(2)=nproc_mxin_tmp(2)*5
+    else
+      nproc_mxin_tmp(1)=nproc_mxin_tmp(1)*5
+    end if
+  end do
+
+  do ii=1,num_factor3
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_tmp(3)=nproc_mxin_tmp(3)*3
+    else if(mod(icount,3)==2)then
+      nproc_mxin_tmp(2)=nproc_mxin_tmp(2)*3
+    else
+      nproc_mxin_tmp(1)=nproc_mxin_tmp(1)*3
+    end if
+  end do
+
+  do ii=1,num_factor2
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_tmp(3)=nproc_mxin_tmp(3)*2
+    else if(mod(icount,3)==2)then
+      nproc_mxin_tmp(2)=nproc_mxin_tmp(2)*2
+    else
+      nproc_mxin_tmp(1)=nproc_mxin_tmp(1)*2
+    end if
+  end do
+
+  nproc_ob=1
+  nproc_mxin(1:3)=nproc_mxin_tmp(1:3)
+  nproc_mxin_s(1:3)=nproc_mxin_tmp(1:3)
+  nproc_mxin_s_dm(1:3)=nproc_mxin_s(1:3)/nproc_mxin(1:3)
+  
+end subroutine set_numcpu_scf

--- a/example/C2H2/intel/C2H2_gs.inp
+++ b/example/C2H2/intel/C2H2_gs.inp
@@ -9,11 +9,6 @@
 &control
   sysname = 'C2H2'
 /
-&parallel
-  nproc_ob = 1
-  nproc_domain = 1,1,1
-  nproc_domain_s = 1,1,1
-/
 &system
   iperiodic = 0
   al = 16d0, 16d0, 16d0

--- a/example/C2H2/intel/C2H2_rt_pulse.inp
+++ b/example/C2H2/intel/C2H2_rt_pulse.inp
@@ -9,11 +9,6 @@
 &control
   sysname = 'C2H2'
 /
-&parallel
-  nproc_ob = 1
-  nproc_domain = 1,1,1
-  nproc_domain_s = 1,1,1
-/
 &system
   iperiodic = 0
   al = 16d0, 16d0, 16d0

--- a/example/C2H2/intel/C2H2_rt_response.inp
+++ b/example/C2H2/intel/C2H2_rt_response.inp
@@ -9,11 +9,6 @@
 &control
   sysname = 'C2H2'
 /
-&parallel
-  nproc_ob = 1
-  nproc_domain = 1,1,1
-  nproc_domain_s = 1,1,1
-/
 &system
   iperiodic = 0
   al = 16d0, 16d0, 16d0


### PR DESCRIPTION
I think most people are being busy. But I think the pass of this PR makes all users happy. 
So could someone please merge this PR?

This modification enables users to run the code without any specification of namelist "parallel". 
If users use default values and use number of processers with the combination of prime factors including 2, 3 and 5, the code for the GCEED part automatically assigns nproc_ob, nproc_domain, and nproc_domain_s.  

I've checked for the GCEED part on FX10, and confirmed that results with 12, 144, and 160 processors
are not different.

At the moment, even if number of processes is too large compared with the system size, the calculation continues to run with giving wrong results. Maybe I'll modify this by next release of SALMON. In addition, I'll modify the manual too. 