### PR TITLE
Optimizing halo communications in GCEED part.

### DIFF
--- a/src/GCEED/common/sendrecv_copy.f90
+++ b/src/GCEED/common/sendrecv_copy.f90
@@ -21,8 +21,11 @@ integer :: ix,iy,iz,iob
 real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
                 mg_sta(3)-Nd:mg_end(3)+Nd,1:iobnum,1)
 
+!$omp parallel default(none) &
+!$omp          shared(iobnum,mg_sta,mg_end,tpsi,psi) &
+!$omp          private(iob,iz,iy,ix)
 do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) 
+!$omp do collapse(2)
   do iz=mg_sta(3)-Nd,mg_end(3)+Nd
   do iy=mg_sta(2)-Nd,mg_end(2)+Nd
   do ix=mg_sta(1)-Nd,mg_end(1)+Nd
@@ -30,7 +33,8 @@ do iob=1,iobnum
   end do
   end do
   end do
-!$OMP parallel do private(iz,iy,ix) 
+!$omp end do
+!$omp do collapse(2)
   do iz=mg_sta(3),mg_end(3)
   do iy=mg_sta(2),mg_end(2)
   do ix=mg_sta(1),mg_end(1)
@@ -38,6 +42,8 @@ do iob=1,iobnum
   end do
   end do
   end do
+!$omp end do
 end do
+!$omp end parallel
 
 end subroutine sendrecv_copy

--- a/src/GCEED/modules/CMakeLists.txt
+++ b/src/GCEED/modules/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SOURCES
     sendrecvh.f90
     total_energy.f90
     writebox_rt.f90
+    persistent_comm.f90
+    pack_unpack.f90
     )
   #  share_mesh_1d_old.f90
 

