### PR TITLE
modify dos and pdos

### DIFF
--- a/ARTED/GS/write_GS_data.f90
+++ b/ARTED/GS/write_GS_data.f90
@@ -19,7 +19,7 @@ Subroutine write_GS_data
   use salmon_global, only: out_dos, &
                          & out_dos_start, &
                          & out_dos_end, &
-                         & out_dos_nenergy, &
+                         & iout_dos_nenergy, &
                          & out_dos_smearing, &
                          & out_dos_method, &
                          & out_dos_fshift
@@ -117,7 +117,7 @@ Subroutine write_GS_data
       real(8) :: vbmax, cbmin, emax, emin, efermi, eshift
       real(8) :: ww, fk, dw
       integer :: iw
-      real(8) :: dos(out_dos_nenergy), dos_l(out_dos_nenergy)  
+      real(8) :: dos(iout_dos_nenergy), dos_l(iout_dos_nenergy)  
     
       if (comm_is_root(nproc_id_global)) then
 
@@ -137,11 +137,11 @@ Subroutine write_GS_data
       call comm_bcast(emax,nproc_group_global)
       call comm_bcast(eshift,nproc_group_global)
       
-      out_dos_start = max(out_dos_start, emin-eshift-out_dos_smearing*2)
-      out_dos_end = min(out_dos_end, emax-eshift+out_dos_smearing*2)
+      out_dos_start = emin - 0.25d0 * (emax - emin)
+      out_dos_end = emax + 0.25d0 * (emax - emin)
       
       dos_l = 0d0
-      dw = (out_dos_end - out_dos_start) / (out_dos_nenergy - 1)
+      dw = (out_dos_end - out_dos_start) / (iout_dos_nenergy - 1)
       
       select case (out_dos_method)
       case('lorentzian')
@@ -149,7 +149,7 @@ Subroutine write_GS_data
         do ik = NK_s,NK_e
           do ib = 1,NB
             fk = 2.d0/(NKxyz)*wk(ik)*(out_dos_smearing/pi)          
-            do iw = 1, out_dos_nenergy
+            do iw = 1, iout_dos_nenergy
               ww =  out_dos_start + (iw-1) * dw + eshift - esp(ib,ik) 
               dos_l(iw) = dos_l(iw) + fk/(ww**2 + out_dos_smearing**2)
             end do
@@ -161,7 +161,7 @@ Subroutine write_GS_data
         do ik = NK_s,NK_e
           do ib = 1,NB
             fk = (2.d0 / (NKxyz * sqrt(2.d0*pi) * out_dos_smearing)) * wk(ik)
-            do iw = 1, out_dos_nenergy
+            do iw = 1, iout_dos_nenergy
               ww =  out_dos_start + (iw-1) * dw + eshift - esp(ib,ik) 
               dos_l(iw) = dos_l(iw) + fk * exp(-(0.5/out_dos_smearing**2)*ww**2)
             end do
@@ -169,14 +169,14 @@ Subroutine write_GS_data
         end do
       end select
       
-      call comm_summation(dos_l,dos,out_dos_nenergy,nproc_group_tdks)
+      call comm_summation(dos_l,dos,iout_dos_nenergy,nproc_group_tdks)
 
       if (comm_is_root(nproc_id_global)) then
         open(404,file=file_DoS)
         write(404,"(A)") '#Density of states'
         write(404,"(6A)") '# energy (', trim(t_unit_energy%name) ,'),', &
                         & ' dos (',  trim(t_unit_energy_inv%name)  ,')'
-        do iw = 1, out_dos_nenergy
+        do iw = 1, iout_dos_nenergy
           ww =  out_dos_start + (iw-1) * dw 
           write(404,"(2e26.16e3)") ww * t_unit_energy%conv, &
                                  & dos(iw) * t_unit_energy_inv%conv

--- a/ARTED/GS/write_GS_data.f90
+++ b/ARTED/GS/write_GS_data.f90
@@ -137,8 +137,8 @@ Subroutine write_GS_data
       call comm_bcast(emax,nproc_group_global)
       call comm_bcast(eshift,nproc_group_global)
       
-      out_dos_start = emin - 0.25d0 * (emax - emin)
-      out_dos_end = emax + 0.25d0 * (emax - emin)
+      out_dos_start = max(out_dos_start, emin - 0.25d0 * (emax - emin))
+      out_dos_end = min(out_dos_end, emax + 0.25d0 * (emax - emin))
       
       dos_l = 0d0
       dw = (out_dos_end - out_dos_start) / (iout_dos_nenergy - 1)

