### PR TITLE
Fix a bug of cube file export

### DIFF
--- a/src/ARTED/common/density_plot.f90
+++ b/src/ARTED/common/density_plot.f90
@@ -15,7 +15,7 @@
 !
 
 subroutine write_density_cube(fh, write_difference)
-  use Global_Variables, only: NLx, NLy, NLz, aLx, aLy, aLz, NI, Kion, Rion, Zatom, Lxyz, Rho, Rho_gs 
+  use Global_Variables, only: NLx, NLy, NLz,  Hx, Hy, Hz,  NI, Kion, Rion, Zatom, Lxyz, Rho, Rho_gs 
   implicit none
   integer, intent(in) :: fh
   logical, intent(in) :: write_difference
@@ -26,9 +26,9 @@ subroutine write_density_cube(fh, write_difference)
   write(fh, '(A)') "# SALMON"
   write(fh, '(A)') "# COMMENT"
   write(fh, '(I5,3(F12.6))') NI, 0.00, 0.00, 0.00
-  write(fh, '(I5,3(F12.6))') NLx, aLx, 0.00, 0.00
-  write(fh, '(I5,3(F12.6))') NLy, 0.00, aLy, 0.00
-  write(fh, '(I5,3(F12.6))') NLz, 0.00, 0.00, aLz
+  write(fh, '(I5,3(F12.6))') NLx, Hx, 0.00, 0.00
+  write(fh, '(I5,3(F12.6))') NLy, 0.00, Hy, 0.00
+  write(fh, '(I5,3(F12.6))') NLz, 0.00, 0.00, Hz
   
   do i=1, NI
     write(fh, '(I5,4(F12.6))') Zatom(Kion(i)), 0.00, Rion(1,i), Rion(2,i), Rion(3,i) 


### PR DESCRIPTION
## About This Pull Request

This pull request contains a bug fix of `.cube` file export from the ARTED part.

In the current implementation, the subroutine of `write_density_cube` exports the charge density profile as `.cube` format, when `out_dns_rt` and `out_format_3d` are specified, however the spacing value defined in the header section is incorrect. 

## Acknowledgement

The author thanks @ayamada224 san for the bug report and fruitful comments.