--- a/src/GCEED/modules/init_sendrecv.f90
+++ b/src/GCEED/modules/init_sendrecv.f90
@@ -35,6 +35,8 @@ complex(8),allocatable :: cmatbox2_x_s(:,:,:),cmatbox2_y_s(:,:,:),cmatbox2_z_s(:
 
 real(8),allocatable :: rmatbox1_x_h(:,:,:),rmatbox1_y_h(:,:,:),rmatbox1_z_h(:,:,:)
 real(8),allocatable :: rmatbox2_x_h(:,:,:),rmatbox2_y_h(:,:,:),rmatbox2_z_h(:,:,:)
+real(8),allocatable :: rmatbox3_x_h(:,:,:),rmatbox3_y_h(:,:,:),rmatbox3_z_h(:,:,:)
+real(8),allocatable :: rmatbox4_x_h(:,:,:),rmatbox4_y_h(:,:,:),rmatbox4_z_h(:,:,:)
 
 complex(8),allocatable :: cmatbox1_x_h(:,:,:),cmatbox1_y_h(:,:,:),cmatbox1_z_h(:,:,:)
 complex(8),allocatable :: cmatbox2_x_h(:,:,:),cmatbox2_y_h(:,:,:),cmatbox2_z_h(:,:,:)
@@ -446,6 +448,12 @@ allocate(rmatbox1_z_h(inum_Mxin2(1,nproc_id_global),inum_Mxin2(2,nproc_id_global
 allocate(rmatbox2_x_h(Ndh,inum_Mxin2(2,nproc_id_global),inum_Mxin2(3,nproc_id_global)))
 allocate(rmatbox2_y_h(inum_Mxin2(1,nproc_id_global),Ndh,inum_Mxin2(3,nproc_id_global)))
 allocate(rmatbox2_z_h(inum_Mxin2(1,nproc_id_global),inum_Mxin2(2,nproc_id_global),Ndh))
+allocate(rmatbox3_x_h(Ndh,inum_Mxin2(2,nproc_id_global),inum_Mxin2(3,nproc_id_global)))
+allocate(rmatbox3_y_h(inum_Mxin2(1,nproc_id_global),Ndh,inum_Mxin2(3,nproc_id_global)))
+allocate(rmatbox3_z_h(inum_Mxin2(1,nproc_id_global),inum_Mxin2(2,nproc_id_global),Ndh))
+allocate(rmatbox4_x_h(Ndh,inum_Mxin2(2,nproc_id_global),inum_Mxin2(3,nproc_id_global)))
+allocate(rmatbox4_y_h(inum_Mxin2(1,nproc_id_global),Ndh,inum_Mxin2(3,nproc_id_global)))
+allocate(rmatbox4_z_h(inum_Mxin2(1,nproc_id_global),inum_Mxin2(2,nproc_id_global),Ndh))
 
 rmatbox1_x_h=0.d0
 rmatbox1_y_h=0.d0
@@ -453,6 +461,12 @@ rmatbox1_z_h=0.d0
 rmatbox2_x_h=0.d0
 rmatbox2_y_h=0.d0
 rmatbox2_z_h=0.d0
+rmatbox3_x_h=0.d0
+rmatbox3_y_h=0.d0
+rmatbox3_z_h=0.d0
+rmatbox4_x_h=0.d0
+rmatbox4_y_h=0.d0
+rmatbox4_z_h=0.d0
 
 allocate(cmatbox1_x_h(Ndh,inum_Mxin2(2,nproc_id_global),inum_Mxin2(3,nproc_id_global)))
 allocate(cmatbox1_y_h(inum_Mxin2(1,nproc_id_global),Ndh,inum_Mxin2(3,nproc_id_global)))

--- a/src/GCEED/modules/pack_unpack.f90
+++ b/src/GCEED/modules/pack_unpack.f90
@@ -1,0 +1,330 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+module pack_unpack
+  implicit none
+
+  type array_shape
+    integer :: nbeg
+    integer :: nend
+    integer :: nsize
+  end type
+
+  public :: array_shape
+  public :: create_array_shape
+  public :: pack_data, unpack_data
+  public :: copy_data
+
+  interface pack_data
+    module procedure pack_data_3d_real8
+    module procedure pack_data_3d_complex8
+    module procedure pack_data_5d_real8
+    module procedure pack_data_5d_complex8
+  end interface
+
+  interface unpack_data
+    module procedure unpack_data_3d_real8
+    module procedure unpack_data_3d_complex8
+    module procedure unpack_data_5d_real8
+    module procedure unpack_data_5d_complex8
+  end interface
+
+  interface copy_data
+    module procedure copy_data_3d_real8
+    module procedure copy_data_3d_complex8
+    module procedure copy_data_5d_real8
+    module procedure copy_data_5d_complex8
+  end interface
+
+contains
+  function create_array_shape(nbeg,nend,nsize) result(s)
+    implicit none
+    integer, intent(in)           :: nbeg,nend
+    integer, intent(in), optional :: nsize
+    type(array_shape) :: s
+    s%nbeg = nbeg
+    s%nend = nend
+    if (present(nsize)) then
+      s%nsize = nsize
+    else
+      s%nsize = abs(nend - nbeg) + 1
+    end if
+  end function
+
+  subroutine pack_data_3d_real8(nsrc_shape,ncopy_range,src,dst)
+    implicit none
+    type(array_shape), intent(in)  :: nsrc_shape(3)
+    type(array_shape), intent(in)  :: ncopy_range(3)
+    real(8),           intent(in)  :: src(nsrc_shape(1)%nbeg:nsrc_shape(1)%nend, &
+                                          nsrc_shape(2)%nbeg:nsrc_shape(2)%nend, &
+                                          nsrc_shape(3)%nbeg:nsrc_shape(3)%nend)
+    real(8),           intent(out) :: dst(ncopy_range(1)%nsize, &
+                                          ncopy_range(2)%nsize, &
+                                          ncopy_range(3)%nsize)
+    call copy_data(src(ncopy_range(1)%nbeg:ncopy_range(1)%nend,  &
+                       ncopy_range(2)%nbeg:ncopy_range(2)%nend,  &
+                       ncopy_range(3)%nbeg:ncopy_range(3)%nend), &
+                   dst)
+  end subroutine
+
+  subroutine pack_data_3d_complex8(nsrc_shape,ncopy_range,src,dst)
+    implicit none
+    type(array_shape), intent(in)  :: nsrc_shape(3)
+    type(array_shape), intent(in)  :: ncopy_range(3)
+    complex(8),        intent(in)  :: src(nsrc_shape(1)%nbeg:nsrc_shape(1)%nend, &
+                                          nsrc_shape(2)%nbeg:nsrc_shape(2)%nend, &
+                                          nsrc_shape(3)%nbeg:nsrc_shape(3)%nend)
+    complex(8),        intent(out) :: dst(ncopy_range(1)%nsize, &
+                                          ncopy_range(2)%nsize, &
+                                          ncopy_range(3)%nsize)
+    call copy_data(src(ncopy_range(1)%nbeg:ncopy_range(1)%nend,  &
+                       ncopy_range(2)%nbeg:ncopy_range(2)%nend,  &
+                       ncopy_range(3)%nbeg:ncopy_range(3)%nend), &
+                   dst)
+  end subroutine
+
+  subroutine pack_data_5d_real8(nsrc_shape,ncopy_range,src,dst)
+    implicit none
+    type(array_shape), intent(in)  :: nsrc_shape(5)
+    type(array_shape), intent(in)  :: ncopy_range(5)
+    real(8),           intent(in)  :: src(nsrc_shape(1)%nbeg:nsrc_shape(1)%nend, &
+                                          nsrc_shape(2)%nbeg:nsrc_shape(2)%nend, &
+                                          nsrc_shape(3)%nbeg:nsrc_shape(3)%nend, &
+                                          nsrc_shape(4)%nbeg:nsrc_shape(4)%nend, &
+                                          nsrc_shape(5)%nbeg:nsrc_shape(5)%nend)
+    real(8),           intent(out) :: dst(ncopy_range(1)%nsize, &
+                                          ncopy_range(2)%nsize, &
+                                          ncopy_range(3)%nsize, &
+                                          ncopy_range(4)%nsize, &
+                                          ncopy_range(5)%nsize)
+    call copy_data(src(ncopy_range(1)%nbeg:ncopy_range(1)%nend,  &
+                       ncopy_range(2)%nbeg:ncopy_range(2)%nend,  &
+                       ncopy_range(3)%nbeg:ncopy_range(3)%nend,  &
+                       ncopy_range(4)%nbeg:ncopy_range(4)%nend,  &
+                       ncopy_range(5)%nbeg:ncopy_range(5)%nend), &
+                   dst)
+  end subroutine
+
+  subroutine pack_data_5d_complex8(nsrc_shape,ncopy_range,src,dst)
+    implicit none
+    type(array_shape), intent(in)  :: nsrc_shape(5)
+    type(array_shape), intent(in)  :: ncopy_range(5)
+    complex(8),        intent(in)  :: src(nsrc_shape(1)%nbeg:nsrc_shape(1)%nend, &
+                                          nsrc_shape(2)%nbeg:nsrc_shape(2)%nend, &
+                                          nsrc_shape(3)%nbeg:nsrc_shape(3)%nend, &
+                                          nsrc_shape(4)%nbeg:nsrc_shape(4)%nend, &
+                                          nsrc_shape(5)%nbeg:nsrc_shape(5)%nend)
+    complex(8),        intent(out) :: dst(ncopy_range(1)%nsize, &
+                                          ncopy_range(2)%nsize, &
+                                          ncopy_range(3)%nsize, &
+                                          ncopy_range(4)%nsize, &
+                                          ncopy_range(5)%nsize)
+    call copy_data(src(ncopy_range(1)%nbeg:ncopy_range(1)%nend,  &
+                       ncopy_range(2)%nbeg:ncopy_range(2)%nend,  &
+                       ncopy_range(3)%nbeg:ncopy_range(3)%nend,  &
+                       ncopy_range(4)%nbeg:ncopy_range(4)%nend,  &
+                       ncopy_range(5)%nbeg:ncopy_range(5)%nend), &
+                   dst)
+  end subroutine
+
+  subroutine unpack_data_3d_real8(ndst_shape,ncopy_range,src,dst)
+    implicit none
+    type(array_shape), intent(in)  :: ndst_shape(3)
+    type(array_shape), intent(in)  :: ncopy_range(3)
+    real(8),           intent(in)  :: src(ncopy_range(1)%nsize, &
+                                          ncopy_range(2)%nsize, &
+                                          ncopy_range(3)%nsize)
+    real(8),           intent(out) :: dst(ndst_shape(1)%nbeg:ndst_shape(1)%nend, &
+                                          ndst_shape(2)%nbeg:ndst_shape(2)%nend, &
+                                          ndst_shape(3)%nbeg:ndst_shape(3)%nend)
+    call copy_data(src, &
+                   dst(ncopy_range(1)%nbeg:ncopy_range(1)%nend, &
+                       ncopy_range(2)%nbeg:ncopy_range(2)%nend, &
+                       ncopy_range(3)%nbeg:ncopy_range(3)%nend))
+  end subroutine
+
+  subroutine unpack_data_3d_complex8(ndst_shape,ncopy_range,src,dst)
+    implicit none
+    type(array_shape), intent(in)  :: ndst_shape(3)
+    type(array_shape), intent(in)  :: ncopy_range(3)
+    complex(8),        intent(in)  :: src(ncopy_range(1)%nsize, &
+                                          ncopy_range(2)%nsize, &
+                                          ncopy_range(3)%nsize)
+    complex(8),        intent(out) :: dst(ndst_shape(1)%nbeg:ndst_shape(1)%nend, &
+                                          ndst_shape(2)%nbeg:ndst_shape(2)%nend, &
+                                          ndst_shape(3)%nbeg:ndst_shape(3)%nend)
+    call copy_data(src, &
+                   dst(ncopy_range(1)%nbeg:ncopy_range(1)%nend, &
+                       ncopy_range(2)%nbeg:ncopy_range(2)%nend, &
+                       ncopy_range(3)%nbeg:ncopy_range(3)%nend))
+  end subroutine
+
+  subroutine unpack_data_5d_real8(ndst_shape,ncopy_range,src,dst)
+    implicit none
+    type(array_shape), intent(in)  :: ndst_shape(5)
+    type(array_shape), intent(in)  :: ncopy_range(5)
+    real(8),           intent(in)  :: src(ncopy_range(1)%nsize, &
+                                          ncopy_range(2)%nsize, &
+                                          ncopy_range(3)%nsize, &
+                                          ncopy_range(4)%nsize, &
+                                          ncopy_range(5)%nsize)
+    real(8),           intent(out) :: dst(ndst_shape(1)%nbeg:ndst_shape(1)%nend, &
+                                          ndst_shape(2)%nbeg:ndst_shape(2)%nend, &
+                                          ndst_shape(3)%nbeg:ndst_shape(3)%nend, &
+                                          ndst_shape(4)%nbeg:ndst_shape(4)%nend, &
+                                          ndst_shape(5)%nbeg:ndst_shape(5)%nend)
+    call copy_data(src, &
+                   dst(ncopy_range(1)%nbeg:ncopy_range(1)%nend, &
+                       ncopy_range(2)%nbeg:ncopy_range(2)%nend, &
+                       ncopy_range(3)%nbeg:ncopy_range(3)%nend, &
+                       ncopy_range(4)%nbeg:ncopy_range(4)%nend, &
+                       ncopy_range(5)%nbeg:ncopy_range(5)%nend))
+  end subroutine
+
+  subroutine unpack_data_5d_complex8(ndst_shape,ncopy_range,src,dst)
+    implicit none
+    type(array_shape), intent(in)  :: ndst_shape(5)
+    type(array_shape), intent(in)  :: ncopy_range(5)
+    complex(8),        intent(in)  :: src(ncopy_range(1)%nsize, &
+                                          ncopy_range(2)%nsize, &
+                                          ncopy_range(3)%nsize, &
+                                          ncopy_range(4)%nsize, &
+                                          ncopy_range(5)%nsize)
+    complex(8),        intent(out) :: dst(ndst_shape(1)%nbeg:ndst_shape(1)%nend, &
+                                          ndst_shape(2)%nbeg:ndst_shape(2)%nend, &
+                                          ndst_shape(3)%nbeg:ndst_shape(3)%nend, &
+                                          ndst_shape(4)%nbeg:ndst_shape(4)%nend, &
+                                          ndst_shape(5)%nbeg:ndst_shape(5)%nend)
+    call copy_data(src, &
+                   dst(ncopy_range(1)%nbeg:ncopy_range(1)%nend, &
+                       ncopy_range(2)%nbeg:ncopy_range(2)%nend, &
+                       ncopy_range(3)%nbeg:ncopy_range(3)%nend, &
+                       ncopy_range(4)%nbeg:ncopy_range(4)%nend, &
+                       ncopy_range(5)%nbeg:ncopy_range(5)%nend))
+  end subroutine
+
+
+  subroutine copy_data_3d_real8(src,dst)
+    implicit none
+    real(8), intent(in)  :: src(:,:,:)
+    real(8), intent(out) :: dst(:,:,:)
+    integer :: ix,iy,iz
+    integer :: nx,ny,nz
+
+    nz = size(src,3)
+    ny = size(src,2)
+    nx = size(src,1)
+
+!$omp parallel do collapse(2) default(none) &
+!$omp          private(ix,iy,iz) &
+!$omp          firstprivate(nx,ny,nz) &
+!$omp          shared(src,dst)
+    do iz=1,nz
+    do iy=1,ny
+    do ix=1,nx
+      dst(ix,iy,iz) = src(ix,iy,iz)
+    end do
+    end do
+    end do
+!$omp end parallel do
+  end subroutine
+
+  subroutine copy_data_3d_complex8(src,dst)
+    implicit none
+    complex(8), intent(in)  :: src(:,:,:)
+    complex(8), intent(out) :: dst(:,:,:)
+    integer :: ix,iy,iz
+    integer :: nx,ny,nz
+
+    nz = size(src,3)
+    ny = size(src,2)
+    nx = size(src,1)
+
+!$omp parallel do collapse(2) default(none) &
+!$omp          private(ix,iy,iz) &
+!$omp          firstprivate(nx,ny,nz) &
+!$omp          shared(src,dst)
+    do iz=1,nz
+    do iy=1,ny
+    do ix=1,nx
+      dst(ix,iy,iz) = src(ix,iy,iz)
+    end do
+    end do
+    end do
+!$omp end parallel do
+  end subroutine
+
+  subroutine copy_data_5d_real8(src,dst)
+    implicit none
+    real(8), intent(in)  :: src(:,:,:,:,:)
+    real(8), intent(out) :: dst(:,:,:,:,:)
+    integer :: nx,ny,nz,nw,nl
+    integer :: ix,iy,iz,iw,il
+
+    nl = size(src,5)
+    nw = size(src,4)
+    nz = size(src,3)
+    ny = size(src,2)
+    nx = size(src,1)
+
+!$omp parallel do collapse(4) default(none) &
+!$omp          private(ix,iy,iz,iw,il) &
+!$omp          firstprivate(nx,ny,nz,nw,nl) &
+!$omp          shared(src,dst)
+    do il=1,nl
+    do iw=1,nw
+    do iz=1,nz
+    do iy=1,ny
+    do ix=1,nx
+      dst(ix,iy,iz,iw,il) = src(ix,iy,iz,iw,il)
+    end do
+    end do
+    end do
+    end do
+    end do
+!$omp end parallel do
+  end subroutine
+
+  subroutine copy_data_5d_complex8(src,dst)
+    implicit none
+    complex(8), intent(in)  :: src(:,:,:,:,:)
+    complex(8), intent(out) :: dst(:,:,:,:,:)
+    integer :: nx,ny,nz,nw,nl
+    integer :: ix,iy,iz,iw,il
+
+    nl = size(src,5)
+    nw = size(src,4)
+    nz = size(src,3)
+    ny = size(src,2)
+    nx = size(src,1)
+
+!$omp parallel do collapse(4) default(none) &
+!$omp          private(ix,iy,iz,iw,il) &
+!$omp          firstprivate(nx,ny,nz,nw,nl) &
+!$omp          shared(src,dst)
+    do il=1,nl
+    do iw=1,nw
+    do iz=1,nz
+    do iy=1,ny
+    do ix=1,nx
+      dst(ix,iy,iz,iw,il) = src(ix,iy,iz,iw,il)
+    end do
+    end do
+    end do
+    end do
+    end do
+!$omp end parallel do
+  end subroutine
+end module

--- a/src/GCEED/modules/persistent_comm.f90
+++ b/src/GCEED/modules/persistent_comm.f90
@@ -32,6 +32,7 @@ contains
 
     call init_comm_orbital
     call init_comm_groupob
+    call init_comm_h
   end subroutine
 
   subroutine init_comm_orbital
@@ -188,5 +189,51 @@ contains
     nrange_groupob(1,12) = create_array_shape(mg_sta(1),  mg_sta(1)+mg_num(1)-1)
     nrange_groupob(2,12) = create_array_shape(mg_sta(2),  mg_sta(2)+mg_num(2)-1)
     nrange_groupob(3,12) = create_array_shape(mg_end(3)+1,mg_end(3)+Nd)
+  end subroutine
+
+  subroutine init_comm_h
+    implicit none
+
+    allocate(nreqs_rh(12,4))
+    call init_reqs_h(nreqs_rh(:,1),1)
+    call init_reqs_h(nreqs_rh(:,2),2)
+    call init_reqs_h(nreqs_rh(:,4),4)
+  end subroutine
+
+  subroutine init_reqs_h(ireqs,itype)
+    use init_sendrecv_sub
+    use salmon_parallel,      only: nproc_group_global, nproc_group_h
+    use salmon_communication, only: comm_send_init, comm_recv_init
+    implicit none
+    integer, intent(out) :: ireqs(12)
+    integer, intent(in)  :: itype
+    integer :: icomm
+    integer :: iup,idw,jup,jdw,kup,kdw
+
+    iup=iup_array(itype)
+    idw=idw_array(itype)
+    jup=jup_array(itype)
+    jdw=jdw_array(itype)
+    kup=kup_array(itype)
+    kdw=kdw_array(itype)
+
+    if (itype == 1) then
+      icomm = nproc_group_global
+    else
+      icomm = nproc_group_h
+    end if
+
+    ireqs( 1) = comm_send_init(rmatbox1_x_h,iup,3,icomm)
+    ireqs( 2) = comm_recv_init(rmatbox2_x_h,idw,3,icomm)
+    ireqs( 3) = comm_send_init(rmatbox3_x_h,idw,4,icomm)
+    ireqs( 4) = comm_recv_init(rmatbox4_x_h,iup,4,icomm)
+    ireqs( 5) = comm_send_init(rmatbox1_y_h,jup,5,icomm)
+    ireqs( 6) = comm_recv_init(rmatbox2_y_h,jdw,5,icomm)
+    ireqs( 7) = comm_send_init(rmatbox3_y_h,jdw,6,icomm)
+    ireqs( 8) = comm_recv_init(rmatbox4_y_h,jup,6,icomm)
+    ireqs( 9) = comm_send_init(rmatbox1_z_h,kup,7,icomm)
+    ireqs(10) = comm_recv_init(rmatbox2_z_h,kdw,7,icomm)
+    ireqs(11) = comm_send_init(rmatbox3_z_h,kdw,8,icomm)
+    ireqs(12) = comm_recv_init(rmatbox4_z_h,kup,8,icomm)
   end subroutine
 end module

--- a/src/GCEED/modules/persistent_comm.f90
+++ b/src/GCEED/modules/persistent_comm.f90
@@ -1,0 +1,138 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+module persistent_comm
+  use pack_unpack, only: array_shape
+
+integer,allocatable :: nreqs_rgroupob(:),nreqs_cgroupob(:)
+
+  type(array_shape),public,allocatable :: nshape_groupob(:),nrange_groupob(:,:)
+
+  public :: init_persistent_requests
+
+private
+contains
+  subroutine init_persistent_requests
+    implicit none
+
+    call init_comm_groupob
+  end subroutine
+
+  subroutine init_comm_groupob
+    use init_sendrecv_sub,    only: iup_array,idw_array,jup_array,jdw_array,kup_array,kdw_array
+    use salmon_parallel,      only: icomm => nproc_group_orbital
+    use salmon_communication, only: comm_send_init, comm_recv_init
+    use pack_unpack,          only: create_array_shape
+    use scf_data
+    implicit none
+    integer :: iup,idw,jup,jdw,kup,kdw
+
+    iup=iup_array(1)
+    idw=idw_array(1)
+    jup=jup_array(1)
+    jdw=jdw_array(1)
+    kup=kup_array(1)
+    kdw=kdw_array(1)
+
+    if(iSCFRT==1.and.icalcforce==1)then
+      allocate(nreqs_rgroupob(12))
+      nreqs_rgroupob( 1) = comm_send_init(srmatbox1_x_5d,iup,3,icomm)
+      nreqs_rgroupob( 2) = comm_recv_init(srmatbox2_x_5d,idw,3,icomm)
+      nreqs_rgroupob( 3) = comm_send_init(srmatbox3_x_5d,idw,4,icomm)
+      nreqs_rgroupob( 4) = comm_recv_init(srmatbox4_x_5d,iup,4,icomm)
+      nreqs_rgroupob( 5) = comm_send_init(srmatbox1_y_5d,jup,5,icomm)
+      nreqs_rgroupob( 6) = comm_recv_init(srmatbox2_y_5d,jdw,5,icomm)
+      nreqs_rgroupob( 7) = comm_send_init(srmatbox3_y_5d,jdw,6,icomm)
+      nreqs_rgroupob( 8) = comm_recv_init(srmatbox4_y_5d,jup,6,icomm)
+      nreqs_rgroupob( 9) = comm_send_init(srmatbox1_z_5d,kup,7,icomm)
+      nreqs_rgroupob(10) = comm_recv_init(srmatbox2_z_5d,kdw,7,icomm)
+      nreqs_rgroupob(11) = comm_send_init(srmatbox3_z_5d,kdw,8,icomm)
+      nreqs_rgroupob(12) = comm_recv_init(srmatbox4_z_5d,kup,8,icomm)
+    else if(iSCFRT==2.and.nproc_Mxin_mul/=1)then
+      allocate(nreqs_cgroupob(12))
+      nreqs_cgroupob( 1) = comm_send_init(scmatbox1_x_5d,iup,3,icomm)
+      nreqs_cgroupob( 2) = comm_recv_init(scmatbox2_x_5d,idw,3,icomm)
+      nreqs_cgroupob( 3) = comm_send_init(scmatbox3_x_5d,idw,4,icomm)
+      nreqs_cgroupob( 4) = comm_recv_init(scmatbox4_x_5d,iup,4,icomm)
+      nreqs_cgroupob( 5) = comm_send_init(scmatbox1_y_5d,jup,5,icomm)
+      nreqs_cgroupob( 6) = comm_recv_init(scmatbox2_y_5d,jdw,5,icomm)
+      nreqs_cgroupob( 7) = comm_send_init(scmatbox3_y_5d,jdw,6,icomm)
+      nreqs_cgroupob( 8) = comm_recv_init(scmatbox4_y_5d,jup,6,icomm)
+      nreqs_cgroupob( 9) = comm_send_init(scmatbox1_z_5d,kup,7,icomm)
+      nreqs_cgroupob(10) = comm_recv_init(scmatbox2_z_5d,kdw,7,icomm)
+      nreqs_cgroupob(11) = comm_send_init(scmatbox3_z_5d,kdw,8,icomm)
+      nreqs_cgroupob(12) = comm_recv_init(scmatbox4_z_5d,kup,8,icomm)
+    end if
+    allocate(nshape_groupob(5))
+    allocate(nrange_groupob(5,12))
+
+    nshape_groupob(1) = create_array_shape(mg_sta(1)-Nd, mg_end(1)+Nd+1)
+    nshape_groupob(2) = create_array_shape(mg_sta(2)-Nd, mg_end(2)+Nd)
+    nshape_groupob(3) = create_array_shape(mg_sta(3)-Nd, mg_end(3)+Nd)
+    nshape_groupob(4) = create_array_shape(1,iobnum)
+    nshape_groupob(5) = create_array_shape(1,1)
+
+    nrange_groupob(4,:) = create_array_shape(1,iobnum)
+    nrange_groupob(5,:) = create_array_shape(1,1)
+
+    nrange_groupob(1,1) = create_array_shape(mg_end(1)-Nd+1,mg_end(1))
+    nrange_groupob(2,1) = create_array_shape(mg_sta(2),     mg_sta(2)+mg_num(2)-1)
+    nrange_groupob(3,1) = create_array_shape(mg_sta(3),     mg_sta(3)+mg_num(3)-1)
+
+    nrange_groupob(1,2) = create_array_shape(mg_sta(1),mg_sta(1)+Nd-1)
+    nrange_groupob(2,2) = create_array_shape(mg_sta(2),mg_sta(2)+mg_num(2)-1)
+    nrange_groupob(3,2) = create_array_shape(mg_sta(3),mg_sta(3)+mg_num(3)-1)
+
+    nrange_groupob(1,3) = create_array_shape(mg_sta(1),     mg_sta(1)+mg_num(1)-1)
+    nrange_groupob(2,3) = create_array_shape(mg_end(2)-Nd+1,mg_end(2))
+    nrange_groupob(3,3) = create_array_shape(mg_sta(3),     mg_sta(3)+mg_num(3)-1)
+
+    nrange_groupob(1,4) = create_array_shape(mg_sta(1),mg_sta(1)+mg_num(1)-1)
+    nrange_groupob(2,4) = create_array_shape(mg_sta(2),mg_sta(2)+Nd-1)
+    nrange_groupob(3,4) = create_array_shape(mg_sta(3),mg_sta(3)+mg_num(3)-1)
+
+    nrange_groupob(1,5) = create_array_shape(mg_sta(1),     mg_sta(1)+mg_num(1)-1)
+    nrange_groupob(2,5) = create_array_shape(mg_sta(2),     mg_sta(2)+mg_num(2)-1)
+    nrange_groupob(3,5) = create_array_shape(mg_end(3)-Nd+1,mg_end(3))
+
+    nrange_groupob(1,6) = create_array_shape(mg_sta(1),mg_sta(1)+mg_num(1)-1)
+    nrange_groupob(2,6) = create_array_shape(mg_sta(2),mg_sta(2)+mg_num(2)-1)
+    nrange_groupob(3,6) = create_array_shape(mg_sta(3),mg_sta(3)+Nd-1)
+
+    nrange_groupob(1,7) = create_array_shape(mg_sta(1)-Nd,mg_sta(1)-1)
+    nrange_groupob(2,7) = create_array_shape(mg_sta(2),   mg_sta(2)+mg_num(2)-1)
+    nrange_groupob(3,7) = create_array_shape(mg_sta(3),   mg_sta(3)+mg_num(3)-1)
+
+    nrange_groupob(1,8) = create_array_shape(mg_end(1)+1,mg_end(1)+Nd)
+    nrange_groupob(2,8) = create_array_shape(mg_sta(2),  mg_sta(2)+mg_num(2)-1)
+    nrange_groupob(3,8) = create_array_shape(mg_sta(3),  mg_sta(3)+mg_num(3)-1)
+
+    nrange_groupob(1,9) = create_array_shape(mg_sta(1),   mg_sta(1)+mg_num(1)-1)
+    nrange_groupob(2,9) = create_array_shape(mg_sta(2)-Nd,mg_sta(2)-1)
+    nrange_groupob(3,9) = create_array_shape(mg_sta(3),   mg_sta(3)+mg_num(3)-1)
+
+    nrange_groupob(1,10) = create_array_shape(mg_sta(1),  mg_sta(1)+mg_num(1)-1)
+    nrange_groupob(2,10) = create_array_shape(mg_end(2)+1,mg_end(2)+Nd)
+    nrange_groupob(3,10) = create_array_shape(mg_sta(3),  mg_sta(3)+mg_num(3)-1)
+
+    nrange_groupob(1,11) = create_array_shape(mg_sta(1),   mg_sta(1)+mg_num(1)-1)
+    nrange_groupob(2,11) = create_array_shape(mg_sta(2),   mg_sta(2)+mg_num(2)-1)
+    nrange_groupob(3,11) = create_array_shape(mg_sta(3)-Nd,mg_sta(3)-1)
+
+    nrange_groupob(1,12) = create_array_shape(mg_sta(1),  mg_sta(1)+mg_num(1)-1)
+    nrange_groupob(2,12) = create_array_shape(mg_sta(2),  mg_sta(2)+mg_num(2)-1)
+    nrange_groupob(3,12) = create_array_shape(mg_end(3)+1,mg_end(3)+Nd)
+  end subroutine
+end module

--- a/src/GCEED/modules/sendrecv.f90
+++ b/src/GCEED/modules/sendrecv.f90
@@ -30,186 +30,87 @@ contains
 !==================================================================================================
 
 subroutine R_sendrecv(tpsi)
-  use salmon_parallel, only: nproc_group_orbital
-  use salmon_communication, only: comm_proc_null, comm_isend, comm_irecv, comm_wait_all
+  use salmon_communication, only: comm_proc_null, comm_start_all, comm_wait_all
+  use persistent_comm,      only: ireq => nreqs_rorbital, &
+                                  nrange => nrange_groupob, nshape => nshape_orbital
+  use pack_unpack
   implicit none
   real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd,mg_sta(2)-Nd:mg_end(2)+Nd, &
                   mg_sta(3)-Nd:mg_end(3)+Nd)
-  integer :: ix,iy,iz
   integer :: iup,idw,jup,jdw,kup,kdw
-  integer :: ireq(12)
-  integer :: icomm
-  
+
   iup=iup_array(1)
   idw=idw_array(1)
   jup=jup_array(1)
   jdw=jdw_array(1)
   kup=kup_array(1)
   kdw=kdw_array(1)
-  
-  icomm=nproc_group_orbital
-  
+
   !send from idw to iup
-  
   if(iup/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      srmatbox1_x_3d(ix,iy,iz)=tpsi(mg_end(1)-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,1), tpsi, srmatbox1_x_3d)
   end if
-  ireq(1) = comm_isend(srmatbox1_x_3d,iup,3,icomm)
-  ireq(2) = comm_irecv(srmatbox2_x_3d,idw,3,icomm)
-  
+  call comm_start_all(ireq(1:2))
+
   !send from iup to idw
-  
   if(idw/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      srmatbox3_x_3d(ix,iy,iz)=tpsi(mg_sta(1)+ix-1,iy+mg_sta(2)-1,iz+mg_sta(3)-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,2), tpsi, srmatbox3_x_3d)
   end if
-  ireq(3) = comm_isend(srmatbox3_x_3d,idw,4,icomm)
-  ireq(4) = comm_irecv(srmatbox4_x_3d,iup,4,icomm)
-  
+  call comm_start_all(ireq(3:4))
+
   !send from jdw to jup
-  
   if(jup/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      srmatbox1_y_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,mg_end(2)-Nd+iy,iz+mg_sta(3)-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,3), tpsi, srmatbox1_y_3d)
   end if
-  ireq(5) = comm_isend(srmatbox1_y_3d,jup,5,icomm)
-  ireq(6) = comm_irecv(srmatbox2_y_3d,jdw,5,icomm)
-  
+  call comm_start_all(ireq(5:6))
+
   !send from jup to jdw
-  
   if(jdw/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      srmatbox3_y_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,mg_sta(2)+iy-1,iz+mg_sta(3)-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,4), tpsi, srmatbox3_y_3d)
   end if
-  ireq(7) = comm_isend(srmatbox3_y_3d,jdw,6,icomm)
-  ireq(8) = comm_irecv(srmatbox4_y_3d,jup,6,icomm)
-  
+  call comm_start_all(ireq(7:8))
+
   !send from kdw to kup
-  
   if(kup/=comm_proc_null)then
-    do iz=1,Nd
-  !$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      srmatbox1_z_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,5), tpsi, srmatbox1_z_3d)
   end if