--- a/GCEED/scf/calc_dos.f90
+++ b/GCEED/scf/calc_dos.f90
@@ -17,15 +17,15 @@ subroutine calc_dos
 use salmon_parallel, only: nproc_id_global, nproc_group_grid
 use salmon_communication, only: comm_is_root, comm_summation
 use inputoutput, only: out_dos_start, out_dos_end, out_dos_method, &
-                       out_dos_smearing, out_dos_nenergy, out_dos_fshift, uenergy_from_au
+                       out_dos_smearing, iout_dos_nenergy, out_dos_fshift, uenergy_from_au
 use scf_data
 use allocate_psl_sub
 use new_world_sub
 implicit none
 !integer :: iob,iobmax,iob_allob
 integer :: iob,iobmax,iob_allob
-real(8) :: dos_l_tmp(1:out_dos_nenergy)
-real(8) :: dos_l(1:out_dos_nenergy)
+real(8) :: dos_l_tmp(1:iout_dos_nenergy)
+real(8) :: dos_l(1:iout_dos_nenergy)
 real(8) :: fk,ww,dw
 integer :: iw
 real(8) :: ene_homo,ene_lumo,ene_min,ene_max,efermi,eshift
@@ -41,9 +41,9 @@ if(out_dos_fshift=='y'.and.nstate>nelec/2) then
 else 
   eshift = 0.d0 
 endif 
-out_dos_start = max(out_dos_start, ene_min-eshift-out_dos_smearing*2)
-out_dos_end = min(out_dos_end, ene_max-eshift+out_dos_smearing*2)
-dw=(out_dos_end-out_dos_start)/dble(out_dos_nenergy-1) 
+out_dos_start = ene_min-0.25d0*(ene_max-ene_min)
+out_dos_end = ene_max+0.25d0*(ene_max-ene_min)
+dw=(out_dos_end-out_dos_start)/dble(iout_dos_nenergy-1) 
 
 dos_l_tmp=0.d0
  
@@ -52,19 +52,19 @@ do iob=1,iobmax
   select case (out_dos_method)
   case('lorentzian') 
     fk=2.d0*out_dos_smearing/pi
-    do iw=1,out_dos_nenergy 
+    do iw=1,iout_dos_nenergy 
       ww=out_dos_start+dble(iw-1)*dw+eshift-esp(iob_allob,1)  
       dos_l_tmp(iw)=dos_l_tmp(iw)+fk/(ww**2+out_dos_smearing**2) 
     end do 
   case('gaussian')
     fk=2.d0/(sqrt(2.d0*pi)*out_dos_smearing)
-    do iw=1,out_dos_nenergy 
+    do iw=1,iout_dos_nenergy 
       ww=out_dos_start+dble(iw-1)*dw+eshift-esp(iob_allob,1)  
       dos_l_tmp(iw)=dos_l_tmp(iw)+fk*exp(-(0.5d0/out_dos_smearing**2)*ww**2) 
     end do
   end select
 end do
-call comm_summation(dos_l_tmp,dos_l,out_dos_nenergy,nproc_group_grid) 
+call comm_summation(dos_l_tmp,dos_l,iout_dos_nenergy,nproc_group_grid) 
 
 if(comm_is_root(nproc_id_global))then
   open(101,file="dos.data")
@@ -76,7 +76,7 @@ if(comm_is_root(nproc_id_global))then
     write(101,'("# Energy[eV]  DOS[1/eV]")') 
   end select
   write(101,'("#-----------------------")') 
-  do iw=1,out_dos_nenergy 
+  do iw=1,iout_dos_nenergy 
     ww=out_dos_start+dble(iw-1)*dw+eshift
     write(101,'(f10.5,f14.8)') ww*uenergy_from_au, dos_l(iw)/uenergy_from_au
   end do

--- a/GCEED/scf/calc_dos.f90
+++ b/GCEED/scf/calc_dos.f90
@@ -41,8 +41,8 @@ if(out_dos_fshift=='y'.and.nstate>nelec/2) then
 else 
   eshift = 0.d0 
 endif 
-out_dos_start = ene_min-0.25d0*(ene_max-ene_min)
-out_dos_end = ene_max+0.25d0*(ene_max-ene_min)
+out_dos_start = max(out_dos_start,ene_min-0.25d0*(ene_max-ene_min))
+out_dos_end = min(out_dos_end,ene_max+0.25d0*(ene_max-ene_min))
 dw=(out_dos_end-out_dos_start)/dble(iout_dos_nenergy-1) 
 
 dos_l_tmp=0.d0

--- a/GCEED/scf/calc_pdos.f90
+++ b/GCEED/scf/calc_pdos.f90
@@ -52,8 +52,8 @@ if(out_dos_fshift=='y'.and.nstate>nelec/2) then
 else 
   eshift = 0d0 
 endif 
