### PR TITLE
Add `install` command to CMake.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -51,6 +51,7 @@ parser.add_option('-v', '--verbose', action='store_true', default=False, dest='v
 
 group = OptionGroup(parser, 'Build target')
 group.add_option('-a', '--arch',   action='store', default=None, dest='arch',   help='cross compile mode. ARCH format should be <COMPILER>-<SYSTEM>')
+group.add_option('--prefix',       action='store', default=None, dest='prefix', help='package install prefix.')
 parser.add_option_group(group)
 
 group = OptionGroup(parser, 'Optimization options')
@@ -82,6 +83,8 @@ parser.add_option_group(group)
 dict = {}
 if options.arch is not None:
   dict['CMAKE_TOOLCHAIN_FILE']     = options.arch.lower()
+if options.prefix is not None:
+  dict['CMAKE_INSTALL_PREFIX']     = options.prefix
 dict['CMAKE_BUILD_TYPE']           = debug_or_release(options.debug)
 dict['CMAKE_VERBOSE_MAKEFILE']     = on_or_off(options.verbose)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,3 +16,6 @@ add_subdirectory("./misc")
 add_executable(${TARGET_NAME} main.f90)
 target_link_libraries(${TARGET_NAME} ${SALMON_LINK_LIBRARIES} ${EXTERNAL_LIBS})
 add_dependencies(${TARGET_NAME} ${SALMON_LINK_LIBRARIES})
+
+# Install binary
+install(TARGETS ${TARGET_NAME} DESTINATION "bin")


### PR DESCRIPTION
I added `make install` command to CMake.
For default, CMake installs packages to /usr/local directory, which is a default value of `CMAKE_INSTALL_PREFIX` variable at Linux.
`configure.py` supports `--prefix` option as same with GNU autotools.

# Specifies install directory 
## `configure.py`

    $ mkdir build-tmp && cd build-tmp
    $ ${SALMON_REPO}/configure.py --prefix=${SALMON_INSTALL_PREFIX}
    $ make && make install
    $ ls ${SALMON_INSTALL_PREFIX}/bin
    salmon.cpu

## CMake directly

    $ mkdir build-tmp && cd build-tmp
    $ cmake -D CMAKE_INSTALL_PREFIX=${SALMON_INSTALL_PREFIX} ${SALMON_REPO}
    $ make && make install
    $ ls ${SALMON_INSTALL_PREFIX}/bin
    salmon.cpu