### PR TITLE
Enabled to specify grid spacing for ARTED part

### DIFF
--- a/ARTED/control/inputfile.f90
+++ b/ARTED/control/inputfile.f90
@@ -64,29 +64,29 @@ contains
 !    namelist/rgrid/ &
 !            Nd,   ! Removed from input
     if(sum(abs(num_rgrid)) /= 0 .and. sum(abs(dl)) /= 0d0)then
-      call err_finalize('num_rgrid and dl are incompatible input parameters.')
-    else if(sum(abs(dl)) == 0d0)then
+      call err_finalize('Error: [num_rgrid] and [dl] are incompatible input parameters.')
+    else if(sum(abs(num_rgrid)) /= 0 .and. sum(abs(dl)) == 0d0)then
       NLx = num_rgrid(1)
       NLy = num_rgrid(2)
       NLz = num_rgrid(3)
-    else if(sum(abs(num_rgrid)) == 0d0)then
+    else if(sum(abs(num_rgrid)) == 0d0 .and. sum(abs(dl)) /= 0d0)then
       NLx = nint(al(1)/dl(1))
       NLy = nint(al(2)/dl(2))
       NLz = nint(al(3)/dl(3))
       if(comm_is_root(nproc_id_global))then
         write(*,"(A)")"Grid number [num_rgrid(3)] is computed from Grid spacing [dl(3)]."
-        write(*,"(A,2x,I7)")"num_rgrid(1)=",num_rgrid(1)
-        write(*,"(A,2x,I7)")"num_rgrid(2)=",num_rgrid(2)
-        write(*,"(A,2x,I7)")"num_rgrid(3)=",num_rgrid(3)
+        write(*,"(A,2x,I7)")"num_rgrid(1)=",NLx
+        write(*,"(A,2x,I7)")"num_rgrid(2)=",NLy
+        write(*,"(A,2x,I7)")"num_rgrid(3)=",NLz
         write(*,"(A)")"Actual grid spacing becomes:"
-        write(*,"(A,2x,e16.6e3)")"dl(1))=",al(1)/NLx
-        write(*,"(A,2x,e16.6e3)")"dl(1))=",al(2)/NLy
-        write(*,"(A,2x,e16.6e3)")"dl(1))=",al(3)/NLz
+        write(*,"(A,2x,e16.6e3,A)")"dl(1)=",al(1)/NLx," [Bohr]"
+        write(*,"(A,2x,e16.6e3,A)")"dl(2)=",al(2)/NLy," [Bohr]"
+        write(*,"(A,2x,e16.6e3,A)")"dl(3)=",al(3)/NLz," [Bohr]"
         write(*,"(A)")"Warning: actual grid spacing can be different from input"
         write(*,"(A)")"so that the lattice parameter is divisible by the spacing."
       end if
     else
-      call err_finalize('num_rgrid or dl should be specified in input.')
+      call err_finalize('Error: [num_rgrid] or [dl] should be specified in input.')
     end if
 
 !! Comment: S.A.S 2017/06/04

--- a/ARTED/control/inputfile.f90
+++ b/ARTED/control/inputfile.f90
@@ -24,7 +24,9 @@ contains
   
   subroutine transfer_basic_input()
     use salmon_global
-    use salmon_communication, only: comm_sync_all
+    use salmon_communication, only: comm_sync_all, &
+                                    comm_is_root
+    use salmon_parallel, only: nproc_id_global
     use Global_Variables
     implicit none
 
@@ -61,9 +63,32 @@ contains
 
 !    namelist/rgrid/ &
 !            Nd,   ! Removed from input
-    NLx = num_rgrid(1)
-    NLy = num_rgrid(2)
-    NLz = num_rgrid(3)
+    if(sum(abs(num_rgrid)) /= 0 .and. sum(abs(dl)) /= 0d0)then
+      call err_finalize('num_rgrid and dl are incompatible input parameters.')
+    else if(sum(abs(dl)) == 0d0)then
+      NLx = num_rgrid(1)
+      NLy = num_rgrid(2)
+      NLz = num_rgrid(3)
+    else if(sum(abs(num_rgrid)) == 0d0)then
+      NLx = nint(al(1)/dl(1))
+      NLy = nint(al(2)/dl(2))
+      NLz = nint(al(3)/dl(3))
+      if(comm_is_root(nproc_id_global))then
+        write(*,"(A)")"Grid number [num_rgrid(3)] is computed from Grid spacing [dl(3)]."
+        write(*,"(A,2x,I7)")"num_rgrid(1)=",num_rgrid(1)
+        write(*,"(A,2x,I7)")"num_rgrid(2)=",num_rgrid(2)
+        write(*,"(A,2x,I7)")"num_rgrid(3)=",num_rgrid(3)
+        write(*,"(A)")"Actual grid spacing becomes:"
+        write(*,"(A,2x,e16.6e3)")"dl(1))=",al(1)/NLx
+        write(*,"(A,2x,e16.6e3)")"dl(1))=",al(2)/NLy
+        write(*,"(A,2x,e16.6e3)")"dl(1))=",al(3)/NLz
+        write(*,"(A)")"Warning: actual grid spacing can be different from input"
+        write(*,"(A)")"so that the lattice parameter is divisible by the spacing."
+      end if
+    else
+      call err_finalize('num_rgrid or dl should be specified in input.')
+    end if
+
 !! Comment: S.A.S 2017/06/04
 !! conversion from dl to num_rgrid(3) should be implemented
 

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -366,11 +366,15 @@ Default is <code>'1.0'</code>.
 ## &rgrid
 <dl>
 
-<dt>dl(3); <code>Real(8)</code>; 0d</dt>
+<dt>dl(3); <code>Real(8)</code>; 0d/3d</dt>
 <dd>Spacing of real-space grids. Unit of length can be chosen by
 <code>&units/unit_length</code>.
 This valiable cannot be set with 
 <code>&rgrid/num_rgrid</code>.
+If <code>&system/iperiodic</code> is set to <code>3</code>,
+the actual grid spacing is automatically refined in calculations
+so that the size of the simulation box
+<code>&system/al(3)</code> becomes divisible by the spacing.
 </dd>
 
 


### PR DESCRIPTION
I enabled to use the grid spacing `%rgrid/dl(3)` in input for ARTED. 

SALMON internally computes the number of grid points `%rgrid/num_rgrid(3)` as the nearest integer to the ratio of the size of the cell `%system/al(3)` to the spacing `%rgrid/dl(3)`. 
Therefore, actual grid spacing in calculations is slightly modified.