-out_dos_start = ene_min-0.25d0*(ene_max-ene_min)
-out_dos_end = ene_max+0.25d0*(ene_max-ene_min)
+out_dos_start = max(out_dos_start,ene_min-0.25d0*(ene_max-ene_min))
+out_dos_end = min(out_dos_end,ene_max+0.25d0*(ene_max-ene_min))
 dw=(out_dos_end-out_dos_start)/dble(iout_dos_nenergy-1) 
 
 pdos_l_tmp=0.d0

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -769,38 +769,32 @@ If <code>'y'</code>, density of state is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_dos_start; <code>Real(8)</code>; 3d</dt>
+<dt>iout_dos_nenergy; <code>Integer</code>; 0d/3d</dt>
 <dd>
-Start point (energy) of the density of state spectra.
-Default value is <code>-3.0</code> eV.
+Number of energies which are calculated in DOS part. 
+Default is <code>601</code>.
 </dd>
 
-<dt>out_dos_end; <code>Real(8)</code>; 3d</dt>
-<dd>
-End point (energy) of the density of state spectra.
-Default value is <code>3.0</code> eV.
-</dd>
-
-<dt>out_dos_method; <code>Character</code>; 3d</dt>
+<dt>out_dos_method; <code>Character</code>; 0d/3d</dt>
 <dd>
 Choise of smearing method for the density of state spectra.
 <code>gaussian</code> and <code>lorentzian</code> function are available.
 Default is <code>gaussian</code>.
 </dd>
 
-<dt>out_dos_smearing; <code>Real(8)</code>; 3d</dt>
+<dt>out_dos_smearing; <code>Real(8)</code>; 0d/3d</dt>
 <dd>
 Smearing width of the density of state spectra.
 Default is <code>0.1</code> eV.
 </dd>
 
-<dt>out_dos_fshift; <code>Character</code>; 3d</dt>
+<dt>out_dos_fshift; <code>Character</code>; 0d/3d</dt>
 <dd>
 If <code>'y'</code>, the electron energy is shifted to fix the Fermi energy as zero point.
+For <code>&system/iperiodic</code> is <code>0</code>, <code> out_dos_fshift</code> is not used 
+if <code>&system/nstate</code> is equal to <code>&system/nelec</code>/2.
 Default is <code>'n'</code>.
 </dd>
-
-
 
 <dt>out_pdos; <code>Character</code>; 0d</dt>
 <dd>

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -769,10 +769,32 @@ If <code>'y'</code>, density of state is output.
 Default is <code>'n'</code>.
 </dd>
 
+<dt>out_dos_start; <code>Real(8)</code>; 0d/3d</dt>
+<dd>
+Start point (energy) of the density of state spectra.
+If this value is lower than a specific value near the lowest energy level, 
+this value is overwrited by that value. 
+Default value is <code>-1.d10</code> eV.
+</dd>
+
+<dt>out_dos_end; <code>Real(8)</code>; 0d/3d</dt>
+<dd>
+End point (energy) of the density of state spectra.
+If this value is higher than a specific value near the highest energy level, 
+this value is overwrited by that value. 
+Default value is <code>1.d10</code> eV.
+</dd>
+
 <dt>iout_dos_nenergy; <code>Integer</code>; 0d/3d</dt>
 <dd>
 Number of energies which are calculated in DOS part. 
 Default is <code>601</code>.
+</dd>
+
+<dt>out_dos_smearing; <code>Real(8)</code>; 0d/3d</dt>
+<dd>
+Smearing width of the density of state spectra.
+Default is <code>0.1</code> eV.
 </dd>
 
 <dt>out_dos_method; <code>Character</code>; 0d/3d</dt>
@@ -780,12 +802,6 @@ Default is <code>601</code>.
 Choise of smearing method for the density of state spectra.
 <code>gaussian</code> and <code>lorentzian</code> function are available.
 Default is <code>gaussian</code>.
-</dd>
-
-<dt>out_dos_smearing; <code>Real(8)</code>; 0d/3d</dt>
-<dd>
-Smearing width of the density of state spectra.
-Default is <code>0.1</code> eV.
 </dd>
 
 <dt>out_dos_fshift; <code>Character</code>; 0d/3d</dt>

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -341,6 +341,8 @@ contains
       & out_dos, &
       & out_pdos, &
       & out_dns, &
+      & out_dos_start, &
+      & out_dos_end, &
       & iout_dos_nenergy, &
       & out_dos_smearing, &
       & out_dos_method, &
@@ -562,6 +564,8 @@ contains
     de                  = (0.01d0/au_energy_ev)*uenergy_from_au  ! eV
     out_psi             = 'n'
     out_dos             = 'n'
