### PR TITLE
Modify the density of states calculation routine in 3d periodic case

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -759,6 +759,39 @@ If <code>'y'</code>, density of state is output.
 Default is <code>'n'</code>.
 </dd>
 
+<dt>out_dos_start; <code>Real(8)</code>; 3d</dt>
+<dd>
+Start point (energy) of the density of state spectra.
+Default value is <code>-3.0</code> eV.
+</dd>
+
+<dt>out_dos_end; <code>Real(8)</code>; 3d</dt>
+<dd>
+End point (energy) of the density of state spectra.
+Default value is <code>3.0</code> eV.
+</dd>
+
+<dt>out_dos_method; <code>Character</code>; 3d</dt>
+<dd>
+Choise of smearing method for the density of state spectra.
+<code>gaussian</code> and <code>lorentzian</code> function are available.
+Default is <code>gaussian</code>.
+</dd>
+
+<dt>out_dos_smearing; <code>Real(8)</code>; 3d</dt>
+<dd>
+Smearing width of the density of state spectra.
+Default is <code>0.1</code> eV.
+</dd>
+
+<dt>out_dos_fshift; <code>Character</code>; 3d</dt>
+<dd>
+If <code>'y'</code>, the electron energy is shifted to fix the Fermi energy as zero point.
+Default is <code>'n'</code>.
+</dd>
+
+
+
 <dt>out_pdos; <code>Character</code>; 0d</dt>
 <dd>
 If <code>'y'</code>, projected density of state is output.
@@ -863,7 +896,3 @@ Default is <code>0.5</code>.
 </dd>
 
 </dl>
-
-
-
-

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -331,6 +331,12 @@ contains
       & out_dos, &
       & out_pdos, &
       & out_dns, &
+      & out_dos_start, &
+      & out_dos_end, &
+      & out_dos_nenergy, &
+      & out_dos_smearing, &
+      & out_dos_method, &
+      & out_dos_fshift, &
       & out_elf, &
       & out_dns_rt, &
       & out_dns_rt_step, &
@@ -495,6 +501,12 @@ contains
     de                  = (0.01d0/au_energy_ev)*uenergy_from_au  ! eV
     out_psi             = 'n'
     out_dos             = 'n'
+    out_dos_start       = -3.00d0 / au_energy_ev * uenergy_from_au
+    out_dos_end         = +3.00d0 / au_energy_ev * uenergy_from_au
+    out_dos_nenergy     = 601
+    out_dos_smearing    = 0.1d0 / au_energy_ev * uenergy_from_au
+    out_dos_method      = 'gaussian'
+    out_dos_fshift      = 'n'
     out_pdos            = 'n'
     out_dns             = 'n'
     out_elf             = 'n'
@@ -705,6 +717,15 @@ contains
     de = de * uenergy_to_au
     call comm_bcast(out_psi            ,nproc_group_global)
     call comm_bcast(out_dos            ,nproc_group_global)
+    call comm_bcast(out_dos_start      ,nproc_group_global)
+    out_dos_start = out_dos_start * uenergy_to_au
+    call comm_bcast(out_dos_end        ,nproc_group_global)
+    out_dos_end = out_dos_end * uenergy_to_au
+    call comm_bcast(out_dos_nenergy    ,nproc_group_global)
+    call comm_bcast(out_dos_smearing   ,nproc_group_global)
+    out_dos_smearing = out_dos_smearing * uenergy_to_au
+    call comm_bcast(out_dos_method     ,nproc_group_global)
+    call comm_bcast(out_dos_fshift     ,nproc_group_global)
     call comm_bcast(out_pdos           ,nproc_group_global)
     call comm_bcast(out_dns            ,nproc_group_global)
     call comm_bcast(out_elf            ,nproc_group_global)
@@ -1124,6 +1145,12 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'de', de
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_psi', out_psi
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos', out_dos
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_start', out_dos_start
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_end', out_dos_end
+      write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_dos_nenergy', out_dos_nenergy
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_smearing', out_dos_smearing
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos_method', out_dos_method
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos_fshift', out_dos_fshift
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_pdos', out_pdos
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dns', out_dns
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_elf', out_elf
@@ -1177,6 +1204,3 @@ contains
   end subroutine dump_input_common
     
 end module inputoutput
-
-
-

--- a/modules/salmon_global.f90
+++ b/modules/salmon_global.f90
@@ -174,6 +174,12 @@ module salmon_global
   real(8)        :: de
   character(1)   :: out_psi
   character(1)   :: out_dos
+  real(8)        :: out_dos_start
+  real(8)        :: out_dos_end
+  integer        :: out_dos_nenergy
+  real(8)        :: out_dos_smearing
+  character(16)  :: out_dos_method
+  character(1)   :: out_dos_fshift
   character(1)   :: out_pdos
   character(1)   :: out_dns
   character(1)   :: out_elf


### PR DESCRIPTION
## About this PR

This pull request contains some modifications in the density of state (DoS) calculation in ARTED part.
- Provide two different smearing method (Lorentzian and Gaussian).
- Add input parameters to specify "energy range of DoS spectra", "smelling method", "smearing width".
- Use the user specified unit system in `SYSNAME_DoS.out` file
- Add switch to control the zero point to energy
- Change the normalization of DoS from "per Volume" to "per Unit cell"

In this modification, the following input parameters are added in the `analysis` group:
- `out_dos_start` : Lower limit enegy of the DoS spectra
- `out_dos_end` : Upper limit energy of the DoS spectra
- `out_dos_nenergy` : Number of sampling points
- `out_dos_method` : Smearing method `gaussian`/`lorentzian`
- `out_dos_smearing`: Smearing width
- `out_dos_fshift`: Switch ('y'/'n') to shift the Fermi energy to the zero point of electron energy.

## Future work
- Add the corresponding implimentation to the GCEED part.