### PR TITLE
Monthly Update of GNU Makefile

### DIFF
--- a/makefiles/Makefile.fujitsu
+++ b/makefiles/Makefile.fujitsu
@@ -1,6 +1,8 @@
 # fujitsu
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.cpu
 FC = mpifrtpx
 CC = mpifccpx
 FFLAGS = -O3 -Kfast,openmp,simd=1 -Cpp -Kocl,nooptmsg
@@ -10,7 +12,5 @@ LIBLAPACK = -SSL2BLAMP
 LIBSCALAPACK = -SCALAPACK -SSL2BLAMP
 MODULE_SWITCH = -M
 COMM_SET =
-
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/Makefile.gnu
+++ b/makefiles/Makefile.gnu
@@ -1,6 +1,8 @@
 # gnu
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.cpu
 FC = mpif90
 CC = mpicc
 FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-form -ffree-line-length-none
@@ -9,7 +11,5 @@ LIBLAPACK = -llapack -lblas
 #LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5 -lm
 MODULE_SWITCH = -J
 COMM_SET =
-
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/Makefile.gnu-without-mpi
+++ b/makefiles/Makefile.gnu-without-mpi
@@ -1,6 +1,8 @@
 # gnu-without-mpi
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.cpu
 FC = gfortran
 CC = gcc
 FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-form -ffree-line-length-none
@@ -9,7 +11,5 @@ LIBLAPACK = -llapack -lblas
 #LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5 -lm
 MODULE_SWITCH = -J
 COMM_SET = dummy
-
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/Makefile.intel
+++ b/makefiles/Makefile.intel
@@ -1,6 +1,8 @@
 # intel
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.cpu
 FC = mpiifort
 CC = mpiicc
 FFLAGS = -O3 -qopenmp -ansi-alias -fno-alias -fpp -nogen-interface -std03 -warn all
@@ -10,7 +12,5 @@ LIBLAPACK = -mkl=cluster
 LIBSCALAPACK = -mkl=cluster
 MODULE_SWITCH = -module
 COMM_SET =
-
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/Makefile.intel-avx
+++ b/makefiles/Makefile.intel-avx
@@ -1,6 +1,8 @@
 # intel-avx
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.cpu
 FC = mpiifort
 CC = mpiicc
 FLAGS = -xAVX -qopenmp -ansi-alias -fno-alias \
@@ -16,7 +18,5 @@ LIBSCALAPACK = -mkl=cluster
 SIMD_SET = AVX
 MODULE_SWITCH = -module
 COMM_SET =
-
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/Makefile.intel-avx2
+++ b/makefiles/Makefile.intel-avx2
@@ -1,6 +1,8 @@
 # intel-avx2
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.cpu
 FC = mpiifort
 CC = mpiicc
 FLAGS = -xCORE-AVX2 -qopenmp -ansi-alias -fno-alias \
@@ -13,7 +15,5 @@ LIBSCALAPACK = -mkl=cluster
 SIMD_SET = AVX
 MODULE_SWITCH = -module
 COMM_SET =
-
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/Makefile.intel-knc
+++ b/makefiles/Makefile.intel-knc
@@ -1,6 +1,8 @@
 # intel-knc
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.mic
 FC = mpiifort
 CC = mpiicc
 FLAGS = -mmic -qopenmp -qopt-assume-safe-padding -qopt-streaming-stores always -qopt-gather-scatter-unroll=4 \
@@ -18,7 +20,5 @@ LIBSCALAPACK = -mkl=cluster
 SIMD_SET = IMCI
 MODULE_SWITCH = -module
 COMM_SET =
-
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/Makefile.intel-knl
+++ b/makefiles/Makefile.intel-knl
@@ -1,6 +1,8 @@
 # intel-knl
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.mic
 FC = mpiifort
 CC = mpiicc
 FLAGS = -xMIC-AVX512 -qopenmp -qopt-ra-region-strategy=block -ansi-alias -fno-alias \
@@ -18,6 +20,5 @@ SIMD_SET = IMCI
 MODULE_SWITCH = -module
 COMM_SET =
 
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/Makefile.intel-without-mpi
+++ b/makefiles/Makefile.intel-without-mpi
@@ -1,6 +1,8 @@
 # intel
 