+    out_dos_start       = -1.d10 / au_energy_ev * uenergy_from_au
+    out_dos_end         = +1.d10 / au_energy_ev * uenergy_from_au
     iout_dos_nenergy    = 601
     out_dos_smearing    = 0.1d0 / au_energy_ev * uenergy_from_au
     out_dos_method      = 'gaussian'
@@ -843,6 +847,10 @@ contains
     de = de * uenergy_to_au
     call comm_bcast(out_psi            ,nproc_group_global)
     call comm_bcast(out_dos            ,nproc_group_global)
+    call comm_bcast(out_dos_start      ,nproc_group_global)
+    out_dos_start = out_dos_start * uenergy_to_au
+    call comm_bcast(out_dos_end        ,nproc_group_global)
+    out_dos_end = out_dos_end * uenergy_to_au
     call comm_bcast(iout_dos_nenergy   ,nproc_group_global)
     call comm_bcast(out_dos_smearing   ,nproc_group_global)
     out_dos_smearing = out_dos_smearing * uenergy_to_au
@@ -1321,6 +1329,8 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'de', de
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_psi', out_psi
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos', out_dos
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_start', out_dos_start
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_end', out_dos_end
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'iout_dos_nenergy', iout_dos_nenergy
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_smearing', out_dos_smearing
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos_method', out_dos_method

--- a/modules/inputoutput.f90
+++ b/modules/inputoutput.f90
@@ -341,9 +341,7 @@ contains
       & out_dos, &
       & out_pdos, &
       & out_dns, &
-      & out_dos_start, &
-      & out_dos_end, &
-      & out_dos_nenergy, &
+      & iout_dos_nenergy, &
       & out_dos_smearing, &
       & out_dos_method, &
       & out_dos_fshift, &
@@ -564,9 +562,7 @@ contains
     de                  = (0.01d0/au_energy_ev)*uenergy_from_au  ! eV
     out_psi             = 'n'
     out_dos             = 'n'
-    out_dos_start       = -1.d10 / au_energy_ev * uenergy_from_au
-    out_dos_end         = +1.d10 / au_energy_ev * uenergy_from_au
-    out_dos_nenergy     = 601
+    iout_dos_nenergy    = 601
     out_dos_smearing    = 0.1d0 / au_energy_ev * uenergy_from_au
     out_dos_method      = 'gaussian'
     out_dos_fshift      = 'n'
@@ -847,11 +843,7 @@ contains
     de = de * uenergy_to_au
     call comm_bcast(out_psi            ,nproc_group_global)
     call comm_bcast(out_dos            ,nproc_group_global)
-    call comm_bcast(out_dos_start      ,nproc_group_global)
-    out_dos_start = out_dos_start * uenergy_to_au
-    call comm_bcast(out_dos_end        ,nproc_group_global)
-    out_dos_end = out_dos_end * uenergy_to_au
-    call comm_bcast(out_dos_nenergy    ,nproc_group_global)
+    call comm_bcast(iout_dos_nenergy   ,nproc_group_global)
     call comm_bcast(out_dos_smearing   ,nproc_group_global)
     out_dos_smearing = out_dos_smearing * uenergy_to_au
     call comm_bcast(out_dos_method     ,nproc_group_global)
@@ -1329,9 +1321,7 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'de', de
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_psi', out_psi
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos', out_dos
-      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_start', out_dos_start
-      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_end', out_dos_end
-      write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_dos_nenergy', out_dos_nenergy
+      write(fh_variables_log, '("#",4X,A,"=",I6)') 'iout_dos_nenergy', iout_dos_nenergy
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dos_smearing', out_dos_smearing
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos_method', out_dos_method
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos_fshift', out_dos_fshift

--- a/modules/salmon_global.f90
+++ b/modules/salmon_global.f90
@@ -176,7 +176,7 @@ module salmon_global
   character(1)   :: out_dos
   real(8)        :: out_dos_start
   real(8)        :: out_dos_end
-  integer        :: out_dos_nenergy
+  integer        :: iout_dos_nenergy
   real(8)        :: out_dos_smearing
   character(16)  :: out_dos_method
   character(1)   :: out_dos_fshift


### PR DESCRIPTION
Thank you for your implementation, @uemoto1 san. And thank you for your advice, @shunsuke-sato san. But I found that top and bottom dos are cut when I use lorentzian function for C2H2 case. This is what @yabana sensei said. I'd like to modify the code as following. 

1. I enlarge energy ranges for the DOS and PDOS plot. 
2. Since out_dos_start and out_dos_end in std input is no longer used, I remove them. But they remain as SALMON global variables.
3. According to the coding rules, I modify from out_dos_nenergy to iout_dos_nenergy. 

People who check may disagree above modification. In that case, I'll modify. So please do not hesitate to comment on this PR. 