### PR TITLE
Enabling tests without MPI.

### DIFF
--- a/cmakefiles/create_test.cmake
+++ b/cmakefiles/create_test.cmake
@@ -7,8 +7,8 @@ function(create_test)
   file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/verification DESTINATION ${CMAKE_CURRENT_BINARY_DIR} FILE_PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE)
 
   add_custom_command(OUTPUT  ${TEST_EXEC}
-                     COMMAND echo '\#! /bin/sh'                                             >  ${TEST_EXEC}
-                     COMMAND echo "${TEST_MPI_COMMAND}" '< ./inputfile |& tee ./outputfile' >> ${TEST_EXEC}
+                     COMMAND echo '\#! /bin/sh'                                         >  ${TEST_EXEC}
+                     COMMAND echo "${TEST_COMMAND}" '< ./inputfile |& tee ./outputfile' >> ${TEST_EXEC}
                      COMMAND chmod +x ${TEST_EXEC})
   add_custom_target("gen_${TEST_NAME}" ALL DEPENDS ${TEST_EXEC} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/testsuites/CMakeLists.txt
+++ b/testsuites/CMakeLists.txt
@@ -1,10 +1,12 @@
 include(${CMAKE_SOURCE_DIR}/cmakefiles/create_test.cmake)
 
-find_package(MPI REQUIRED) # find executable file for running MPI application.
-
-set(TEST_MPI_NPROC   4)
-set(TEST_MPI_COMMAND "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${TEST_MPI_NPROC} ${CMAKE_BINARY_DIR}/${TARGET_NAME}")
-message(STATUS "testing MPI: ${TEST_MPI_COMMAND}")
+if (USE_MPI)
+  set(TEST_MPI_NPROC 4)
+  set(TEST_COMMAND "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${TEST_MPI_NPROC} ${CMAKE_BINARY_DIR}/${TARGET_NAME}")
+else ()
+  set(TEST_COMMAND "${CMAKE_BINARY_DIR}/${TARGET_NAME}")
+endif ()
+message(STATUS "testing command: ${TEST_COMMAND}")
 
 add_custom_target("check_test_requirements" COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS ${TARGET_NAME})
 add_custom_target("test_preparations" ALL


### PR DESCRIPTION
Until now the tests under cmake required MPI, this PR fixed it.