### PR TITLE
change names of std output files

### DIFF
--- a/example/C2H2/intel/gs.sh
+++ b/example/C2H2/intel/gs.sh
@@ -1,4 +1,4 @@
 export OMP_NUM_THREADS=24
-date > output_gs
-mpiexec -np 1 ../../../salmon.cpu < C2H2_gs.inp >> output_gs
-date >> output_gs
+date > C2H2_gs.out
+mpiexec -np 1 ../../../salmon.cpu < C2H2_gs.inp >> C2H2_gs.out
+date >> C2H2_gs.out

--- a/example/C2H2/intel/rt_pulse.sh
+++ b/example/C2H2/intel/rt_pulse.sh
@@ -1,4 +1,4 @@
 export OMP_NUM_THREADS=24
-date > output_rt_pulse
-mpiexec -np 1 ../../../salmon.cpu < C2H2_rt_pulse.inp >> output_rt_pulse
-date >> output_rt_pulse
+date > C2H2_rt_pulse.out
+mpiexec -np 1 ../../../salmon.cpu < C2H2_rt_pulse.inp >> C2H2_rt_pulse.out
+date >> C2H2_rt_pulse.out

--- a/example/C2H2/intel/rt_response.sh
+++ b/example/C2H2/intel/rt_response.sh
@@ -1,4 +1,4 @@
 export OMP_NUM_THREADS=24
-date > output_rt_response
-mpiexec -np 1 ../../../salmon.cpu < C2H2_rt_response.inp >> output_rt_response
-date >> output_rt_response
+date > C2H2_rt_response.out
+mpiexec -np 1 ../../../salmon.cpu < C2H2_rt_response.inp >> C2H2_rt_response.out
+date >> C2H2_rt_response.out


### PR DESCRIPTION
On wiki, std output files "???.out" are written in the periodic system calculation. So I'd like to modify names of std output files for the isolated system calcualtion to match ones for the periodic system calculation.  I didn't any check because this is a mere modification for shell scripts.  