### PR TITLE
Add condition to k_shift_wf_last

### DIFF
--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -420,7 +420,9 @@ subroutine tddft_sc
 !====Analyzing calculation====================
 
 !Adiabatic evolution
-  call k_shift_wf_last(Rion_update_rt,10,zu_t)
+  if (projection_option /= 'no') then
+    call k_shift_wf_last(Rion_update_rt,10,zu_t)
+  end if
 
   call Fourier_tr
 

--- a/testsuites/001_bulk_gs_rt/verification
+++ b/testsuites/001_bulk_gs_rt/verification
@@ -22,13 +22,13 @@ checklist = {
     # Total Energy Check
     "Eall": [
         r"^\s*Eall\s*=\s*([E\+\-\.\d]+)\s*$",  # Regular expression
-        -31.1739726751449,  # Reference value
+        -3.095228e+01,  # Reference value
         0.1,  # Permissible error
     ],
     # Bandgap Check
     "Bandgap": [
         r"^\s*The Bandgap\s+([E\+\-\.\d]+)\s*$",  # Regular expression
-        5.686255746897059E-002,  # Reference value
+        5.607843e-02,  # Reference value
         1E-3,  # Permissible error
     ],
 }


### PR DESCRIPTION
## About This Pull Request

This pull request contains the modification to avoid to call `k_shift_wf_last` when `projection_option == 'no'`). Originally, the above subroutine provides the `_last_bandmap.out` file and the projected overlaps at the end of the real-time calculation. In the ARTED mode, this calculation is always performed regardless of the setting. However, it consumes relativity large computation time when the system size and number of the electrons are large. Therefore, we prefer to skip this routine when `projection_option` is not specified, due to the convenience of the general users.

## Acknowledgement
- The author thanks @ayamada224 san for the bug report and fruitful comments.

## Command to Jenkins
- testmode = all
