### PR TITLE
Added input keywords: read_initial_guess and modify_initial_guess opt…

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -96,6 +96,18 @@ Default is the current directoy, <code>./</code>.
 <dd>Name of a filename for the restart calculation.
 </dd>
 
+<dt>read_initial_guess; <code>Character</code>; 3d</dt>
+<dd>
+Option to read wave function as initial guess (pre-calculated "gs_wfn_k" directory) if this is <code>y</code>.
+Default is <code>n</code>.
+</dd>
+
+<dt>modify_initial_guess; <code>Character</code>; 3d</dt>
+<dd>
+Option to modify initial guess wave function (pre-calculated "gs_wfn_k" directory) in combination with <code>read_initial_guess = y</code>.
+If <code>copy_1stk_to_all</code> is set, the first k-point data file, wfn_gs_k0000001.wfn (supposed to be obtained by gamma-point calculation), is copied to all other points.
+Default is <code>n</code>.
+</dd>
 
 </dl>
 

--- a/src/ARTED/control/ground_state.f90
+++ b/src/ARTED/control/ground_state.f90
@@ -24,6 +24,7 @@ contains
     use timer
     use salmon_parallel, only: nproc_id_global
     use salmon_communication, only: comm_bcast, comm_sync_all, comm_is_root
+    use io_gs_wfn_k, only: iflag_read,read_write_gs_wfn_k
     implicit none
     integer :: iter, ik, ib, ia
     character(10) :: functional_t
@@ -43,8 +44,13 @@ contains
 
       call Hartree
     
-    else if(iflag_gs_init_wf==1) then  !case that initial guess is already read from files
+    else if(iflag_gs_init_wf==1) then  !case that initial guess has been already read from files
       rho_in(1:NL,1)=rho(1:NL)
+
+    else if(iflag_gs_init_wf==2) then  !case of option that initial guess is read from files
+      call read_write_gs_wfn_k(iflag_read)
+      rho_in(1:NL,1)=rho(1:NL)
+
     endif
 
     functional_t = functional

--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -29,6 +29,7 @@ contains
     use misc_routines
     use inputfile,only: transfer_input
     use restart,only: prep_restart_read
+    use io_gs_wfn_k,only: modify_initial_guess_copy_1stk_to_all
     implicit none
 !$ integer :: omp_get_max_threads  
 
@@ -81,8 +82,15 @@ contains
 ! initialize for optimization.
     call opt_vars_initialize_p2
 
-    if(use_ehrenfest_md=='y')then
+    if(use_ehrenfest_md=='y') then
        call init_md
+    endif
+
+! modify initial guess if read and modify options = y
+    if(read_initial_guess=='y') then
+       if(modify_initial_guess=='copy_1stk_to_all') then
+          call modify_initial_guess_copy_1stk_to_all
+       endif
     endif
 
   end subroutine initialize
@@ -384,7 +392,8 @@ contains
     call comm_bcast(NBoccmax,nproc_group_global)
     call comm_sync_all
     NKB=(NK_e-NK_s+1)*NBoccmax ! sato
-    
+    if(read_initial_guess=='y') iflag_gs_init_wf=2
+
     allocate(occ(NB,NK),wk(NK),esp(NB,NK))
     allocate(ovlp_occ_l(NB,NK),ovlp_occ(NB,NK))
     allocate(zu_GS(NL,NB,NK_s:NK_e),zu_GS0(NL,NB,NK_s:NK_e))

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -98,7 +98,7 @@ Module Global_Variables
   complex(8),allocatable :: tpsi(:),htpsi(:),zwork(:,:,:),ttpsi(:)
   real(8),allocatable :: work(:,:,:)
   real(8),allocatable :: esp_var(:,:)