-  ireq( 9) = comm_isend(srmatbox1_z_3d,kup,7,icomm)
-  ireq(10) = comm_irecv(srmatbox2_z_3d,kdw,7,icomm)
-  
+  call comm_start_all(ireq(9:10))
+
   !send from kup to kdw
-  
   if(kdw/=comm_proc_null)then
-    do iz=1,Nd
-  !$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      srmatbox3_z_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,6), tpsi, srmatbox3_z_3d)
   end if
-  ireq(11) = comm_isend(srmatbox3_z_3d,kdw,8,icomm)
-  ireq(12) = comm_irecv(srmatbox4_z_3d,kup,8,icomm)
-  
-  
+  call comm_start_all(ireq(11:12))
+
+
   call comm_wait_all(ireq(1:2))
   if(idw/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      tpsi(mg_sta(1)-1-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1)=srmatbox2_x_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,7), srmatbox2_x_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(3:4))
   if(iup/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      tpsi(mg_end(1)+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1)=srmatbox4_x_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,8), srmatbox4_x_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(5:6))
   if(jdw/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,mg_sta(2)-1-Nd+iy,iz+mg_sta(3)-1)=srmatbox2_y_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,9), srmatbox2_y_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(7:8))
   if(jup/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,mg_end(2)+iy,iz+mg_sta(3)-1)=srmatbox4_y_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,10), srmatbox4_y_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(9:10))
   if(kdw/=comm_proc_null)then