-TARGET = salmon.cpu
+SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
+
+TARGET = $(SALMON)/bin/salmon.cpu
 FC = ifort
 CC = icc
 FFLAGS = -O3 -qopenmp -ansi-alias -fno-alias -fpp -nogen-interface -std03 -warn all
@@ -10,7 +12,5 @@ LIBLAPACK = -mkl=cluster
 LIBSCALAPACK = -mkl=cluster
 MODULE_SWITCH = -module
 COMM_SET = dummy
-
-SALMON = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../)
 
 include $(SALMON)/makefiles/make.body

--- a/makefiles/make.body
+++ b/makefiles/make.body
@@ -1,79 +1,77 @@
+SRCDIR = $(SALMON)/src
 OBJDIR = $(SALMON)/build_temp
 
 ifdef SIMD_SET
-C_SRC_STENCIL_FILE=\
-	stencil/C/$(SIMD_SET)/current.c \
-	stencil/C/$(SIMD_SET)/hpsi.c \
-	stencil/C/$(SIMD_SET)/total_energy.c
-F_SRC_STENCIL_FILE=
+	C_STENCIL_FILE= \
+		stencil/C/$(SIMD_SET)/current.c \
+		stencil/C/$(SIMD_SET)/hpsi.c \
+		stencil/C/$(SIMD_SET)/total_energy.c 
+	F_STENCIL_FILE=
 else
-C_SRC_STENCIL_FILE=
-F_SRC_STENCIL_FILE=\
-	stencil/F90/current.f90 \
-	stencil/F90/hpsi.f90 \
-	stencil/F90/total_energy.f90
+	C_STENCIL_FILE=
+	F_STENCIL_FILE = \
+		stencil/F90/current.f90 \
+		stencil/F90/hpsi.f90 \
+		stencil/F90/total_energy.f90
 endif
 
 ifdef COMM_SET
-F_SRC_COMM_FILE=salmon_communication_$(COMM_SET).f90
+	F_COMM_FILE=salmon_communication_$(COMM_SET).f90
 else
-F_SRC_COMM_FILE=salmon_communication.f90
+	F_COMM_FILE=salmon_communication.f90
 endif
 
-H_IN_VERSION_FILE=version.h.in versionf.h.in
+H_IN_VERSION = $(addprefix $(SRCDIR)/, version.h.in versionf.h.in)
+H_VERSION = $(addprefix $(OBJDIR)/, version.h versionf.h)
 
