### PR TITLE
Fix a header of makefile template

### DIFF
--- a/makefiles/arch/gnu
+++ b/makefiles/arch/gnu
@@ -1,11 +1,9 @@
 TARGET = salmon.cpu
-FC = mpifc
+FC = mpif90
 CC = mpicc
 FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-form -ffree-line-length-none
 CFLAGS = -O3 -fopenmp -Wall
-FILE_MATHLIB = lapack
-LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5 -lm
-LIBSCALAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5 \
-    -lmkl_blacs_intelmpi_lp64 -lmkl_scalapack_lp64 -lm
+LIBLAPACK = -llapack -lblas
 MODULE_SWITCH = -J
 COMM_SET =
+


### PR DESCRIPTION
This PR modify the header section of gnu makefile (`/makefiles/arch/gnu`) to reproduce current `Makefile.gnu` by generator script.
Since this modification has no affection to build process and binary file, someone can merge this PR without any testing.