### PR TITLE
Add salmon_file module

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    salmon_file.f90
     inputoutput.f90
     salmon_global.f90
     salmon_parallel.f90

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -23,12 +23,12 @@ module inputoutput
   real(8),parameter :: au_length_aa = 0.52917721067d0
 
 
-  integer, parameter :: fh_variables_log = 801
-  integer, parameter :: fh_namelist = 901
-  integer, parameter :: fh_atomic_spiecies = 902
-  integer, parameter :: fh_atomic_coor = 903
-  integer, parameter :: fh_reentrance = 904
-  integer, parameter :: fh_atomic_red_coor = 905
+  integer :: fh_variables_log
+  integer :: fh_namelist
+!  integer, parameter :: fh_atomic_spiecies = 902
+  integer :: fh_atomic_coor
+  integer :: fh_reentrance
+  integer :: fh_atomic_red_coor
   logical :: if_nml_coor, if_nml_red_coor
 
   integer :: inml_calculation
@@ -121,23 +121,28 @@ contains
   subroutine read_stdin
     use salmon_parallel, only: nproc_id_global
     use salmon_communication, only: comm_is_root
+    use salmon_file, only: get_filehandle
     implicit none
 
-    integer :: cur = fh_namelist
+    integer :: cur 
     integer :: ret = 0
     character(100) :: buff, text
+        
 
-
-    
     if (comm_is_root(nproc_id_global)) then
+      fh_namelist = get_filehandle()
       open(fh_namelist, file='.namelist.tmp', status='replace')
 !      open(fh_atomic_spiecies, file='.atomic_spiecies.tmp', status='replace')
-      if_nml_coor =.false. 
+      if_nml_coor =.false.
+      fh_atomic_coor = get_filehandle()
       open(fh_atomic_coor, file='.atomic_coor.tmp', status='replace')
       if_nml_red_coor = .false.
+      fh_atomic_red_coor = get_filehandle()
       open(fh_atomic_red_coor, file='.atomic_red_coor.tmp', status='replace')
+      fh_reentrance = get_filehandle()
       open(fh_reentrance, file='.reenetrance.tmp', status='replace')
       
+      cur = fh_namelist
       do while (.true.)
         read(*, '(a)', iostat=ret) buff
         if (ret < 0) then
@@ -192,6 +197,7 @@ contains
   subroutine read_input_common
     use salmon_parallel
     use salmon_communication
+    use salmon_file, only: get_filehandle
     implicit none
     integer :: ii
 
@@ -633,6 +639,7 @@ contains
 
 
     if (comm_is_root(nproc_id_global)) then
+      fh_namelist = get_filehandle()
       open(fh_namelist, file='.namelist.tmp', status='old')
 
       read(fh_namelist, nml=calculation, iostat=inml_calculation)
@@ -1140,12 +1147,14 @@ contains
   subroutine dump_input_common
     use salmon_parallel
     use salmon_communication
+    use salmon_file, only: get_filehandle
     implicit none
     integer :: i,ierr_nml
     ierr_nml = 0
 
     if (comm_is_root(nproc_id_global)) then
 
+      fh_variables_log = get_filehandle()
       open(fh_variables_log,file='variables.log')
 
       if(inml_calculation >0)ierr_nml = ierr_nml +1

--- a/modules/salmon_file.f90
+++ b/modules/salmon_file.f90
@@ -1,0 +1,41 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+!-----------------------------------------------------------------------------------------
+module salmon_file
+  implicit none
+  private
+
+  integer, parameter :: fh_start = 1000
+
+  public :: get_filehandle
+contains
+!--------------------------------------------------------------------------------
+!! Return a unit number available to open file
+  integer function get_filehandle() result(fh)
+    implicit none
+    logical :: flag
+    
+    fh = fh_start - 1
+    flag = .true.
+    do while (flag)
+      fh = fh + 1
+      inquire(unit=fh, opened=flag)
+    end do
+    return
+  end function get_filehandle
+  
+end module salmon_file
+!--------------------------------------------------------------------------------


### PR DESCRIPTION
## About This Pull Request

This modification adds a shared module `salmon_file` which provides an automatic assignation of IO unit: `get_filehandle`. 
And, in this time, the IO unit definition in `inputoutput` module is modified to utilize `get_filehandle` function.

## Usage
- Get the available unit number by `get_filehandle` function just before using `open` method.

```
use salmon_file, only: get_filehandle
implicit none

integer :: fh_example

fh_example = get_filehandle() 
open(fh_example, file='example', status='old')
write(fh_example, *) "hello world"
close(fh_example)
```

## Future Works
- Currently, the assignation of  IO unit is very complicated and distributed to many source files in SALMON. Since I guess this situation is not clear for the maintenance, I recommend replacing the present IO unit assignation to proposed method.
