### PR TITLE
Add automatic range assumption of DoS output

### DIFF
--- a/ARTED/GS/write_GS_data.f90
+++ b/ARTED/GS/write_GS_data.f90
@@ -114,21 +114,25 @@ Subroutine write_GS_data
     subroutine dos_write
       use inputoutput, only: t_unit_energy_inv, t_unit_energy
       implicit none
-      real(8) :: vbmax, cbmin, efermi, eshift
+      real(8) :: vbmax, vbmin, cbmax, cbmin, efermi, eshift
       real(8) :: ww, fk, dw
       integer :: iw
-      real(8), allocatable :: dos(:), dos_l(:)  
-      
-      allocate(dos(out_dos_nenergy), dos_l(out_dos_nenergy))
-      
+      real(8) :: dos(out_dos_nenergy), dos_l(out_dos_nenergy)  
+    
+      vbmin = minval(esp_vb_min)
+      vbmax = maxval(esp_vb_max)
+      cbmin = minval(esp_cb_min)
+      cbmax = maxval(esp_cb_max)
+    
       if (out_dos_fshift == 'y') then
-        vbmax = maxval(esp_vb_max)
-        cbmin = minval(esp_cb_min)
         efermi = (vbmax + cbmin) * 0.5d0
         eshift = efermi
       else
         eshift = 0d0
       endif
+      
+      out_dos_start = max(out_dos_start, vbmin-eshift-out_dos_smearing*2)
+      out_dos_end = min(out_dos_end, cbmax-eshift+out_dos_smearing*2)
       
       dos_l = 0d0
       dw = (out_dos_end - out_dos_start) / (out_dos_nenergy - 1)

--- a/ARTED/GS/write_GS_data.f90
+++ b/ARTED/GS/write_GS_data.f90
@@ -23,8 +23,8 @@ Subroutine write_GS_data
                          & out_dos_smearing, &
                          & out_dos_method, &
                          & out_dos_fshift
-  use salmon_parallel, only: nproc_id_global, nproc_group_tdks
-  use salmon_communication, only: comm_is_root,comm_summation
+  use salmon_parallel, only: nproc_group_global, nproc_id_global, nproc_group_tdks
+  use salmon_communication, only: comm_is_root,comm_summation, comm_bcast
   implicit none
   integer ik,ib,ia,iter,j
 
@@ -114,25 +114,31 @@ Subroutine write_GS_data
     subroutine dos_write
       use inputoutput, only: t_unit_energy_inv, t_unit_energy
       implicit none
-      real(8) :: vbmax, vbmin, cbmax, cbmin, efermi, eshift
+      real(8) :: vbmax, cbmin, emax, emin, efermi, eshift
       real(8) :: ww, fk, dw
       integer :: iw
       real(8) :: dos(out_dos_nenergy), dos_l(out_dos_nenergy)  
     
-      vbmin = minval(esp_vb_min)
-      vbmax = maxval(esp_vb_max)
-      cbmin = minval(esp_cb_min)
-      cbmax = maxval(esp_cb_max)
-    
-      if (out_dos_fshift == 'y') then
-        efermi = (vbmax + cbmin) * 0.5d0
-        eshift = efermi
-      else
-        eshift = 0d0
-      endif
+      if (comm_is_root(nproc_id_global)) then
+
+        emin = minval(esp(:,:))
+        emax = maxval(esp(:,:))
+        cbmin = minval(esp_cb_min(:))
+        vbmax = maxval(esp_vb_max(:))
       
-      out_dos_start = max(out_dos_start, vbmin-eshift-out_dos_smearing*2)
-      out_dos_end = min(out_dos_end, cbmax-eshift+out_dos_smearing*2)
+        if (out_dos_fshift == 'y') then
+          efermi = (vbmax + cbmin) * 0.5d0
+          eshift = efermi
+        else
+          eshift = 0d0
+        endif
+      end if
+      call comm_bcast(emin,nproc_group_global)
+      call comm_bcast(emax,nproc_group_global)
+      call comm_bcast(eshift,nproc_group_global)
+      
+      out_dos_start = max(out_dos_start, emin-eshift-out_dos_smearing*2)
+      out_dos_end = min(out_dos_end, emax-eshift+out_dos_smearing*2)
       
       dos_l = 0d0
       dw = (out_dos_end - out_dos_start) / (out_dos_nenergy - 1)

