### PR TITLE
remove variable "rmixrate" in input file

### DIFF
--- a/example/C2H2/intel/C2H2_gs.inp
+++ b/example/C2H2/intel/C2H2_gs.inp
@@ -31,7 +31,6 @@
   dl = 0.25d0, 0.25d0, 0.25d0
 /
 &scf
-  rmixrate = 0.1d0
   ncg = 4
   nscf = 1000
 /


### PR DESCRIPTION
At the moment, a default for mixing density in the GCEED part is Broyden's method and rmixrate isn't used when the Bryoden's method is used. It's confusing to leave this variable, so I remove it. I checked that it runs successfully for the ARTED part and the GCEED part.