### PR TITLE
Modify the dielectric function calculation

### DIFF
--- a/src/ARTED/RT/Fourier_tr.f90
+++ b/src/ARTED/RT/Fourier_tr.f90
@@ -86,16 +86,16 @@ Subroutine Fourier_tr
              &,(real(E_tot_w(ixyz)),ixyz=1,3)&
              &,(aimag(E_tot_w(ixyz)),ixyz=1,3)
       endif
+      
+      if (Trans_Longi == 'tr') then
+        write(fh_lr,'(1x,f13.7,12f22.14)') &
+            & hw &
+            &,(real(zsigma_w(ixyz)),ixyz=1,3)&
+            &,(aimag(zsigma_w(ixyz)),ixyz=1,3)&
+            &,(real(zeps(ixyz)),ixyz=1,3)&
+            &,(aimag(zeps(ixyz)),ixyz=1,3)
+      endif
     endif
-    
-    if (Trans_Longi == 'tr') then
-      write(fh_lr,'(1x,f13.7,12f22.14)') &
-          & hw &
-          &,(real(zsigma_w(ixyz)),ixyz=1,3)&
-          &,(aimag(zsigma_w(ixyz)),ixyz=1,3)&
-          &,(real(zeps(ixyz)),ixyz=1,3)&
-          &,(aimag(zeps(ixyz)),ixyz=1,3)
-    end if
   enddo
  
   if (comm_is_root(nproc_id_global)) then

--- a/src/ARTED/RT/Fourier_tr.f90
+++ b/src/ARTED/RT/Fourier_tr.f90
@@ -38,7 +38,7 @@ Subroutine Fourier_tr
     ! sigma(omega=0) correcton
     jav_s=0d0; smt_s=0d0;
     do iter=0,Nt
-      tt=(iter+0.5)*dt
+      tt=iter*dt
       jav_s(:)=jav_s(:)+javt(iter,:)*smoothing_t(tt)
       smt_s=smt_s+smoothing_t(tt)
     end do
@@ -51,7 +51,7 @@ Subroutine Fourier_tr
     hw=ihw*domega
     jav_w=0.d0; E_ext_w=0.d0; E_tot_w=0.d0
     do iter=0,Nt
-      tt=(iter+0.5)*dt
+      tt=iter*dt
       jav_w(:)=jav_w(:)+(javt(iter,:)-jav_d(:))*exp(zI*hw*tt)*smoothing_t(tt)
       E_ext_w(:)=E_ext_w(:)+E_ext(iter,:)*exp(zI*hw*tt)*smoothing_t(tt)
       E_tot_w(:)=E_tot_w(:)+E_tot(iter,:)*exp(zI*hw*tt)*smoothing_t(tt)

--- a/src/ARTED/RT/Fourier_tr.f90
+++ b/src/ARTED/RT/Fourier_tr.f90
@@ -77,6 +77,12 @@ Subroutine Fourier_tr
              &,(aimag(zsigma_w(ixyz)),ixyz=1,3)&
              &,(real(zeps(ixyz)),ixyz=1,3)&
              &,(aimag(zeps(ixyz)),ixyz=1,3)
+         write(fh_lr,'(1x,f13.7,12f22.14)') &
+             & hw &
+             &,(real(zsigma_w(ixyz)),ixyz=1,3)&
+             &,(aimag(zsigma_w(ixyz)),ixyz=1,3)&
+             &,(real(zeps(ixyz)),ixyz=1,3)&
+             &,(aimag(zeps(ixyz)),ixyz=1,3)
       else
         write(7,'(1x,f13.7,18f22.14)') hw&
              &,(real(jav_w(ixyz)),ixyz=1,3)&
@@ -85,15 +91,6 @@ Subroutine Fourier_tr
              &,(aimag(E_ext_w(ixyz)),ixyz=1,3)&
              &,(real(E_tot_w(ixyz)),ixyz=1,3)&
              &,(aimag(E_tot_w(ixyz)),ixyz=1,3)
-      endif
-      
-      if (Trans_Longi == 'tr') then
-        write(fh_lr,'(1x,f13.7,12f22.14)') &
-            & hw &
-            &,(real(zsigma_w(ixyz)),ixyz=1,3)&
-            &,(aimag(zsigma_w(ixyz)),ixyz=1,3)&
-            &,(real(zeps(ixyz)),ixyz=1,3)&
-            &,(aimag(zeps(ixyz)),ixyz=1,3)
       endif
     endif
   enddo


### PR DESCRIPTION
## Overview
This pull request provides the improvements for the dielectric function calculation routines for the periodic system.
1. Added the exporter (`SYSNAME_lr.data`) of the dielectric function, which has been proposed at the June meeting. (https://www.dropbox.com/s/43qyhxj0n5y7a5z/uemoto0805_output_format.pdf?dl=0) Besides, the old output file (`SYSNAME_e.out`) is also remained for the compativility.

2. Implemented the zero frequency correction of conductivity calculation, which avoids the divergence of the dielectric function caused by the existence of the numerical error. This correction is automatically enabled in the case of the electronic temperature < 0  (insulator case).

![dev_dielec](https://user-images.githubusercontent.com/5200546/30839398-910adf24-a2ac-11e7-9dae-85f856ae3330.png)

- Dielectric function of the silicon crystal with comparing between the original result (dotted curve) and modified method (solid curve). In the case of the modified code, it is obviously that the divergence at the low frequency region is successfully removed.

## Future work
- Presently, this implementation for the output file `SYSNAME_lr.data` only supports the atomic units. For the future work, the export in fs_ev units will be added in the output routine.