-    do iz=1,Nd
-  !$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz)=srmatbox2_z_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,11), srmatbox2_z_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(11:12))
   if(kup/=comm_proc_null)then
-    do iz=1,Nd
-  !$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz)=srmatbox4_z_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,12), srmatbox4_z_3d, tpsi)
   end if
 
 end subroutine R_sendrecv
@@ -217,15 +118,14 @@ end subroutine R_sendrecv
 !==================================================================================================
 
 subroutine C_sendrecv(tpsi)
-  use salmon_parallel, only: nproc_group_orbital
-  use salmon_communication, only: comm_proc_null, comm_isend, comm_irecv, comm_wait_all
+  use salmon_communication, only: comm_proc_null, comm_start_all, comm_wait_all
+  use persistent_comm,      only: ireq => nreqs_corbital, &
+                                  nrange => nrange_groupob, nshape => nshape_groupob
+  use pack_unpack
   implicit none
   complex(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd,mg_sta(2)-Nd:mg_end(2)+Nd, &
                      mg_sta(3)-Nd:mg_end(3)+Nd)
-  integer :: ix,iy,iz
   integer :: iup,idw,jup,jdw,kup,kdw
-  integer :: icomm
-  integer :: ireq(12)
   
   iup=iup_array(1)
   idw=idw_array(1)
