### PR TITLE
change unit of output files for avs

### DIFF
--- a/GCEED/common/writeavs.f90
+++ b/GCEED/common/writeavs.f90
@@ -13,12 +13,13 @@
 !  See the License for the specific language governing permissions and
 !  limitations under the License.
 !
-subroutine writeavs(fp,suffix,tmatbox_l)
+subroutine writeavs(fp,suffix,header_unit,tmatbox_l)
   use salmon_parallel, only: nproc_id_global
   use salmon_communication, only: comm_is_root
   use scf_data
   implicit none
   integer, intent(IN) :: fp
+  character(20), intent(IN) :: header_unit
   real(8), intent(IN) :: tmatbox_l(lg_sta(1):lg_end(1),lg_sta(2):lg_end(2),  &
                                    lg_sta(3):lg_end(3))
   character(30),intent(in):: suffix
@@ -27,12 +28,16 @@ subroutine writeavs(fp,suffix,tmatbox_l)
   integer::jj
   integer::jsta,jend
   character(8)  :: filenumber_data
-  
+
+ 
   if(numfiles_out_3d>=2)then
     if(nproc_id_global<numfiles_out_3d)then
       write(filenumber_data, '(i8)') nproc_id_global
       filename = trim(suffix)//"."//adjustl(filenumber_data)
       open(fp,file=filename)
+      if(comm_is_root(nproc_id_global))then
+        write(fp,'("# unit is ",a)') header_unit
+      end if
       jsta=nproc_id_global*(lg_num(1)*lg_num(2)*lg_num(3))/numfiles_out_3d+1
       jend=(nproc_id_global+1)*(lg_num(1)*lg_num(2)*lg_num(3))/numfiles_out_3d
       do jj=jsta,jend
@@ -48,6 +53,7 @@ subroutine writeavs(fp,suffix,tmatbox_l)
     if(comm_is_root(nproc_id_global))then
       filename=trim(suffix)
       open(fp,file=filename)
+      write(fp,'("# unit is ",a)') header_unit
       do iz=lg_sta(3),lg_end(3)
       do iy=lg_sta(2),lg_end(2)
       do ix=lg_sta(1),lg_end(1)

--- a/GCEED/common/writeelf.f90
+++ b/GCEED/common/writeelf.f90
@@ -22,6 +22,7 @@ subroutine writeelf
   character(30) :: suffix
   character(30) :: phys_quantity
   character(10) :: filenum
+  character(20) :: header_unit
 
   if(iSCFRT==1)then 
     suffix = "elf"
@@ -31,7 +32,8 @@ subroutine writeelf
   end if
   phys_quantity = "elf"
   if(format3d=='avs')then
-    call writeavs(103,suffix,elf)
+    header_unit = "none"
+    call writeavs(103,suffix,header_unit,elf)
   else if(format3d=='cube')then
     call writecube(103,suffix,phys_quantity,elf)
   end if

--- a/GCEED/common/writeestatic.f90
+++ b/GCEED/common/writeestatic.f90
@@ -24,6 +24,7 @@ subroutine writeestatic
   character(30) :: suffix
   character(30) :: phys_quantity
   character(10) :: filenum
+  character(20) :: header_unit
 
   do jj=1,3
 
@@ -64,7 +65,18 @@ subroutine writeestatic
       end do
       end do
     end if
-    
+   
+    if(format3d=='avs')then
+      !$OMP parallel do collapse(2) private(iz,iy,ix)
+      do iz=ng_sta(3),ng_end(3)
+      do iy=ng_sta(2),ng_end(2)
+      do ix=ng_sta(1),ng_end(1)
+        matbox_l(ix,iy,iz)=matbox_l(ix,iy,iz)*5.14223d1
+      end do
+      end do
+      end do
+    end if
+ 
     call comm_summation(matbox_l,matbox_l2,lg_num(1)*lg_num(2)*lg_num(3),nproc_group_global)
   
     write(filenum, '(i8)') itt
@@ -80,7 +92,8 @@ subroutine writeestatic
     end if
 
     if(format3d=='avs')then
-      call writeavs(103,suffix,matbox_l2)
+      header_unit = "V/A"
+      call writeavs(103,suffix,header_unit,matbox_l2)
     else if(format3d=='cube')then
       call writecube(103,suffix,phys_quantity,matbox_l2)
     end if


### PR DESCRIPTION
I change unit of output files for avs. The unit is changed from a.u. to A/eV/fs. The reason why I modify is that A/eV/fs is familiar to us. I also add header to identify unit. In future, I may modify to correspond both unit. For cube files, length is generally specified by a.u. So I don't change cube files.  

I checked the calculation successfully finished as always. And I checked that time propagation of difference of density is correcly displayed. 

It may be difficult to check this PR. But I'd like to pass this PR before next release of SALMON. Could you please check this PR?