### PR TITLE
Optimization of hartree calculation in GCEED part.

### DIFF
--- a/src/GCEED/common/hartree_cg.f90
+++ b/src/GCEED/common/hartree_cg.f90
@@ -54,7 +54,7 @@ call hartree_boundary(trho,pk)
 
 !------------------------- C-G minimization
 
-!$OMP parallel do private(iz,iy,ix)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
@@ -63,7 +63,7 @@ end do
 end do
 end do
 
-!$OMP parallel do private(iz,iy,ix)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -75,7 +75,7 @@ end do
 call sendrecvh(pk)
 call calc_laplacianh(pk,rlap_wk)
 
-!$OMP parallel do private(iz,iy,ix)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -84,7 +84,7 @@ end do
 end do
 end do
 
-!$OMP parallel do private(iz,iy,ix)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
@@ -93,7 +93,7 @@ end do
 end do
 end do
 
-!$OMP parallel do private(iz,iy,ix)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -103,7 +103,7 @@ end do
 end do
 
 sum1=0.d0
-!$OMP parallel do reduction(+ : sum1) private(iz,iy,ix) 
+!$OMP parallel do reduction(+ : sum1) private(iz,iy,ix) collapse(2)
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
@@ -127,7 +127,7 @@ Iteration : do iter=1,maxiter
   call calc_laplacianh(pk,rlap_wk)
 
   totbox=0d0
-!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) 
+!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) collapse(2)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -147,7 +147,7 @@ Iteration : do iter=1,maxiter
 
   ak=sum1/tottmp/Hvol
 
-!$OMP parallel do private(iz,iy,ix) 
+!$OMP parallel do private(iz,iy,ix) firstprivate(ak) collapse(2)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -158,7 +158,7 @@ Iteration : do iter=1,maxiter
   end do
 
   totbox=0d0
-!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) 
+!$OMP parallel do reduction(+ : totbox) private(iz,iy,ix) collapse(2)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)
@@ -182,7 +182,7 @@ Iteration : do iter=1,maxiter
 
   ck=sum2/sum1 ; sum1=sum2
 
-!$OMP parallel do private(iz,iy,ix) 
+!$OMP parallel do private(iz,iy,ix) firstprivate(ck) collapse(2)
   do iz=ng_sta(3),ng_end(3)
   do iy=ng_sta(2),ng_end(2)
   do ix=ng_sta(1),ng_end(1)

--- a/src/GCEED/common/hartree_cg.f90
+++ b/src/GCEED/common/hartree_cg.f90
@@ -76,15 +76,6 @@ call sendrecvh(pk)
 call calc_laplacianh(pk,rlap_wk)
 
 !$OMP parallel do private(iz,iy,ix) collapse(2)
-do iz=ng_sta(3),ng_end(3)
-do iy=ng_sta(2),ng_end(2)
-do ix=ng_sta(1),ng_end(1)
-  zk(ix,iy,iz)=zk(ix,iy,iz)-rlap_wk(ix,iy,iz)
-end do
-end do
-end do
-
-!$OMP parallel do private(iz,iy,ix) collapse(2)
 do iz=ng_sta(3)-Ndh,ng_end(3)+Ndh
 do iy=ng_sta(2)-Ndh,ng_end(2)+Ndh
 do ix=ng_sta(1)-Ndh,ng_end(1)+Ndh
@@ -97,6 +88,7 @@ end do
 do iz=ng_sta(3),ng_end(3)
 do iy=ng_sta(2),ng_end(2)
 do ix=ng_sta(1),ng_end(1)
+  zk(ix,iy,iz)=zk(ix,iy,iz)-rlap_wk(ix,iy,iz)
   pk(ix,iy,iz)=zk(ix,iy,iz)
 end do
 end do

--- a/src/GCEED/modules/sendrecvh.f90
+++ b/src/GCEED/modules/sendrecvh.f90
@@ -29,7 +29,7 @@ END INTERFACE
 CONTAINS
 
 !======================================================================
-SUBROUTINE R_sendrecvh(wk2)
+SUBROUTINE R_sendrecvh(wk2,wk1)
 use salmon_communication, only: comm_proc_null, comm_start_all, comm_wait_all
 use scf_data
 use init_sendrecv_sub
@@ -38,7 +38,8 @@ use pack_unpack
 use persistent_comm, only: nreqs_rh
 
 implicit none
-real(8) :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end(3))
+real(8),intent(inout)        :: wk2(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end(3))
+real(8),intent(out),optional :: wk1(iwk2sta(1):iwk2end(1),iwk2sta(2):iwk2end(2),iwk2sta(3):iwk2end(3))
 
 integer :: iup,idw,jup,jdw,kup,kdw
 integer :: ireqs(12)
@@ -143,19 +144,33 @@ call comm_start_all(ireqs(11:12))
 !recv from idw to iup
 call comm_wait_all(ireqs(1:2))
 if(idw/=comm_proc_null)then
+  if(present(wk1)) then
+    call copy_data(rmatbox2_x_h,                               &
+                   wk1(iwk3sta(1)-Ndh:iwk3sta(1),              &
+                       iwk3sta(2)    :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3sta(3)    :iwk3sta(3)+iwk3num(3)-1))
+  else
     call copy_data(rmatbox2_x_h,                               &
                    wk2(iwk3sta(1)-Ndh:iwk3sta(1),              &
                        iwk3sta(2)    :iwk3sta(2)+iwk3num(2)-1, &
                        iwk3sta(3)    :iwk3sta(3)+iwk3num(3)-1))