--- a/GCEED/scf/calc_dos.f90
+++ b/GCEED/scf/calc_dos.f90
@@ -28,18 +28,21 @@ real(8) :: dos_l_tmp(1:out_dos_nenergy)
 real(8) :: dos_l(1:out_dos_nenergy)
 real(8) :: fk,ww,dw
 integer :: iw
-real(8) :: ene_homo,ene_lumo,efermi,eshift
+real(8) :: ene_homo,ene_lumo,ene_min,ene_max,efermi,eshift
 
 call calc_pmax(iobmax)
-
+ene_min = minval(esp(:,1))
+ene_max = maxval(esp(:,1))
+ene_homo = esp(nelec/2,1)
+ene_lumo = esp(nelec/2+1,1)
 if(out_dos_fshift=='y'.and.nstate>nelec/2) then 
-  ene_homo = esp(nelec/2,1)
-  ene_lumo = esp(nelec/2+1,1)
   efermi = (ene_homo+ene_lumo)*0.5d0 
   eshift = efermi 
 else 
   eshift = 0.d0 
 endif 
+out_dos_start = max(out_dos_start, ene_min-eshift-out_dos_smearing*2)
+out_dos_end = min(out_dos_end, ene_max-eshift+out_dos_smearing*2)
 dw=(out_dos_end-out_dos_start)/dble(out_dos_nenergy-1) 
 
 dos_l_tmp=0.d0

--- a/GCEED/scf/calc_pdos.f90
+++ b/GCEED/scf/calc_pdos.f90
@@ -38,10 +38,12 @@ real(8) :: pdos_l(out_dos_nenergy,0:4,MI)
 character(100) :: Outfile
 real(8) :: fk,ww,dw
 integer :: iw
-real(8) :: ene_homo,ene_lumo,efermi,eshift
+real(8) :: ene_homo,ene_lumo,ene_min,ene_max,efermi,eshift
 
 call calc_pmax(iobmax)
 
+ene_min = minval(esp(:,1))
+ene_max = maxval(esp(:,1))
 if(out_dos_fshift=='y'.and.nstate>nelec/2) then 
   ene_homo = esp(nelec/2,1)
   ene_lumo = esp(nelec/2+1,1)
@@ -50,6 +52,8 @@ if(out_dos_fshift=='y'.and.nstate>nelec/2) then
 else 
   eshift = 0d0 
 endif 
+out_dos_start = max(out_dos_start, ene_min-eshift-out_dos_smearing*2)
+out_dos_end = min(out_dos_end, ene_max-eshift+out_dos_smearing*2)
 dw=(out_dos_end-out_dos_start)/dble(out_dos_nenergy-1) 
 
 pdos_l_tmp=0.d0

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -564,8 +564,8 @@ contains
     de                  = (0.01d0/au_energy_ev)*uenergy_from_au  ! eV
     out_psi             = 'n'
     out_dos             = 'n'
-    out_dos_start       = -3.00d0 / au_energy_ev * uenergy_from_au
-    out_dos_end         = +3.00d0 / au_energy_ev * uenergy_from_au
+    out_dos_start       = -1.d10 / au_energy_ev * uenergy_from_au
+    out_dos_end         = +1.d10 / au_energy_ev * uenergy_from_au
     out_dos_nenergy     = 601
     out_dos_smearing    = 0.1d0 / au_energy_ev * uenergy_from_au
     out_dos_method      = 'gaussian'


### PR DESCRIPTION
## About This Pull Request
This pull request provides the automatic range estimation of DoS output for ARTED and GCEED section. 
- This PR is related to the issue (https://github.com/SALMON-TDDFT/SALMON/issues/122).
- In this implementation, if the input variable `out_dos_start` / `out_dos_end` exceeds the minimal/maximal value of the electron eigenenergies, the upper/lower bound of plot region is clipped inside the electron energy range.
- By default, the plot range is automatically fixed on energy region as above.
