### PR TITLE
Workaround for parallelized BLAS routine in OpenMP parallelized loop.

### DIFF
--- a/src/ARTED/GS/diag.f90
+++ b/src/ARTED/GS/diag.f90
@@ -29,13 +29,18 @@ Subroutine diag_omp
   integer           :: ik,ib1,ib2
   integer           :: ia,j,i,ix,iy,iz,thr_id
   real(8)           :: kr
-  integer           :: ithr
 
 !LAPACK
   integer                :: lwork,info
-  complex(8),allocatable :: za(:,:),zutmp(:,:,:)
+  complex(8),allocatable :: za(:,:)
   complex(8),allocatable :: work_lp(:)
   real(8),allocatable    :: rwork(:),w(:)
+#ifdef __FUJITSU
+  complex(8),allocatable :: zutmp(:,:,:)
+  integer                :: ithr
+#else
+  complex(8),allocatable :: zutmp(:,:)
+#endif
 
   lwork=6*NB
   thr_id=0
@@ -57,6 +62,11 @@ Subroutine diag_omp
 !$omp end do
 !$omp end parallel
 
+! FIXME: For Fujitsu's parallelized BLAS routines, the application crashes when
+!        invoking a routine under OpenMP parallelized loop.
+!        However, for many-core processors, outermost loop must be parallelized
+!        due to OpenMP overheads.
+#ifdef __FUJITSU
   allocate(za(NB,NB),zutmp(NL,NB,0:NUMBER_THREADS-1))
   allocate(work_lp(lwork),rwork(3*NB-2),w(NB))
   do ik=NK_s,NK_e
@@ -94,6 +104,37 @@ Subroutine diag_omp
     esp(:,ik)=w(:)
   enddo
   deallocate(za,zutmp,work_lp,rwork)
+#else
+!$omp parallel private(thr_id,za,zutmp,work_lp,rwork,w)
+!$ thr_id = omp_get_thread_num()
+  allocate(za(NB,NB),zutmp(NL,NB))
+  allocate(work_lp(lwork),rwork(3*NB-2),w(NB))
+!$omp do private(ik,ib1,ib2)
+  do ik=NK_s,NK_e
+    do ib1=1,NB
+      tpsi_omp(1:NL,thr_id)=zu_GS(1:NL,ib1,ik)
+      call hpsi_omp_KB_GS(ik,tpsi_omp(:,thr_id),ttpsi_omp(:,thr_id),htpsi_omp(:,thr_id))
+      do ib2=ib1+1,NB
+        za(ib2,ib1)=sum(conjg(zu_GS(:,ib2,ik))*htpsi_omp(:,thr_id))*Hxyz
+        za(ib1,ib2)=conjg(za(ib2,ib1))
+      end do
+      za(ib1,ib1)=real(sum(conjg(zu_GS(:,ib1,ik))*htpsi_omp(:,thr_id))*Hxyz)
+    end do
+    call zheev('V', 'U', NB, za, NB, w, work_lp, lwork, rwork, info)
+
+    zutmp=0.d0
+    do ib1=1,NB
+    do ib2=1,NB
+      zutmp(:,ib1)=zutmp(:,ib1)+zu_GS(:,ib2,ik)*za(ib2,ib1)
+    end do
+    end do
+    zu_GS(:,:,ik)=zutmp(:,:)
+    esp(:,ik)=w(:)
+  enddo
+!$omp end do
+  deallocate(za,zutmp,work_lp,rwork)
+!$omp end parallel
+#endif
   call timer_end(LOG_DIAG)
 
   return


### PR DESCRIPTION
For Fujitsu's parallelized BLAS routines, the application crashes when invoking a routine under OpenMP parallelized loop.
However, for many-core processors, outermost loop must be parallelized due to OpenMP overheads.

I added two implementation as a workaround.
I think that Fujitsu should be fixed it's problem.