### PR TITLE
Add the common GS output files

### DIFF
--- a/ARTED/GS/write_GS_data.f90
+++ b/ARTED/GS/write_GS_data.f90
@@ -108,9 +108,11 @@ Subroutine write_GS_data
 
   
   if(out_dos == 'y')call dos_write
-  call write_k_data
-  call write_eigen_data
 
+  if (comm_is_root(nproc_id_global)) then
+    call write_k_data
+    call write_eigen_data
+  end if
   return
 
   contains

--- a/ARTED/GS/write_GS_data.f90
+++ b/ARTED/GS/write_GS_data.f90
@@ -198,7 +198,7 @@ Subroutine write_GS_data
       integer :: fh_k_data
       integer :: ik
       
-      file_k_data = trim(directory) // trim(SYSname) // '_eigen.data'
+      file_k_data = trim(directory) // trim(SYSname) // '_k.data'
       
       fh_k_data = open_filehandle(file_k_data, status="replace")
       write(fh_k_data, '(a)') "# k-point coordinates"

--- a/ARTED/modules/global_variables.f90
+++ b/ARTED/modules/global_variables.f90
@@ -132,6 +132,8 @@ Module Global_Variables
   character(256) :: file_ac_m            ! 943
   character(256) :: file_ac              ! 902
   character(256) :: file_ac_init         ! 902
+  character(256) :: file_k_data
+  character(256) :: file_eigen_data
   character(256) :: process_directory
 
 !  character(2) :: ext_field ! this variable is removed

--- a/modules/salmon_file.f90
+++ b/modules/salmon_file.f90
@@ -21,6 +21,7 @@ module salmon_file
   integer, parameter :: fh_start = 1000
 
   public :: get_filehandle
+  public :: open_filehandle
 contains
 !--------------------------------------------------------------------------------
 !! Return a unit number available to open file
@@ -36,6 +37,26 @@ contains
     end do
     return
   end function get_filehandle
+  
+!--------------------------------------------------------------------------------
+!! Open file and Return the unit number 
+  integer function open_filehandle(file, status) result(fh)
+    implicit none
+    character(*), intent(in) :: file
+    character(*), optional, intent(in) :: status
+    character(256) :: my_status
+    
+    if (present(status)) then
+      my_status = status
+    else
+      my_status = "unknown"
+    endif
+    
+    fh = get_filehandle()
+    open(unit=fh, file=trim(file), status=trim(my_status))
+    
+    return
+  end function open_filehandle
   
 end module salmon_file
 !--------------------------------------------------------------------------------


### PR DESCRIPTION
## About This Pull Request

This modification provides the subroutines of the common output file format for SALMON-TDDFT. This PR experimentally implements the output for GS calculation. 
I employ the file formats discussed on **SALMON June meeting**:
https://www.dropbox.com/s/43qyhxj0n5y7a5z/uemoto0805_output_format.pdf?dl=0
(Attached is document distributed in previous meeting)

The ordinary output files (e.g. `SYSName_band.out` ...) have also remained for now to keep the compatibility of the old calculation results.

##  Output Files
- `SYSName_k.data` : describe the k-point coordinates (only in 3d mode)

| Column | Detail | Unit |
|----------|------------|------|
| 1 | k-point index | integer starts from 1 |
| 2:4 | kx, ky, kz coordinates | 1 / length |
| 5 | k-point weights | dimensionless |

- `SYSName_eigen.data` : describe the eigenenergies and occupation number

| Column | Detail | Unit |
|----------|------------|------|
| 1 | k-point index | integer starts from 1  |
| 2 | band index | integer starts from 1  |
| 3 | eigenenergy  | energy |
| 4 | occupation | dimensionless |

## Additional Work
- In this time, I add the function (`open_filehandle`) to `salmon_file` module, which provides the similar functionality of `fopen` (in C) or `open` (in Python).
```
fh=open_filehandle("filename.txt", status="old")
```
- `open_filehandle` opens a file with assigning the free io unit number automatically, and it is equivalent to `get_filehandle` and `open` statement.
```
fh = get_filehandle()
open(fh, "filename.txt", status="old")
```

## Future Work
- Add the similar output subroutines for GCEED section
- Add the common output formats of RT calculation