@@ -234,169 +134,71 @@ subroutine C_sendrecv(tpsi)
   kup=kup_array(1)
   kdw=kdw_array(1)
   
-  icomm=nproc_group_orbital
-  
   !send from idw to iup
-  
   if(iup/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      scmatbox1_x_3d(ix,iy,iz)=tpsi(mg_end(1)-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,1), tpsi, scmatbox1_x_3d)
   end if
-  ireq(1) = comm_isend(scmatbox1_x_3d,iup,3,icomm)
-  ireq(2) = comm_irecv(scmatbox2_x_3d,idw,3,icomm)
-  
+  call comm_start_all(ireq(1:2))
+
   !send from iup to idw
-  
   if(idw/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      scmatbox3_x_3d(ix,iy,iz)=tpsi(mg_sta(1)+ix-1,iy+mg_sta(2)-1,iz+mg_sta(3)-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,2), tpsi, scmatbox3_x_3d)
   end if
-  ireq(3) = comm_isend(scmatbox3_x_3d,idw,4,icomm)
-  ireq(4) = comm_irecv(scmatbox4_x_3d,iup,4,icomm)
-  
+  call comm_start_all(ireq(3:4))
+
   !send from jdw to jup
-  
   if(jup/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      scmatbox1_y_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,mg_end(2)-Nd+iy,iz+mg_sta(3)-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,3), tpsi, scmatbox1_y_3d)
   end if
-  ireq(5) = comm_isend(scmatbox1_y_3d,jup,5,icomm)
-  ireq(6) = comm_irecv(scmatbox2_y_3d,jdw,5,icomm)
-  
+  call comm_start_all(ireq(5:6))
+
   !send from jup to jdw
-  
   if(jdw/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      scmatbox3_y_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,mg_sta(2)+iy-1,iz+mg_sta(3)-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,4), tpsi, scmatbox3_y_3d)
   end if
-  ireq(7) = comm_isend(scmatbox3_y_3d,jdw,6,icomm)
-  ireq(8) = comm_irecv(scmatbox4_y_3d,jup,6,icomm)
-  
+  call comm_start_all(ireq(7:8))
+
   !send from kdw to kup
-  
   if(kup/=comm_proc_null)then
-    do iz=1,Nd
-  !$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      scmatbox1_z_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,5), tpsi, scmatbox1_z_3d)
   end if
-  ireq( 9) = comm_isend(scmatbox1_z_3d,kup,7,icomm)
-  ireq(10) = comm_irecv(scmatbox2_z_3d,kdw,7,icomm)
-  
+  call comm_start_all(ireq(9:10))
+
   !send from kup to kdw
-  
   if(kdw/=comm_proc_null)then
-    do iz=1,Nd
-  !$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      scmatbox3_z_3d(ix,iy,iz)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1)
-    end do
-    end do
-    end do
+    call pack_data(nshape(1:3), nrange(1:3,6), tpsi, scmatbox3_z_3d)
   end if
-  ireq(11) = comm_isend(scmatbox3_z_3d,kdw,8,icomm)
-  ireq(12) = comm_irecv(scmatbox4_z_3d,kup,8,icomm)
-  
-  
+  call comm_start_all(ireq(11:12))
+
+
   call comm_wait_all(ireq(1:2))
   if(idw/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      tpsi(mg_sta(1)-1-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1)=scmatbox2_x_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,7), scmatbox2_x_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(3:4))
   if(iup/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      tpsi(mg_end(1)+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1)=scmatbox4_x_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,8), scmatbox4_x_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(5:6))
   if(jdw/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,mg_sta(2)-1-Nd+iy,iz+mg_sta(3)-1)=scmatbox2_y_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,9), scmatbox2_y_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(7:8))
   if(jup/=comm_proc_null)then
-  !$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,mg_end(2)+iy,iz+mg_sta(3)-1)=scmatbox4_y_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,10), scmatbox4_y_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(9:10))
   if(kdw/=comm_proc_null)then
-    do iz=1,Nd
-  !$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz)=scmatbox2_z_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,11), scmatbox2_z_3d, tpsi)
   end if
-  
+
   call comm_wait_all(ireq(11:12))
   if(kup/=comm_proc_null)then
-    do iz=1,Nd
-  !$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz)=scmatbox4_z_3d(ix,iy,iz)
-    end do
-    end do
-    end do
+    call unpack_data(nshape(1:3), nrange(1:3,12), scmatbox4_z_3d, tpsi)
   end if
   
 end subroutine C_sendrecv

--- a/src/GCEED/modules/sendrecv_groupob.f90
+++ b/src/GCEED/modules/sendrecv_groupob.f90
@@ -20,25 +20,22 @@ use new_world_sub
 use init_sendrecv_sub
 
 interface sendrecv_groupob
-
   module procedure R_sendrecv_groupob, C_sendrecv_groupob
-
-end interface 
+end interface
 
 contains
 
 !==================================================================================================
 
 subroutine R_sendrecv_groupob(tpsi)
-use salmon_parallel, only: nproc_group_orbital
-use salmon_communication, only: comm_proc_null, comm_isend, comm_irecv, comm_wait_all
+use salmon_communication, only: comm_proc_null, comm_start_all, comm_wait_all
+use persistent_comm,      only: ireq => nreqs_rgroupob, &
+                                nrange => nrange_groupob, nshape => nshape_groupob
+use pack_unpack
 implicit none
 real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
                 mg_sta(3)-Nd:mg_end(3)+Nd,1:iobnum,1)
-integer :: ix,iy,iz,iob
 integer :: iup,idw,jup,jdw,kup,kdw
-integer :: ireq(12)
-integer :: icomm
 
 iup=iup_array(1)
 idw=idw_array(1)
@@ -47,193 +44,71 @@ jdw=jdw_array(1)
 kup=kup_array(1)
 kdw=kdw_array(1)
 
-icomm=nproc_group_orbital
-
 !send from idw to iup
-
 if(iup/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      srmatbox1_x_5d(ix,iy,iz,iob,1)=tpsi(mg_end(1)-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,1), tpsi, srmatbox1_x_5d)
 end if
-ireq(1) = comm_isend(srmatbox1_x_5d,iup,3,icomm)
-ireq(2) = comm_irecv(srmatbox2_x_5d,idw,3,icomm)
+call comm_start_all(ireq(1:2))
 
 !send from iup to idw
-
 if(idw/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      srmatbox3_x_5d(ix,iy,iz,iob,1)=tpsi(mg_sta(1)+ix-1,iy+mg_sta(2)-1,iz+mg_sta(3)-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,2), tpsi, srmatbox3_x_5d)
 end if
-ireq(3) = comm_isend(srmatbox3_x_5d,idw,4,icomm)
-ireq(4) = comm_irecv(srmatbox4_x_5d,iup,4,icomm)
+call comm_start_all(ireq(3:4))
 
 !send from jdw to jup
-
 if(jup/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) 
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      srmatbox1_y_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,mg_end(2)-Nd+iy,iz+mg_sta(3)-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,3), tpsi, srmatbox1_y_5d)
 end if
-ireq(5) = comm_isend(srmatbox1_y_5d,jup,5,icomm)
-ireq(6) = comm_irecv(srmatbox2_y_5d,jdw,5,icomm)
+call comm_start_all(ireq(5:6))
 
 !send from jup to jdw
-
 if(jdw/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) 
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      srmatbox3_y_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,mg_sta(2)+iy-1,iz+mg_sta(3)-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,4), tpsi, srmatbox3_y_5d)
 end if
-ireq(7) = comm_isend(srmatbox3_y_5d,jdw,6,icomm)
-ireq(8) = comm_irecv(srmatbox4_y_5d,jup,6,icomm)
+call comm_start_all(ireq(7:8))
 
 !send from kdw to kup
-
 if(kup/=comm_proc_null)then
-  do iob=1,iobnum
-    do iz=1,Nd
-!$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      srmatbox1_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,5), tpsi, srmatbox1_z_5d)
 end if
-ireq( 9)  = comm_isend(srmatbox1_z_5d,kup,7,icomm)
-ireq(10) = comm_irecv(srmatbox2_z_5d,kdw,7,icomm)
+call comm_start_all(ireq(9:10))
 
 !send from kup to kdw
-
 if(kdw/=comm_proc_null)then
-  do iob=1,iobnum
-    do iz=1,Nd
-!$OMP parallel do private(iy,ix) 
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      srmatbox3_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,6), tpsi, srmatbox3_z_5d)
 end if
-ireq(11) = comm_isend(srmatbox3_z_5d,kdw,8,icomm)
-ireq(12) = comm_irecv(srmatbox4_z_5d,kup,8,icomm)
+call comm_start_all(ireq(11:12))
 
 
 call comm_wait_all(ireq(1:2))
 if(idw/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) 
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      tpsi(mg_sta(1)-1-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1,iob,1)=srmatbox2_x_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,7), srmatbox2_x_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(3:4))
 if(iup/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      tpsi(mg_end(1)+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1,iob,1)=srmatbox4_x_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,8), srmatbox4_x_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(5:6))
 if(jdw/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,mg_sta(2)-1-Nd+iy,iz+mg_sta(3)-1,iob,1)=srmatbox2_y_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,9), srmatbox2_y_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(7:8))
 if(jup/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,mg_end(2)+iy,iz+mg_sta(3)-1,iob,1)=srmatbox4_y_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,10), srmatbox4_y_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(9:10))
 if(kdw/=comm_proc_null)then
