### PR TITLE
CMake generates git information.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 2.8)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/misc.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/setup.cmake)
-
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/get_git_info.cmake)
 
 ### Project settings
 project(SALMON Fortran C)
@@ -136,6 +136,20 @@ endif ()
 add_definitions("${ADDITIONAL_MACRO}")
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/workaround.cmake)
+
+
+# Generate configure header
+configure_file(
+  ${CMAKE_SOURCE_DIR}/src/version.h.in
+  ${CMAKE_BINARY_DIR}/version.h
+)
+
+configure_file(
+  ${CMAKE_SOURCE_DIR}/src/versionf.h.in
+  ${CMAKE_BINARY_DIR}/versionf.h
+)
+
+include_directories(${CMAKE_BINARY_DIR})
 
 
 ### Build target

--- a/cmake/get_git_info.cmake
+++ b/cmake/get_git_info.cmake
@@ -1,0 +1,20 @@
+# [Ref] CMake: Use Git Branch & Commit Details in Project
+#       http://xit0.org/2013/04/cmake-use-git-branch-and-commit-details-in-project/
+
+# Get the current working branch
+execute_process(
+  COMMAND git rev-parse --abbrev-ref HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_BRANCH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Get the latest abbreviated commit hash of the working branch
+execute_process(
+  COMMAND git log -1 --format=%H
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_COMMIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+message(STATUS "Git: ${GIT_COMMIT_HASH} in branch '${GIT_BRANCH}'")

--- a/src/main.f90
+++ b/src/main.f90
@@ -5,6 +5,11 @@ program main
   implicit none
 
   call setup_parallel
+
+  if (nproc_id_global == 0) then
+    call print_software_version
+  endif
+
   call read_input
 
   select case(iperiodic)
@@ -18,4 +23,14 @@ program main
 
   call end_parallel
 
+contains
+  subroutine print_software_version
+    implicit none
+    include 'versionf.h'
+    print '(A)',       '##############################################################################'
+    print '(A)',       '# SALMON: Scalable Ab-initio Light-Matter simulator for Optics and Nanoscience'
+    print '(A)',       '#'
+    print '(A,A,A,A)', '#   [Git revision] ', GIT_COMMIT_HASH, ' in ', GIT_BRANCH
+    print '(A)',       '##############################################################################'
+  end subroutine
 end program main

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,7 @@
+#ifndef SALMON_VERSION_H
+#define SALMON_VERSION_H
+
+#define GIT_BRANCH      "@GIT_BRANCH@"
+#define GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
+
+#endif

--- a/src/versionf.h.in
+++ b/src/versionf.h.in
@@ -1,0 +1,2 @@
+character(*), parameter :: GIT_BRANCH      = '@GIT_BRANCH@'
+character(*), parameter :: GIT_COMMIT_HASH = '@GIT_COMMIT_HASH@'


### PR DESCRIPTION
CMake generates version.h for C-lang, versionf.h for Fortran.
In this PR, SALMON prints git version (commit hash ID) of current branch at header as below.

```
##############################################################################
# SALMON: Scalable Ab-initio Light-Matter simulator for Optics and Nanoscience
#
#   [Git revision] 07ff7cee49ee1e2df0c3e8de6fa0217d98d05717 in print-git-info
##############################################################################
```