### PR TITLE
performance_analyzer.f90 hides performance log of uncalled routines.

### DIFF
--- a/src/ARTED/modules/performance_analyzer.f90
+++ b/src/ARTED/modules/performance_analyzer.f90
@@ -92,6 +92,7 @@ contains
     use salmon_parallel
     use salmon_communication
     use timer
+    use ieee_arithmetic
     implicit none
     integer,intent(in) :: iounit
 
@@ -122,18 +123,18 @@ contains
     if (comm_is_root(nproc_id_global)) then
       write (iounit,'(A)') 'Load balance check [sec]'
       write (iounit,'(A,4(A12))') 'Function    ','min','max','diff','rel'
-      write (iounit,f)            'dt_evolve   ',rmin( 1),rmax( 1),diff( 1),rel( 1)
-      write (iounit,f)            'hpsi        ',rmin( 2),rmax( 2),diff( 2),rel( 2)
-      write (iounit,f)            'psi_rho     ',rmin( 3),rmax( 3),diff( 3),rel( 3)
-      write (iounit,f)            'hartree     ',rmin( 4),rmax( 4),diff( 4),rel( 4)
-      write (iounit,f)            'current     ',rmin( 5),rmax( 5),diff( 5),rel( 5)
-      write (iounit,f)            'total_energy',rmin( 6),rmax( 6),diff( 6),rel( 6)
-      write (iounit,f)            'ion_force   ',rmin( 7),rmax( 7),diff( 7),rel( 7)
-      write (iounit,f)            'dt_evolve_ac',rmin( 8),rmax( 8),diff( 8),rel( 8)
-      write (iounit,f)            'k_shift_wf  ',rmin( 9),rmax( 9),diff( 9),rel( 9)
-      write (iounit,f)            'other       ',rmin(10),rmax(10),diff(10),rel(10)
-      write (iounit,f)            'allreduce   ',rmin(11),rmax(11),diff(11),rel(11)
-      write (iounit,f)            'dynamics    ',rmin(12),rmax(12),diff(12),rel(12)
+      if (.NOT. ieee_is_nan(rel( 1))) write (iounit,f) 'dt_evolve   ',rmin( 1),rmax( 1),diff( 1),rel( 1)
+      if (.NOT. ieee_is_nan(rel( 2))) write (iounit,f) 'hpsi        ',rmin( 2),rmax( 2),diff( 2),rel( 2)
+      if (.NOT. ieee_is_nan(rel( 3))) write (iounit,f) 'psi_rho     ',rmin( 3),rmax( 3),diff( 3),rel( 3)
+      if (.NOT. ieee_is_nan(rel( 4))) write (iounit,f) 'hartree     ',rmin( 4),rmax( 4),diff( 4),rel( 4)
+      if (.NOT. ieee_is_nan(rel( 5))) write (iounit,f) 'current     ',rmin( 5),rmax( 5),diff( 5),rel( 5)
+      if (.NOT. ieee_is_nan(rel( 6))) write (iounit,f) 'total_energy',rmin( 6),rmax( 6),diff( 6),rel( 6)
+      if (.NOT. ieee_is_nan(rel( 7))) write (iounit,f) 'ion_force   ',rmin( 7),rmax( 7),diff( 7),rel( 7)
+      if (.NOT. ieee_is_nan(rel( 8))) write (iounit,f) 'dt_evolve_ac',rmin( 8),rmax( 8),diff( 8),rel( 8)
+      if (.NOT. ieee_is_nan(rel( 9))) write (iounit,f) 'k_shift_wf  ',rmin( 9),rmax( 9),diff( 9),rel( 9)
+      if (.NOT. ieee_is_nan(rel(10))) write (iounit,f) 'other       ',rmin(10),rmax(10),diff(10),rel(10)
+      if (.NOT. ieee_is_nan(rel(11))) write (iounit,f) 'allreduce   ',rmin(11),rmax(11),diff(11),rel(11)
+      if (.NOT. ieee_is_nan(rel(12))) write (iounit,f) 'dynamics    ',rmin(12),rmax(12),diff(12),rel(12)
     end if
   end subroutine
 


### PR DESCRIPTION
This is relevant to PR #181.
An uncalled routine prints NaN at "relative performance" column.