-  do iob=1,iobnum
-    do iz=1,Nd
-!$OMP parallel do private(iy,ix) 
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz,iob,1)=srmatbox2_z_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,11), srmatbox2_z_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(11:12))
 if(kup/=comm_proc_null)then
-  do iob=1,iobnum
-    do iz=1,Nd
-!$OMP parallel do private(iy,ix) 
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz,iob,1)=srmatbox4_z_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,12), srmatbox4_z_5d, tpsi)
 end if
 
 end subroutine R_sendrecv_groupob
@@ -241,15 +116,14 @@ end subroutine R_sendrecv_groupob
 !==================================================================================================
 
 subroutine C_sendrecv_groupob(tpsi)
-use salmon_parallel, only: nproc_group_orbital
-use salmon_communication, only: comm_proc_null, comm_isend, comm_irecv, comm_wait_all
+use salmon_communication, only: comm_proc_null, comm_start_all, comm_wait_all
+use persistent_comm,      only: ireq => nreqs_cgroupob, &
+                                nrange => nrange_groupob, nshape => nshape_groupob
+use pack_unpack
 implicit none
 complex(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
                    mg_sta(3)-Nd:mg_end(3)+Nd,1:iobnum,1)
-integer :: ix,iy,iz,iob
 integer :: iup,idw,jup,jdw,kup,kdw
-integer :: icomm
-integer :: ireq(12)
 
 iup=iup_array(1)
 idw=idw_array(1)
@@ -258,193 +132,71 @@ jdw=jdw_array(1)
 kup=kup_array(1)
 kdw=kdw_array(1)
 
-icomm=nproc_group_orbital
-
 !send from idw to iup
-
 if(iup/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) 
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      scmatbox1_x_5d(ix,iy,iz,iob,1)=tpsi(mg_end(1)-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,1), tpsi, scmatbox1_x_5d)
 end if
-ireq(1) = comm_isend(scmatbox1_x_5d,iup,3,icomm)
-ireq(2) = comm_irecv(scmatbox2_x_5d,idw,3,icomm)
+call comm_start_all(ireq(1:2))
 
 !send from iup to idw
-
 if(idw/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      scmatbox3_x_5d(ix,iy,iz,iob,1)=tpsi(mg_sta(1)+ix-1,iy+mg_sta(2)-1,iz+mg_sta(3)-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,2), tpsi, scmatbox3_x_5d)
 end if
-ireq(3) = comm_isend(scmatbox3_x_5d,idw,4,icomm)
-ireq(4) = comm_irecv(scmatbox4_x_5d,iup,4,icomm)
+call comm_start_all(ireq(3:4))
 
 !send from jdw to jup
-
 if(jup/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) 
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      scmatbox1_y_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,mg_end(2)-Nd+iy,iz+mg_sta(3)-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,3), tpsi, scmatbox1_y_5d)
 end if
-ireq(5) = comm_isend(scmatbox1_y_5d,jup,5,icomm)
-ireq(6) = comm_irecv(scmatbox2_y_5d,jdw,5,icomm)
+call comm_start_all(ireq(5:6))
 
 !send from jup to jdw
-
 if(jdw/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      scmatbox3_y_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,mg_sta(2)+iy-1,iz+mg_sta(3)-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,4), tpsi, scmatbox3_y_5d)
 end if
-ireq(7) = comm_isend(scmatbox3_y_5d,jdw,6,icomm)
-ireq(8) = comm_irecv(scmatbox4_y_5d,jup,6,icomm)
+call comm_start_all(ireq(7:8))
 
 !send from kdw to kup
-
 if(kup/=comm_proc_null)then
-  do iob=1,iobnum
-    do iz=1,Nd
-!$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      scmatbox1_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)-Nd+iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,5), tpsi, scmatbox1_z_5d)
 end if
-ireq( 9) = comm_isend(scmatbox1_z_5d,kup,7,icomm)
-ireq(10) = comm_irecv(scmatbox2_z_5d,kdw,7,icomm)
+call comm_start_all(ireq(9:10))
 
 !send from kup to kdw
-
 if(kdw/=comm_proc_null)then
-  do iob=1,iobnum
-    do iz=1,Nd
-!$OMP parallel do private(iy,ix) 
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      scmatbox3_z_5d(ix,iy,iz,iob,1)=tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call pack_data(nshape, nrange(:,6), tpsi, scmatbox3_z_5d)
 end if
-ireq(11) = comm_isend(scmatbox3_z_5d,kdw,8,icomm)
-ireq(12) = comm_irecv(scmatbox4_z_5d,kup,8,icomm)
+call comm_start_all(ireq(11:12))
 
 
 call comm_wait_all(ireq(1:2))
 if(idw/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      tpsi(mg_sta(1)-1-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1,iob,1)=scmatbox2_x_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,7), scmatbox2_x_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(3:4))
 if(iup/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,mg_num(2)
-    do ix=1,Nd
-      tpsi(mg_end(1)+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1,iob,1)=scmatbox4_x_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,8), scmatbox4_x_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(5:6))
 if(jdw/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix)
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,mg_sta(2)-1-Nd+iy,iz+mg_sta(3)-1,iob,1)=scmatbox2_y_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,9), scmatbox2_y_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(7:8))
 if(jup/=comm_proc_null)then
-  do iob=1,iobnum
-!$OMP parallel do private(iz,iy,ix) 
-    do iz=1,mg_num(3)
-    do iy=1,Nd
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,mg_end(2)+iy,iz+mg_sta(3)-1,iob,1)=scmatbox4_y_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,10), scmatbox4_y_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(9:10))
 if(kdw/=comm_proc_null)then
-  do iob=1,iobnum
-    do iz=1,Nd
-!$OMP parallel do private(iy,ix) 
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz,iob,1)=scmatbox2_z_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,11), scmatbox2_z_5d, tpsi)
 end if
 
 call comm_wait_all(ireq(11:12))
 if(kup/=comm_proc_null)then
-  do iob=1,iobnum
-    do iz=1,Nd
-!$OMP parallel do private(iy,ix)
-    do iy=1,mg_num(2)
-    do ix=1,mg_num(1)
-      tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz,iob,1)=scmatbox4_z_5d(ix,iy,iz,iob,1)
-    end do
-    end do
-    end do
-  end do
+  call unpack_data(nshape, nrange(:,12), scmatbox4_z_5d, tpsi)
 end if
 
 end subroutine C_sendrecv_groupob

--- a/src/GCEED/modules/sendrecvh.f90
+++ b/src/GCEED/modules/sendrecvh.f90
@@ -21,7 +21,8 @@ implicit none
 
 INTERFACE sendrecvh
 
-  MODULE PROCEDURE R_sendrecvh,C_sendrecvh
+  module procedure R_sendrecvh
+  ! C_sendrecvh is never used in GCEED part.
 
 END INTERFACE
 
@@ -29,20 +30,18 @@ CONTAINS
 
 !======================================================================
 SUBROUTINE R_sendrecvh(wk2)
-use salmon_parallel, only: nproc_group_global, nproc_group_h
-use salmon_communication, only: comm_proc_null, comm_exchange
+use salmon_communication, only: comm_proc_null, comm_start_all, comm_wait_all
 use scf_data
 use init_sendrecv_sub
 use new_world_sub
+use pack_unpack
+use persistent_comm, only: nreqs_rh
 
 implicit none
 real(8) :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end(3))
 
-integer :: ibox
-integer :: ix,iy,iz
 integer :: iup,idw,jup,jdw,kup,kdw
-integer :: icomm
-
+integer :: ireqs(12)
 
 if(iwk_size>=1.and.iwk_size<=3)then
 
@@ -53,7 +52,7 @@ if(iwk_size>=1.and.iwk_size<=3)then
   kup=kup_array(1)
   kdw=kdw_array(1)
 
-  icomm=nproc_group_global
+  ireqs(:) = nreqs_rh(:,1)
 
 else if(iwk_size>=11.and.iwk_size<=13)then
 
@@ -64,7 +63,7 @@ else if(iwk_size>=11.and.iwk_size<=13)then
   kup=kup_array(2)
   kdw=kdw_array(2)
 
-  icomm=nproc_group_h
+  ireqs(:) = nreqs_rh(:,2)
 
 else if(iwk_size>=31.and.iwk_size<=33)then
 
@@ -75,184 +74,128 @@ else if(iwk_size>=31.and.iwk_size<=33)then
   kup=kup_array(4)
   kdw=kdw_array(4)
 
-  icomm=nproc_group_h
+  ireqs(:) = nreqs_rh(:,4)
 
 end if
 
+!=====================================================================-
 
 !send from idw to iup
-
-if(iwk_size>=1.and.iwk_size<=3)then
-  ibox=1
-else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
-  ibox=13
-end if
 if(iup/=comm_proc_null)then
-!$OMP parallel do private(iz,iy,ix)
-  do iz=1,iwk3num(3)
-  do iy=1,iwk3num(2)
-  do ix=1,Ndh
-    rmatbox1_x_h(ix,iy,iz)=wk2(iwk3end(1)-Ndh+ix,iy+iwk3sta(2)-1,iz+iwk3sta(3)-1)
-  end do
-  end do
-  end do
+    call copy_data(wk2(iwk3end(1)-Ndh+1:iwk3end(1),               &
+                       iwk3sta(2)      :iwk3sta(2)+iwk3num(2)-1,  &
+                       iwk3sta(3)      :iwk3sta(3)+iwk3num(3)-1), &
+                   rmatbox1_x_h)
 end if
