### PR TITLE
Enable testing under CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 # recommended version : 3.0.2
 cmake_minimum_required(VERSION 2.8)
+enable_testing()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmakefiles/Platforms)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmakefiles/Modules)
 include(${CMAKE_SOURCE_DIR}/cmakefiles/misc.cmake)
@@ -184,6 +186,10 @@ set(SALMON_MISC_LIB      "misc_rtl")
 
 set(SALMON_SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 add_subdirectory(${SALMON_SRC_DIR})
+
+# test directory
+set(SALMON_TEST_DIR ${CMAKE_SOURCE_DIR}/testsuites)
+add_subdirectory(${SALMON_TEST_DIR})
 
 message(STATUS "Enabled macro")
 get_directory_property(MACRO_LOG COMPILE_DEFINITIONS)

--- a/cmakefiles/create_test.cmake
+++ b/cmakefiles/create_test.cmake
@@ -1,0 +1,22 @@
+function(create_test)
+  get_filename_component(TEST_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+  set(TEST_EXEC "wrap_mpiexec_${TEST_NAME}.sh")
+
+  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/preparation  DESTINATION ${CMAKE_CURRENT_BINARY_DIR} FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE)
+  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/inputfile    DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/verification DESTINATION ${CMAKE_CURRENT_BINARY_DIR} FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE)
+
+  add_custom_command(OUTPUT  ${TEST_EXEC}
+                     COMMAND echo '\#! /bin/sh'                                             >  ${TEST_EXEC}
+                     COMMAND echo "${TEST_MPI_COMMAND}" '< ./inputfile |& tee ./outputfile' >> ${TEST_EXEC}
+                     COMMAND chmod +x ${TEST_EXEC})
+  add_custom_target("gen_${TEST_NAME}" ALL DEPENDS ${TEST_EXEC} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+  add_test(NAME "prep_${TEST_NAME}"   COMMAND preparation)
+  add_test(NAME "run_${TEST_NAME}"    COMMAND ${TEST_EXEC})
+  add_test(NAME "verify_${TEST_NAME}" COMMAND verification)
+
+  set_tests_properties("run_${TEST_NAME}"    PROPERTIES RUN_SERIAL ENABLE)
+  set_tests_properties("run_${TEST_NAME}"    PROPERTIES DEPENDS "prep_${TEST_NAME}")
+  set_tests_properties("verify_${TEST_NAME}" PROPERTIES DEPENDS "run_${TEST_NAME}")
+endfunction(create_test)

--- a/testsuites/001_bulk_gs_rt/CMakeLists.txt
+++ b/testsuites/001_bulk_gs_rt/CMakeLists.txt
@@ -1,0 +1,1 @@
+create_test()

--- a/testsuites/CMakeLists.txt
+++ b/testsuites/CMakeLists.txt
@@ -1,0 +1,15 @@
+include(${CMAKE_SOURCE_DIR}/cmakefiles/create_test.cmake)
+
+find_package(MPI REQUIRED) # find executable file for running MPI application.
+
+set(TEST_MPI_NPROC   4)
+set(TEST_MPI_COMMAND "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${TEST_MPI_NPROC} ${CMAKE_BINARY_DIR}/${TARGET_NAME}")
+message(STATUS "testing MPI: ${TEST_MPI_COMMAND}")
+
+add_custom_target("check_test_requirements" COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS ${TARGET_NAME})
+add_custom_target("test_preparations" ALL
+                  COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan "generate ctest scripts"
+                  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/pseudo" "${CMAKE_CURRENT_BINARY_DIR}/pseudo")
+
+# test directories
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/001_bulk_gs_rt")


### PR DESCRIPTION
This PR enables test suites under CMake.
Test configuration and requirement are same as PR #167 by @uemoto1 san.
When adding a new test case, you work as following steps for enabling tests under CMake.

1. Add `add_subdirectory` command at `testsuites/CMakeLists.txt`
2. Add CMakeLists.txt to new test directory, it writes one-line: `create_test()`

Would you please refer to `testsuites/CMakeLists.txt` and `testsuites/001_bulk_gs_rt/CMakeLists.txt`.

You can execute all tests in top build directory:

    $ make test
    or
    $ ctest .

If you want verbose mode (stdout print to window), it types to:

    $ ctest -V .