-  integer :: iflag_gs_init_wf=0   !use random number(=0), don't use it(=1)
+  integer :: iflag_gs_init_wf=0   !use random number(=0)
 
 ! variables for 4-times loop in Fourier transportation
   integer,allocatable :: nxyz(:,:,:)

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -217,7 +217,9 @@ contains
       & time_shutdown, &
       & sysname, &
       & directory, &
-      & dump_filename
+      & dump_filename, &
+      & read_initial_guess, &
+      & modify_initial_guess
 
     namelist/units/ &
       & unit_system
@@ -478,12 +480,14 @@ contains
     use_force        = 'n'
     use_geometry_opt = 'n'
 !! == default for &control
-    restart_option   = 'new'
-    backup_frequency = 0
-    time_shutdown    = -1d0
-    sysname          = 'default'
-    directory        = './'
-    dump_filename    = 'default'
+    restart_option      = 'new'
+    backup_frequency    = 0
+    time_shutdown       = -1d0
+    sysname             = 'default'
+    directory           = './'
+    dump_filename       = 'default'
+    read_initial_guess  = 'n'
+    modify_initial_guess= 'n'
 !! == default for &parallel
     domain_parallel   = 'n'
     nproc_ob          = 0
@@ -767,12 +771,15 @@ contains
     call comm_bcast(use_force       ,nproc_group_global)
     call comm_bcast(use_geometry_opt,nproc_group_global)
 !! == bcast for &control
-    call comm_bcast(restart_option  ,nproc_group_global)
-    call comm_bcast(backup_frequency,nproc_group_global)
-    call comm_bcast(time_shutdown   ,nproc_group_global)
-    call comm_bcast(sysname         ,nproc_group_global)
-    call comm_bcast(directory       ,nproc_group_global)
-    call comm_bcast(dump_filename   ,nproc_group_global)
+    call comm_bcast(restart_option      ,nproc_group_global)
+    call comm_bcast(backup_frequency    ,nproc_group_global)
+    call comm_bcast(time_shutdown       ,nproc_group_global)
+    call comm_bcast(sysname             ,nproc_group_global)
+    call comm_bcast(directory           ,nproc_group_global)
+    call comm_bcast(dump_filename       ,nproc_group_global)
+    call comm_bcast(read_initial_guess  ,nproc_group_global)
+    call comm_bcast(modify_initial_guess,nproc_group_global)
+
 !! == bcast for &parallel
     call comm_bcast(domain_parallel  ,nproc_group_global)
     call comm_bcast(nproc_ob         ,nproc_group_global)
@@ -1247,6 +1254,8 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'sysname', trim(sysname)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'directory', trim(directory)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'dump_filename', trim(dump_filename)
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'read_initial_guess', trim(read_initial_guess)
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'modify_initial_guess', trim(modify_initial_guess)
 
       if(inml_units >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'units', inml_units

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -50,6 +50,8 @@ module salmon_global
   character(256) :: sysname
   character(256) :: directory
   character(256) :: dump_filename
+  character(1)   :: read_initial_guess
+  character(20)  :: modify_initial_guess
                  
 !! &units
   character(16)  :: unit_system


### PR DESCRIPTION
…ions (ARTED side)

(1) New input keywords: "read_initial_guess" and "modify_initial_guess" were added in &control block.
(1-A) read_initial_guess:
This is useful for continuing GS calculations restarting from the previously obtained wave function ("gs_wfn_k" directory) if the previous GS calculation was not converged. Also it can be used for geometry optimization starting from the converged GS wave function. 

(1-B) modify_initial_guess:
This keyword is to modify the initial guess wave function to be efficient GS convergence. It works only if the previous read_initial_guess=y, and currenty, modify_initial_guess = "copy_1stk_to_all" is implemented, meaning that the first k-point wave function data (in "gs_wfn_k" directory) is copied to the other all k-points as initial guess, where the first k-point wave function is already pre-calculated as gamma-point. 

(2) Minor improvement in optimization iteration:  just single line was inserted to be a little efficient way, and also printed iteration loop number was fixed.

 