-call comm_exchange(rmatbox1_x_h,iup,rmatbox2_x_h,idw,1,icomm)
-if(idw/=comm_proc_null)then
-!$OMP parallel do private(iz,iy,ix)
-  do iz=1,iwk3num(3)
-  do iy=1,iwk3num(2)
-  do ix=1,Ndh
-    wk2(iwk3sta(1)-1-Ndh+ix,iy+iwk3sta(2)-1,iz+iwk3sta(3)-1)=rmatbox2_x_h(ix,iy,iz)
-  end do
-  end do
-  end do
-end if
+call comm_start_all(ireqs(1:2))
 
 !send from iup to idw
-
-if(iwk_size>=1.and.iwk_size<=3)then
-  ibox=3
-else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
-  ibox=15
-end if
 if(idw/=comm_proc_null)then
-!$OMP parallel do private(iz,iy,ix)
-  do iz=1,iwk3num(3)
-  do iy=1,iwk3num(2)
-  do ix=1,Ndh
-    rmatbox1_x_h(ix,iy,iz)=wk2(iwk3sta(1)+ix-1,iy+iwk3sta(2)-1,iz+iwk3sta(3)-1)
-  end do
-  end do
-  end do
+    call copy_data(wk2(iwk3sta(1):iwk3sta(1)+Ndh-1,         &
+                       iwk3sta(2):iwk3sta(2)+iwk3num(2)-1,  &
+                       iwk3sta(3):iwk3sta(3)+iwk3num(3)-1), &
+                   rmatbox3_x_h)
 end if
-call comm_exchange(rmatbox1_x_h,idw,rmatbox2_x_h,iup,1,icomm)
-if(iup/=comm_proc_null)then
-!$OMP parallel do private(iz,iy,ix)
-  do iz=1,iwk3num(3)
-  do iy=1,iwk3num(2)
-  do ix=1,Ndh
-    wk2(iwk3end(1)+ix,iy+iwk3sta(2)-1,iz+iwk3sta(3)-1)=rmatbox2_x_h(ix,iy,iz)
-  end do
-  end do
-  end do
-end if
+call comm_start_all(ireqs(3:4))
 
+!=====================================================================-
 
 !send from jdw to jup
-
-if(iwk_size>=1.and.iwk_size<=3)then
-  ibox=5
-else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
-  ibox=17
-end if
 if(jup/=comm_proc_null)then
-!$OMP parallel do private(iz,iy,ix)
-  do iz=1,iwk3num(3)
-  do iy=1,Ndh
-  do ix=1,iwk3num(1)
-    rmatbox1_y_h(ix,iy,iz)=wk2(ix+iwk3sta(1)-1,iwk3end(2)-Ndh+iy,iz+iwk3sta(3)-1)
-  end do
-  end do
-  end do
+    call copy_data(wk2(iwk3sta(1)      :iwk3sta(1)+iwk3num(1)-1,  &
+                       iwk3end(2)-Ndh+1:iwk3end(2),               &
+                       iwk3sta(3)      :iwk3sta(3)+iwk3num(3)-1), &
+                   rmatbox1_y_h)
 end if
-call comm_exchange(rmatbox1_y_h,jup,rmatbox2_y_h,jdw,1,icomm)
-if(jdw/=comm_proc_null)then
-!$OMP parallel do private(iz,iy,ix)
-  do iz=1,iwk3num(3)
-  do iy=1,Ndh
-  do ix=1,iwk3num(1)
-    wk2(ix+iwk3sta(1)-1,iwk3sta(2)-1-Ndh+iy,iz+iwk3sta(3)-1)=rmatbox2_y_h(ix,iy,iz)
-  end do
-  end do
-  end do
-end if
+call comm_start_all(ireqs(5:6))
 
 !send from jup to jdw
-
-if(iwk_size>=1.and.iwk_size<=3)then
-  ibox=7
-else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
-  ibox=19
-end if
 if(jdw/=comm_proc_null)then
-!$OMP parallel do private(iz,iy,ix)
-  do iz=1,iwk3num(3)
-  do iy=1,Ndh
-  do ix=1,iwk3num(1)
-    rmatbox1_y_h(ix,iy,iz)=wk2(ix+iwk3sta(1)-1,iwk3sta(2)+iy-1,iz+iwk3sta(3)-1)
-  end do
-  end do
-  end do
+    call copy_data(wk2(iwk3sta(1):iwk3sta(1)+iwk3num(1)-1,  &
+                       iwk3sta(2):iwk3sta(2)+Ndh-1,         &
+                       iwk3sta(3):iwk3sta(3)+iwk3num(3)-1), &
+                   rmatbox3_y_h)
 end if
-call comm_exchange(rmatbox1_y_h,jdw,rmatbox2_y_h,jup,1,icomm)
-if(jup/=comm_proc_null)then
-!$OMP parallel do private(iz,iy,ix)
-  do iz=1,iwk3num(3)
-  do iy=1,Ndh
-  do ix=1,iwk3num(1)
-    wk2(ix+iwk3sta(1)-1,iwk3end(2)+iy,iz+iwk3sta(3)-1)=rmatbox2_y_h(ix,iy,iz)
-  end do
-  end do
-  end do
-end if
+call comm_start_all(ireqs(7:8))
+
+!=====================================================================-
 
 !send from kdw to kup
-
-if(iwk_size>=1.and.iwk_size<=3)then
-  ibox=9
-else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
-  ibox=21
-end if
 if(kup/=comm_proc_null)then
-  do iz=1,Ndh
-!$OMP parallel do  private(iy,ix)
-  do iy=1,iwk3num(2)
-  do ix=1,iwk3num(1)
-    rmatbox1_z_h(ix,iy,iz)=wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3end(3)-Ndh+iz)
-  end do
-  end do
-  end do
+    call copy_data(wk2(iwk3sta(1)      :iwk3sta(1)+iwk3num(1)-1, &
+                       iwk3sta(2)      :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3end(3)-Ndh+1:iwk3end(3)),             &
+                   rmatbox1_z_h)
 end if
-call comm_exchange(rmatbox1_z_h,kup,rmatbox2_z_h,kdw,1,icomm)
-if(kdw/=comm_proc_null)then
-  do iz=1,Ndh
-!$OMP parallel do private(iy,ix)
-  do iy=1,iwk3num(2)
-  do ix=1,iwk3num(1)
-    wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3sta(3)-1-Ndh+iz)=rmatbox2_z_h(ix,iy,iz)
-  end do
-  end do
-  end do
-end if
+call comm_start_all(ireqs(9:10))
 
 !send from kup to kdw
-
-if(iwk_size>=1.and.iwk_size<=3)then
-  ibox=11
-else if((iwk_size>=11.and.iwk_size<=13).or.(iwk_size>=31.and.iwk_size<=33))then
-  ibox=23
-end if
 if(kdw/=comm_proc_null)then
-  do iz=1,Ndh
-!$OMP parallel do private(iy,ix)
-  do iy=1,iwk3num(2)
-  do ix=1,iwk3num(1)
-    rmatbox1_z_h(ix,iy,iz)=wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3sta(3)+iz-1)
-  end do
-  end do
-  end do
+    call copy_data(wk2(iwk3sta(1):iwk3sta(1)+iwk3num(1)-1,  &
+                       iwk3sta(2):iwk3sta(2)+iwk3num(2)-1,  &
+                       iwk3sta(3):iwk3sta(3)+Ndh-1),        &
+                   rmatbox3_z_h)
 end if
-call comm_exchange(rmatbox1_z_h,kdw,rmatbox2_z_h,kup,1,icomm)
+call comm_start_all(ireqs(11:12))
+
+!=====================================================================-
+
+!recv from idw to iup
+call comm_wait_all(ireqs(1:2))
+if(idw/=comm_proc_null)then
+    call copy_data(rmatbox2_x_h,                               &
+                   wk2(iwk3sta(1)-Ndh:iwk3sta(1),              &
+                       iwk3sta(2)    :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3sta(3)    :iwk3sta(3)+iwk3num(3)-1))
+end if
+
+!recv from iup to idw
+call comm_wait_all(ireqs(3:4))
+if(iup/=comm_proc_null)then
+    call copy_data(rmatbox4_x_h,                             &
+                   wk2(iwk3end(1)+1:iwk3end(1)+Ndh,          &
+                       iwk3sta(2)  :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3sta(3)  :iwk3sta(3)+iwk3num(3)-1))
+end if
+
+!=====================================================================-
+
+!recv from jdw to jup
+call comm_wait_all(ireqs(5:6))
+if(jdw/=comm_proc_null)then
+    call copy_data(rmatbox2_y_h,                               &
+                   wk2(iwk3sta(1)    :iwk3sta(1)+iwk3num(1)-1, &
+                       iwk3sta(2)-Ndh:iwk3sta(2),              &
+                       iwk3sta(3)    :iwk3sta(3)+iwk3num(3)-1))
+end if
+
+!recv from jup to jdw
+call comm_wait_all(ireqs(7:8))
+if(jup/=comm_proc_null)then
+    call copy_data(rmatbox4_y_h,                              &
+                   wk2(iwk3sta(1)   :iwk3sta(1)+iwk3num(1)-1, &
+                        iwk3end(2)+1:iwk3end(2)+Ndh,          &
+                        iwk3sta(3)  :iwk3sta(3)+iwk3num(3)-1))
+end if
+
+!=====================================================================-
+
+!recv from kdw to kup
+call comm_wait_all(ireqs(9:10))
+if(kdw/=comm_proc_null)then
+    call copy_data(rmatbox2_z_h,                               &
+                   wk2(iwk3sta(1)    :iwk3sta(1)+iwk3num(1)-1, &
+                       iwk3sta(2)    :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3sta(3)-Ndh:iwk3sta(3)))
+end if
+
+!recv from kup to kdw
+call comm_wait_all(ireqs(11:12))
 if(kup/=comm_proc_null)then