+  end if
 end if
 
 !recv from iup to idw
 call comm_wait_all(ireqs(3:4))
 if(iup/=comm_proc_null)then
+  if(present(wk1)) then
+    call copy_data(rmatbox4_x_h,                             &
+                   wk1(iwk3end(1)+1:iwk3end(1)+Ndh,          &
+                       iwk3sta(2)  :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3sta(3)  :iwk3sta(3)+iwk3num(3)-1))
+  else
     call copy_data(rmatbox4_x_h,                             &
                    wk2(iwk3end(1)+1:iwk3end(1)+Ndh,          &
                        iwk3sta(2)  :iwk3sta(2)+iwk3num(2)-1, &
                        iwk3sta(3)  :iwk3sta(3)+iwk3num(3)-1))
+  end if
 end if
 
 !=====================================================================-
@@ -163,19 +178,33 @@ end if
 !recv from jdw to jup
 call comm_wait_all(ireqs(5:6))
 if(jdw/=comm_proc_null)then
+  if(present(wk1)) then
+    call copy_data(rmatbox2_y_h,                               &
+                   wk1(iwk3sta(1)    :iwk3sta(1)+iwk3num(1)-1, &
+                       iwk3sta(2)-Ndh:iwk3sta(2),              &
+                       iwk3sta(3)    :iwk3sta(3)+iwk3num(3)-1))
+  else
     call copy_data(rmatbox2_y_h,                               &
                    wk2(iwk3sta(1)    :iwk3sta(1)+iwk3num(1)-1, &
                        iwk3sta(2)-Ndh:iwk3sta(2),              &
                        iwk3sta(3)    :iwk3sta(3)+iwk3num(3)-1))
+  end if
 end if
 
 !recv from jup to jdw
 call comm_wait_all(ireqs(7:8))
 if(jup/=comm_proc_null)then
+  if(present(wk1)) then
+    call copy_data(rmatbox4_y_h,                              &
+                   wk1(iwk3sta(1)   :iwk3sta(1)+iwk3num(1)-1, &
+                       iwk3end(2)+1:iwk3end(2)+Ndh,          &
+                        iwk3sta(3)  :iwk3sta(3)+iwk3num(3)-1))
+  else
     call copy_data(rmatbox4_y_h,                              &
                    wk2(iwk3sta(1)   :iwk3sta(1)+iwk3num(1)-1, &
-                        iwk3end(2)+1:iwk3end(2)+Ndh,          &
-                        iwk3sta(3)  :iwk3sta(3)+iwk3num(3)-1))
+                       iwk3end(2)+1:iwk3end(2)+Ndh,          &
+                       iwk3sta(3)  :iwk3sta(3)+iwk3num(3)-1))
+  end if
 end if
 
 !=====================================================================-
@@ -183,19 +212,33 @@ end if
 !recv from kdw to kup
 call comm_wait_all(ireqs(9:10))
 if(kdw/=comm_proc_null)then
+  if(present(wk1)) then
+    call copy_data(rmatbox2_z_h,                               &
+                   wk1(iwk3sta(1)    :iwk3sta(1)+iwk3num(1)-1, &
+                       iwk3sta(2)    :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3sta(3)-Ndh:iwk3sta(3)))
+  else
     call copy_data(rmatbox2_z_h,                               &
                    wk2(iwk3sta(1)    :iwk3sta(1)+iwk3num(1)-1, &
                        iwk3sta(2)    :iwk3sta(2)+iwk3num(2)-1, &
                        iwk3sta(3)-Ndh:iwk3sta(3)))
+  end if
 end if
 
 !recv from kup to kdw
 call comm_wait_all(ireqs(11:12))
 if(kup/=comm_proc_null)then
+  if(present(wk1)) then
+    call copy_data(rmatbox4_z_h,                             &
+                   wk1(iwk3sta(1)  :iwk3sta(1)+iwk3num(1)-1, &
+                       iwk3sta(2)  :iwk3sta(2)+iwk3num(2)-1, &
+                       iwk3end(3)+1:iwk3end(3)+Ndh))
+  else
     call copy_data(rmatbox4_z_h,                             &
                    wk2(iwk3sta(1)  :iwk3sta(1)+iwk3num(1)-1, &
                        iwk3sta(2)  :iwk3sta(2)+iwk3num(2)-1, &
                        iwk3end(3)+1:iwk3end(3)+Ndh))
+  end if
 end if
 
 return


### PR DESCRIPTION
I optimized the following source files:

+ GCEED/common/hartree_cg.f90
+ GCEED/common/hartree_boundary.f90
+ GCEED/common/laplacianf.h

This PR reduces computation time, especially when hartree calculation (CG method) consumes a lot of computational costs.

It changes tendency of computational error because computation order is changed by modifying OpenMP parallelization manner (e.g. `omp collapse` clause).
Unfortunately, GCEED part does not provide automatic test case yet, so I can not validate the calculation results.

@mn2007 san, would you please let me check the calculation results with it?