-
-
-
-
-F_SRC_PARALLEL=$(addprefix $(SALMON)/src/parallel/, \
-	$(F_SRC_COMM_FILE) \
+F_SRC_PARALLEL=$(addprefix parallel/, \
+	$(F_COMM_FILE) \
 	salmon_parallel.f90 \
 )
 
-F_SRC_IO=$(addprefix $(SALMON)/src/io/, \
+F_SRC_IO=$(addprefix io/, \
 	salmon_file.f90 \
 	salmon_global.f90 \
 	inputoutput.f90 \
 )
 
-F_SRC_MATH=$(addprefix $(SALMON)/src/math/, \
+F_SRC_MATH=$(addprefix math/, \
 	salmon_math.f90 \
 )
 
-F_SRC_RT=$(addprefix $(SALMON)/src/rt/, \
+F_SRC_RT=$(addprefix rt/, \
 )
 
-F_SRC_ATOM=$(addprefix $(SALMON)/src/atom/, \
+F_SRC_ATOM=$(addprefix atom/, \
 )
 
-F_SRC_MAXWELL=$(addprefix $(SALMON)/src/maxwell/, \
+F_SRC_MAXWELL=$(addprefix maxwell/, \
 )
 
-F_SRC_GS=$(addprefix $(SALMON)/src/gs/, \
+F_SRC_GS=$(addprefix gs/, \
 )
 
-F_SRC_XC=$(addprefix $(SALMON)/src/xc/, \
+F_SRC_XC=$(addprefix xc/, \
 	exc_cor.f90 \
 )
 
-F_SRC_POISSON=$(addprefix $(SALMON)/src/poisson/, \
+F_SRC_POISSON=$(addprefix poisson/, \
 )
 
-F_SRC_MISC=$(addprefix $(SALMON)/src/misc/, \
+F_SRC_MISC=$(addprefix misc/, \
 	backup_routines.f90 \
 	misc_routines.f90 \
 	unusedvar.f90 \
 	timer.f90 \
 )
 
-F_SRC_COMMON=$(addprefix $(SALMON)/src/common/, \
+F_SRC_COMMON=$(addprefix common/, \
 	stencil.f90 \
 	update_overlap.f90 \
 	hpsi.f90 \
 )
 
-F_SRC_ARTED=$(addprefix $(SALMON)/src/ARTED/, \
+F_SRC_ARTED=$(addprefix ARTED/, \
 	common/Ylm_dYlm.f90 \
 	common/preprocessor.f90 \
 	modules/env_variables.f90 \
@@ -109,7 +107,7 @@ F_SRC_ARTED=$(addprefix $(SALMON)/src/ARTED/, \
 	common/restart.f90 \
 	common/total_energy.f90 \
 	preparation/prep_ps.f90 \
-	$(F_SRC_STENCIL_FILE) \
+	$(F_STENCIL_FILE) \
 	GS/CG.f90 \
 	GS/diag.f90 \
 	GS/sp_energy.f90 \
@@ -120,7 +118,7 @@ F_SRC_ARTED=$(addprefix $(SALMON)/src/ARTED/, \
 	main.f90 \
 )
 
-F_SRC_GCEED=$(addprefix $(SALMON)/src/GCEED/, \
+F_SRC_GCEED=$(addprefix GCEED/, \
 	common/calc_iquotient.f90 \
 	common/calc_ob_num.f90 \
 	common/check_cep.f90 \
@@ -129,6 +127,7 @@ F_SRC_GCEED=$(addprefix $(SALMON)/src/GCEED/, \
 	misc/setlg.f90 \
 	misc/setmg.f90 \
 	misc/setng.f90 \
+	modules/pack_unpack.f90 \
 	modules/rmmdiis_eigen_lapack.f90 \
 	modules/scf_data.f90 \
 	read_input_gceed.f90 \
@@ -220,15 +219,16 @@ F_SRC_GCEED=$(addprefix $(SALMON)/src/GCEED/, \
 	common/calcuV.f90 \
 	common/psl.f90 \
 	common/storevpp.f90 \
-	modules/sendrecv.f90 \
-	modules/sendrecv_groupob.f90 \
-	modules/sendrecvh.f90 \
+	modules/persistent_comm.f90 \
 	rt/read_rt.f90 \
 	rt/taylor.f90 \
 	rt/total_energy_groupob.f90 \
 	scf/calc_dos.f90 \
 	scf/calc_pdos.f90 \
 	scf/rmmdiis_eigen.f90 \
+	modules/sendrecv.f90 \
+	modules/sendrecv_groupob.f90 \
+	modules/sendrecvh.f90 \
 	common/calc_gradient_fast.f90 \
 	common/calc_gradient_fast_c.f90 \
 	common/hartree_boundary.f90 \
@@ -248,46 +248,50 @@ F_SRC_GCEED=$(addprefix $(SALMON)/src/GCEED/, \
 	scf/real_space_dft.f90 \
 )
 
-F_SRC=$(addprefix $(SALMON)/src/, \
-	main.f90 \
-)
+F_SRCS= \
+	$(F_SRC_PARALLEL) \
+	$(F_SRC_IO) \
+	$(F_SRC_MATH) \
+	$(F_SRC_RT) \
+	$(F_SRC_ATOM) \
+	$(F_SRC_MAXWELL) \
+	$(F_SRC_GS) \
+	$(F_SRC_XC) \
+	$(F_SRC_POISSON) \
+	$(F_SRC_MISC) \
+	$(F_SRC_COMMON) \
+	$(F_SRC_ARTED) \
+	$(F_SRC_GCEED) \
+	main.f90
 
-F_SRCS=$(F_SRC_PARALLEL) $(F_SRC_IO) $(F_SRC_MATH) $(F_SRC_RT) $(F_SRC_ATOM) $(F_SRC_MAXWELL) $(F_SRC_GS) $(F_SRC_XC) $(F_SRC_POISSON) $(F_SRC_MISC) $(F_SRC_COMMON) $(F_SRC_ARTED) $(F_SRC_GCEED) $(F_SRC) 
+C_SRCS= \
+	$(addprefix ARTED/, $(C_STENCIL_FILE)) \
+	ARTED/modules/env_variables_internal.c
 
-
-
-
-
-C_SRCS=$(addprefix $(SALMON)/src/ARTED/, \
-	$(C_SRC_STENCIL_FILE) \
-	modules/env_variables_internal.c \
-)
-
-F_OBJS = $(addprefix $(OBJDIR)/,$(F_SRCS:.f90=.o))
-C_OBJS = $(addprefix $(OBJDIR)/,$(C_SRCS:.c=.o))
-
-H_IN_VERSION=$(addprefix $(SALMON)/src/, $(H_IN_VERSION_FILE))
-H_VERSION=$(addprefix $(OBJDIR)/, $(H_IN_VERSION_FILE:.h.in=.h))
+F_SRC_FILES=$(addprefix $(SRCDIR)/, $(F_SRCS))
+F_OBJ_FILES=$(addprefix $(OBJDIR)/, $(F_SRCS:.f90=.o))
+C_SRC_FILES=$(addprefix $(SRCDIR)/, $(C_SRCS))
+C_OBJ_FILES=$(addprefix $(OBJDIR)/, $(C_SRCS:.c=.o))
 
 .PHONY: all clean
 
+$(TARGET): $(F_OBJ_FILES) $(C_OBJ_FILES)
+	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+	$(FC) $(FFLAGS) -o $@ $(F_OBJ_FILES) $(C_OBJ_FILES) -I $(OBJDIR) $(LIBLAPACK)
 
-$(TARGET): $(F_OBJS) $(C_OBJS)
-	$(FC) $(FFLAGS) -o $@ $(F_OBJS) $(C_OBJS) -I $(OBJDIR)  $(LIBLAPACK)
-
-$(F_OBJS): $(F_SRCS) 
-$(C_OBJS): $(C_SRCS)
+$(F_OBJ_FILES): $(F_SRC_FILES)
+$(C_OBJ_FILES): $(C_SRC_FILES)
 $(H_VERSION): $(H_IN_VERSION)
 
-$(OBJDIR)/%.o: %.f90 $(H_VERSION)
+$(OBJDIR)/%.o: $(SRCDIR)/%.f90 $(H_VERSION)
 	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
 	$(FC) $(FFLAGS) $(MODULE_SWITCH) $(OBJDIR) -o $@ -c $< -I $(OBJDIR) 
 
-$(OBJDIR)/%.o: %.c $(H_VERSION)
+$(OBJDIR)/%.o: $(SRCDIR)/%.c $(H_VERSION)
 	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
 	$(CC) $(CFLAGS) -o $@ -c $< -I $(OBJDIR)  
 
-$(OBJDIR)/%.h: $(SALMON)/src/%.h.in
+$(OBJDIR)/%.h: $(SRCDIR)/%.h.in
 	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
 	cat $< \
 	| sed  -e "/cmakedefine/d" \
@@ -296,7 +300,8 @@ $(OBJDIR)/%.h: $(SALMON)/src/%.h.in
 	| sed  -e "~s/@GIT_COMMIT_HASH@//" \
 	> $@
 	
-
+all: $(TARGET)
+	
 clean:
 	rm -f $(TARGET)
 	rm -rf $(OBJDIR)


### PR DESCRIPTION
## Overview
This pull request contains the update of GNU makefiles, which is not working presently. In this time,  the Makefile are fixed in order to follow up the modification of the directory location proposed on PR#200.

I have already tested this new makefile only for `intel` and `gcc` environment in Oakforest-PACS. However, I have not checked how it works in Fujitsu environment. Please, someone check this?

### How to build by GNU Makefile
Enter to the makefile directory:
```
$ cd SALMON/makefiles
```
and execute `make` command with the platform specified makefile:
```
$ make -f Makefile.PLATFORM
```
If the build is successfully finished, the binary is generated on `SALMON/bin/` directory.


### Supported Platform
- fujitsu
- gnu
- gnu-without-mpi
- intel
- intel-avx
- intel-avx2
- intel-knc
- intel-knl
- intel-without-mpi

### Command for Jenkins
```
testmode = skip
```