-  do iz=1,Ndh
-!$OMP parallel do private(iy,ix)
-  do iy=1,iwk3num(2)
-  do ix=1,iwk3num(1)
-    wk2(ix+iwk3sta(1)-1,iy+iwk3sta(2)-1,iwk3end(3)+iz)=rmatbox2_z_h(ix,iy,iz)
-  end do
-  end do
-  end do
+    call copy_data(rmatbox4_z_h,                             &
+                   wk2(iwk3sta(1)  :iwk3sta(1)+iwk3num(1)-1, &
+                       iwk3sta(2)  :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3end(3)+1:iwk3end(3)+Ndh))
 end if
 
 return

--- a/src/GCEED/rt/real_time_dft.f90
+++ b/src/GCEED/rt/real_time_dft.f90
@@ -23,6 +23,7 @@ use new_world_sub
 use Total_Energy_sub
 use read_pslfile_sub
 use allocate_psl_sub
+use persistent_comm
 
 implicit none
 
@@ -193,6 +194,7 @@ call init_itype
 call init_sendrecv_matrix
 
 call allocate_sendrecv
+call init_persistent_requests
 
 if(ilsda==0)then
   numspin=1

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -30,6 +30,7 @@ use calc_density_sub
 use change_order_sub
 use read_pslfile_sub
 use allocate_psl_sub
+use persistent_comm
 implicit none
 
 END MODULE global_variables_scf
@@ -116,6 +117,7 @@ if(istopt==1)then
     call allocate_mat
     call set_icoo1d
     call allocate_sendrecv
+    call init_persistent_requests
     allocate( Vpsl(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)) )
     if(icalcforce==1)then
       allocate( Vpsl_atom(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),MI) )
@@ -198,6 +200,7 @@ if(istopt==1)then
     call allocate_mat
     call set_icoo1d
     call allocate_sendrecv
+    call init_persistent_requests
 
     if(iflag_ps/=0) then
       call read_pslfile

--- a/src/parallel/salmon_communication.f90
+++ b/src/parallel/salmon_communication.f90
@@ -105,12 +105,20 @@ module salmon_communication
   end interface
 
   interface comm_send_init
+    ! 3-D array
+    module procedure comm_send_init_array3d_double
+    module procedure comm_send_init_array3d_dcomplex
+
     ! 5-D array
     module procedure comm_send_init_array5d_double
     module procedure comm_send_init_array5d_dcomplex
   end interface
 
   interface comm_recv_init
+    ! 3-D array
+    module procedure comm_recv_init_array3d_double
+    module procedure comm_recv_init_array3d_dcomplex
+
     ! 5-D array
     module procedure comm_recv_init_array5d_double
     module procedure comm_recv_init_array5d_dcomplex
@@ -440,6 +448,23 @@ contains
     MPI_ERROR_CHECK(call MPI_Waitall(size(reqs), reqs, MPI_STATUSES_IGNORE, ierr))
   end subroutine
 
+  function comm_send_init_array3d_double(invalue, ndest, ntag, ngroup) result(req)
+    use mpi, only: MPI_DOUBLE_PRECISION
+    implicit none
+    real(8), intent(in) :: invalue(:,:,:)
+    integer, intent(in) :: ndest, ntag, ngroup
+    integer :: ierr, req
+    MPI_ERROR_CHECK(call MPI_Send_init(invalue, size(invalue), MPI_DOUBLE_PRECISION, ndest, ntag, ngroup, req, ierr))
+  end function
+
+  function comm_send_init_array3d_dcomplex(invalue, ndest, ntag, ngroup) result(req)
+    use mpi, only: MPI_DOUBLE_COMPLEX
+    implicit none
+    complex(8), intent(in) :: invalue(:,:,:)
+    integer, intent(in)    :: ndest, ntag, ngroup
+    integer :: ierr, req
+    MPI_ERROR_CHECK(call MPI_Send_init(invalue, size(invalue), MPI_DOUBLE_COMPLEX, ndest, ntag, ngroup, req, ierr))
+  end function
 
   function comm_send_init_array5d_double(invalue, ndest, ntag, ngroup) result(req)
     use mpi, only: MPI_DOUBLE_PRECISION
@@ -457,6 +482,24 @@ contains
     integer, intent(in)    :: ndest, ntag, ngroup
     integer :: ierr, req
     MPI_ERROR_CHECK(call MPI_Send_init(invalue, size(invalue), MPI_DOUBLE_COMPLEX, ndest, ntag, ngroup, req, ierr))
+  end function
+
+  function comm_recv_init_array3d_double(outvalue, nsrc, ntag, ngroup) result(req)
+    use mpi, only: MPI_DOUBLE_PRECISION
+    implicit none
+    real(8), intent(out) :: outvalue(:,:,:)
+    integer, intent(in)  :: nsrc, ntag, ngroup
+    integer :: ierr, req
+    MPI_ERROR_CHECK(call MPI_Recv_init(outvalue, size(outvalue), MPI_DOUBLE_PRECISION, nsrc, ntag, ngroup, req, ierr))
+  end function
+
+  function comm_recv_init_array3d_dcomplex(outvalue, nsrc, ntag, ngroup) result(req)
+    use mpi, only: MPI_DOUBLE_COMPLEX
+    implicit none
+    complex(8), intent(out) :: outvalue(:,:,:)
+    integer, intent(in)     :: nsrc, ntag, ngroup
+    integer :: ierr, req
+    MPI_ERROR_CHECK(call MPI_Recv_init(outvalue, size(outvalue), MPI_DOUBLE_COMPLEX, nsrc, ntag, ngroup, req, ierr))
   end function
 
   function comm_recv_init_array5d_double(outvalue, nsrc, ntag, ngroup) result(req)

--- a/src/parallel/salmon_communication_dummy.f90
+++ b/src/parallel/salmon_communication_dummy.f90
@@ -102,12 +102,20 @@ module salmon_communication
   end interface
 
   interface comm_send_init
+    ! 3-D array
+    module procedure comm_send_init_array3d_double
+    module procedure comm_send_init_array3d_dcomplex
+
     ! 5-D array
     module procedure comm_send_init_array5d_double
     module procedure comm_send_init_array5d_dcomplex
   end interface
 
   interface comm_recv_init
+    ! 3-D array
+    module procedure comm_recv_init_array3d_double
+    module procedure comm_recv_init_array3d_dcomplex
+
     ! 5-D array
     module procedure comm_recv_init_array5d_double
     module procedure comm_recv_init_array5d_dcomplex
@@ -441,6 +449,30 @@ contains
   end subroutine
 
 
+  function comm_send_init_array3d_double(invalue, ndest, ntag, ngroup) result(req)
+    implicit none
+    real(8), intent(in) :: invalue(:,:,:)
+    integer, intent(in) :: ndest, ntag, ngroup
+    integer :: req
+    UNUSED_VARIABLE(invalue)
+    UNUSED_VARIABLE(ndest)
+    UNUSED_VARIABLE(ntag)
+    UNUSED_VARIABLE(ngroup)
+    UNUSED_VARIABLE(req)
+  end function
+
+  function comm_send_init_array3d_dcomplex(invalue, ndest, ntag, ngroup) result(req)
+    implicit none
+    complex(8), intent(in) :: invalue(:,:,:)
+    integer, intent(in)    :: ndest, ntag, ngroup
+    integer :: req
+    UNUSED_VARIABLE(invalue)
+    UNUSED_VARIABLE(ndest)
+    UNUSED_VARIABLE(ntag)
+    UNUSED_VARIABLE(ngroup)
+    UNUSED_VARIABLE(req)
+  end function
+
   function comm_send_init_array5d_double(invalue, ndest, ntag, ngroup) result(req)
     implicit none
     real(8), intent(in) :: invalue(:,:,:,:,:)
@@ -460,6 +492,30 @@ contains
     integer :: req
     UNUSED_VARIABLE(invalue)
     UNUSED_VARIABLE(ndest)
+    UNUSED_VARIABLE(ntag)
+    UNUSED_VARIABLE(ngroup)
+    UNUSED_VARIABLE(req)
+  end function
+
+  function comm_recv_init_array3d_double(outvalue, nsrc, ntag, ngroup) result(req)
+    implicit none
+    real(8), intent(out) :: outvalue(:,:,:)
+    integer, intent(in)  :: nsrc, ntag, ngroup
+    integer :: req
+    UNUSED_VARIABLE(outvalue)
+    UNUSED_VARIABLE(nsrc)
+    UNUSED_VARIABLE(ntag)
+    UNUSED_VARIABLE(ngroup)
+    UNUSED_VARIABLE(req)
+  end function
+
+  function comm_recv_init_array3d_dcomplex(outvalue, nsrc, ntag, ngroup) result(req)
+    implicit none
+    complex(8), intent(out) :: outvalue(:,:,:)
+    integer, intent(in)     :: nsrc, ntag, ngroup
+    integer :: req
+    UNUSED_VARIABLE(outvalue)
+    UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(req)


### PR DESCRIPTION
I optimized halo communications (peer-to-peer communications) in GCEED part as follows:

1. optimize pack/unpack routines.
2. use persistent communication of MPI.

I checked the performance results under Xeon Phi 16 nodes, this PR reduced 20% of total execution time when RT calculation.

## Verification of results

I verified calculation results with C2H2 molecule example under Xeon Phi as following process distributions:

1. Xeon Phi executes with 16 MPI processes
2. `nproc_ob` sets `2`.
3. `nproc_domain` sets `2,2,2`
4. `nproc_domain_s` sets `4,2,2`

## Note

I will send PR for reducing and unifying halo communications after merged it.

## Suggestion
`C_sendrecvh` and `sendrecv_groupob_ngp` are never used, so I suggest that remove it.