### PR TITLE
OpenMP parallelization by space grids and orbitals in ground-state calc (ARTED side)

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -541,6 +541,24 @@ Threshold for convergence check that is used when either <code>'pot'</code> or <
 Default is <code>-1d0</code> a.u. (1 a.u.= 1.10d2 Å<sup>3</sup>eV<sup>2</sup>)
 </dd>
 
+<dt>omp_loop; <code>Character</code>; 3d</dt>
+<dd>
+Loop for OpenMP parallelization if periodic boundary system is used. 
+<li>
+<code>k</code>: parallelization by k-point loop (Default).
+<li>
+</li>
+<code>b</code>: parallelization mainly by band orbital loop (sometimzes space grid loop too). This works efficiently if the number of k-point to be calculated in a node is small (e.x. the case of single k-point for each node)
+</li>
+</dd>
+
+<dt>skip_gsortho; <code>Character</code>; 3d</dt>
+<dd>
+Flag to skip Gram-Schmidt orthogonalization in CG loop if periodic boundary system is used. If this is skipped the more iteration number is necessary to get convergence but each iteration step gets faster. If <code>omp_loop=b</code>, this flag is always applied.
+Default is <code>n</code>
+</dd>
+
+
 </dl>
 
 ## &emfield

--- a/src/ARTED/GS/CG.f90
+++ b/src/ARTED/GS/CG.f90
@@ -185,6 +185,7 @@ Subroutine CG_ompr(iter_cg_max)
 !$omp do private(j,i,ix,iy,iz,kr,ib,ibt,s,xkHxk,xkTxk,iter,uk,gkgk,xkHpk,pkHpk,ev,cx,cp,zs) collapse(2)
   do ik=NK_s,NK_e
   do ib=1,NB
+    !(GramShumit)
     !do ibt=1,ib-1
     !  s=sum(conjg(zu_GS(:,ibt,ik))*zu_GS(:,ib,ik))*Hxyz
     !  zu_GS(1:NL,ib,ik)=zu_GS(1:NL,ib,ik)-zu_GS(1:NL,ibt,ik)*s
@@ -197,24 +198,24 @@ Subroutine CG_ompr(iter_cg_max)
     xkTxk=sum(conjg(xk_omp(:,thr_id))*txk_omp(:,thr_id))*Hxyz
 
     do iter=1,iter_cg_max
-!??? GramShumit???
-!      gk_omp(1:NL,thr_id)=(hxk_omp(1:NL,thr_id)-xkHxk*xk_omp(1:NL,thr_id))
-!      do ibt=1,ib-1
-!        zs=sum(conjg(zu_GS(:,ibt,ik))*gk_omp(:,thr_id))*Hxyz
-!        gk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)-zu_GS(1:NL,ibt,ik)*zs
-!      end do
-!      s=sum(abs(gk_omp(:,thr_id))**2)*Hxyz
-!
-!      select case (iter)
-!      case(1)
-!        pk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)
-!      case default
-!        uk=s/gkgk
-!        pk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)+uk*pk_omp(1:NL,thr_id)
-!      end select
-!      gkgk=s
+      !(GramShumit)
+      !gk_omp(1:NL,thr_id)=(hxk_omp(1:NL,thr_id)-xkHxk*xk_omp(1:NL,thr_id))
+      !do ibt=1,ib-1
+      !  zs=sum(conjg(zu_GS(:,ibt,ik))*gk_omp(:,thr_id))*Hxyz
+      !  gk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)-zu_GS(1:NL,ibt,ik)*zs
+      !end do
+      !s=sum(abs(gk_omp(:,thr_id))**2)*Hxyz
+      !
+      !select case (iter)
+      !case(1)
+      !  pk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)
+      !case default
+      !  uk=s/gkgk
+      !  pk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)+uk*pk_omp(1:NL,thr_id)
+      !end select
+      !gkgk=s
 
-      !Is this correct??  removed above GS(?) and added this line by AY
+      !added instead of GramShumit procedure
       pk_omp(1:NL,thr_id)=(hxk_omp(1:NL,thr_id)-xkHxk*xk_omp(1:NL,thr_id)) 
 
       zs=sum(conjg(xk_omp(:,thr_id))*pk_omp(:,thr_id))*Hxyz

--- a/src/ARTED/GS/CG.f90
+++ b/src/ARTED/GS/CG.f90
@@ -19,6 +19,19 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
 Subroutine CG_omp(iter_cg_max)
   use Global_Variables
+  implicit none
+  integer :: iter_cg_max
+
+  if( NK_e-NK_s+1 .lt. NB ) then !change as you like
+     call CG_ompr(iter_cg_max)
+  else
+     call CG_ompk(iter_cg_max)
+  endif
+
+End Subroutine CG_omp
+
+Subroutine CG_ompk(iter_cg_max)
+  use Global_Variables
   use salmon_parallel, only: nproc_group_tdks
   use salmon_communication, only: comm_summation
   use timer
@@ -58,12 +71,13 @@ Subroutine CG_omp(iter_cg_max)
   enddo
 ! sato -----------------------------------------------------------------------------------------
   do ib=1,NB
-    do ibt=1,ib-1
-      s=sum(conjg(zu_GS(:,ibt,ik))*zu_GS(:,ib,ik))*Hxyz
-      zu_GS(1:NL,ib,ik)=zu_GS(1:NL,ib,ik)-zu_GS(1:NL,ibt,ik)*s
-    end do
-    s=1.0d0/sqrt(sum(abs(zu_GS(:,ib,ik))**2)*Hxyz)
-    xk_omp(1:NL,thr_id)=zu_GS(1:NL,ib,ik)*s
+    !do ibt=1,ib-1
+    !  s=sum(conjg(zu_GS(:,ibt,ik))*zu_GS(:,ib,ik))*Hxyz
+    !  zu_GS(1:NL,ib,ik)=zu_GS(1:NL,ib,ik)-zu_GS(1:NL,ibt,ik)*s
+    !end do
+    !s=1.0d0/sqrt(sum(abs(zu_GS(:,ib,ik))**2)*Hxyz)
+    !xk_omp(1:NL,thr_id)=zu_GS(1:NL,ib,ik)*s
+    xk_omp(1:NL,thr_id)=zu_GS(1:NL,ib,ik)
     call hpsi_omp_KB_GS(ik,xk_omp(:,thr_id),txk_omp(:,thr_id),hxk_omp(:,thr_id))
     xkHxk=sum(conjg(xk_omp(:,thr_id))*hxk_omp(:,thr_id))*Hxyz
     xkTxk=sum(conjg(xk_omp(:,thr_id))*txk_omp(:,thr_id))*Hxyz
@@ -121,5 +135,122 @@ Subroutine CG_omp(iter_cg_max)
   call timer_end(LOG_CG)
 
   return
-End Subroutine CG_OMP
+End Subroutine CG_ompk
+
+Subroutine CG_ompr(iter_cg_max)
+  use Global_Variables
+  use salmon_parallel, only: nproc_group_tdks
+  use salmon_communication, only: comm_summation
+  use timer
+  use hpsi, only: hpsi_omp_KB_GS
+  implicit none
+  real(8),parameter :: delta_cg=1.d-15
+  integer iter,ik,ib,ibt
+  integer :: iter_cg_max
+  real(8) :: xkHxk,gkgk,pkHpk,xkTxk
+  real(8) :: uk,s,ev
+!  complex(8) :: xk(NL),hxk(NL),gk(NL),pk(NL),pko(NL),txk(NL)
+  complex(8) :: cx,cp,xkHpk
+  real(8) :: esp_var_l(1:NB,1:NK)
+  complex(8) :: zs
+! sato
+  integer :: ia,j,i,ix,iy,iz
+  real(8) :: kr
+! omp
+  integer :: thr_id,omp_get_thread_num
+  thr_id=0
+
+  call timer_begin(LOG_CG)
+  esp_var_l(:,:)=0.d0
+
+!$omp parallel 
+!$omp do private(j,i,ix,iy,iz,kr) collapse(2)
+  do ik=NK_s,NK_e
+  !    k2=sum(kAc(ik,:)**2)
+  !Constructing nonlocal part
+  do ia=1,NI
+  do j=1,Mps(ia)
+    i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
+    kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
+    ekr_omp(j,ia,ik)=exp(zI*kr)
+  enddo
+  enddo
+  enddo
+!$omp end do
+!$omp end parallel 
+
+
+!$omp parallel private(thr_id)
+!$  thr_id=omp_get_thread_num()
+!$omp do private(j,i,ix,iy,iz,kr,ib,ibt,s,xkHxk,xkTxk,iter,uk,gkgk,xkHpk,pkHpk,ev,cx,cp,zs) collapse(2)
+  do ik=NK_s,NK_e
+  do ib=1,NB
+    !do ibt=1,ib-1
+    !  s=sum(conjg(zu_GS(:,ibt,ik))*zu_GS(:,ib,ik))*Hxyz
+    !  zu_GS(1:NL,ib,ik)=zu_GS(1:NL,ib,ik)-zu_GS(1:NL,ibt,ik)*s
+    !end do
+    !s=1.0d0/sqrt(sum(abs(zu_GS(:,ib,ik))**2)*Hxyz)
+    !xk_omp(1:NL,thr_id)=zu_GS(1:NL,ib,ik)*s
+    xk_omp(1:NL,thr_id)=zu_GS(1:NL,ib,ik)
+    call hpsi_omp_KB_GS(ik,xk_omp(:,thr_id),txk_omp(:,thr_id),hxk_omp(:,thr_id))
+    xkHxk=sum(conjg(xk_omp(:,thr_id))*hxk_omp(:,thr_id))*Hxyz
+    xkTxk=sum(conjg(xk_omp(:,thr_id))*txk_omp(:,thr_id))*Hxyz
+
+    do iter=1,iter_cg_max
+!??? GramShumit???
+!      gk_omp(1:NL,thr_id)=(hxk_omp(1:NL,thr_id)-xkHxk*xk_omp(1:NL,thr_id))
+!      do ibt=1,ib-1
+!        zs=sum(conjg(zu_GS(:,ibt,ik))*gk_omp(:,thr_id))*Hxyz
+!        gk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)-zu_GS(1:NL,ibt,ik)*zs
+!      end do
+!      s=sum(abs(gk_omp(:,thr_id))**2)*Hxyz
+!
+!      select case (iter)
+!      case(1)
+!        pk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)
+!      case default
+!        uk=s/gkgk
+!        pk_omp(1:NL,thr_id)=gk_omp(1:NL,thr_id)+uk*pk_omp(1:NL,thr_id)
+!      end select
+!      gkgk=s
+
+      !Is this correct??  removed above GS(?) and added this line by AY
+      pk_omp(1:NL,thr_id)=(hxk_omp(1:NL,thr_id)-xkHxk*xk_omp(1:NL,thr_id)) 
+
+      zs=sum(conjg(xk_omp(:,thr_id))*pk_omp(:,thr_id))*Hxyz
+      pko_omp(1:NL,thr_id)=pk_omp(1:NL,thr_id)-xk_omp(1:NL,thr_id)*zs
+      s=1.0d0/sqrt(sum(abs(pko_omp(:,thr_id))**2)*Hxyz)
+      pko_omp(1:NL,thr_id)=pko_omp(1:NL,thr_id)*s
+      call hpsi_omp_KB_GS(ik,pko_omp(:,thr_id),ttpsi_omp(:,thr_id),htpsi_omp(:,thr_id))
+      xkHpk=sum(conjg( xk_omp(:,thr_id))*htpsi_omp(:,thr_id))*Hxyz
+      pkHpk=sum(conjg(pko_omp(:,thr_id))*htpsi_omp(:,thr_id))*Hxyz
+      ev=0.5d0*((xkHxk+pkHpk)-sqrt((xkHxk-pkHpk)**2+4*abs(xkHpk)**2))
+      cx=xkHpk/(ev-xkHxk)
+      cp=1.d0/sqrt(1.d0+abs(cx)**2)
+      cx=cx*cp
+      if(abs(ev-xkHxk)<delta_cg) exit
+       xk_omp(1:NL,thr_id)=cx* xk_omp(1:NL,thr_id)+cp*  pko_omp(1:NL,thr_id)
+      hxk_omp(1:NL,thr_id)=cx*hxk_omp(1:NL,thr_id)+cp*htpsi_omp(1:NL,thr_id)
+      txk_omp(1:NL,thr_id)=cx*txk_omp(1:NL,thr_id)+cp*ttpsi_omp(1:NL,thr_id)
+      xkHxk=sum(conjg(xk_omp(:,thr_id))*hxk_omp(:,thr_id))*Hxyz
+      xkTxk=sum(conjg(xk_omp(:,thr_id))*txk_omp(:,thr_id))*Hxyz
+    enddo
+
+    s=1.0d0/sqrt(sum(abs(xk_omp(:,thr_id))**2)*Hxyz)
+    zu_GS(1:NL,ib,ik)=xk_omp(1:NL,thr_id)*s
+    call hpsi_omp_KB_GS(ik,zu_GS(:,ib,ik),ttpsi_omp(:,thr_id),htpsi_omp(:,thr_id))
+    xkHxk=sum(conjg(zu_GS(1:NL,ib,ik))*htpsi_omp(:,thr_id))*Hxyz
+    esp_var_l(ib,ik)=sqrt(sum(abs(htpsi_omp(:,thr_id)-xkHxk*zu_GS(1:NL,ib,ik))**2)*Hxyz)*occ(ib,ik)
+  enddo
+  enddo
+!$omp end parallel
+
+  call timer_begin(LOG_ALLREDUCE)
+  call comm_summation(esp_var_l,esp_var,NB*NK,nproc_group_tdks)
+  call timer_end(LOG_ALLREDUCE)
+
+  call timer_end(LOG_CG)
+
+  return
+End Subroutine CG_ompr
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130

--- a/src/ARTED/GS/Gram_Schmidt.f90
+++ b/src/ARTED/GS/Gram_Schmidt.f90
@@ -20,11 +20,12 @@
 Subroutine Gram_Schmidt
   use Global_Variables
 
-  if( NK_e-NK_s+1 .lt. NB ) then !change as you like
-     call Gram_Schmidt_ompr
-  else
+  select case (omp_loop)
+  case('k')
      call Gram_Schmidt_ompk
-  endif
+  case('b')
+     call Gram_Schmidt_ompb
+  end select
 
 End Subroutine Gram_Schmidt
 
@@ -42,7 +43,7 @@ Subroutine Gram_Schmidt_ompk
   do ib=1,NB
     do ibt=1,ib-1
       zov=sum(conjg(zu_GS(:,ibt,ik))*zu_GS(:,ib,ik))*Hxyz
-      zu_GS(:,ib,ik)=zu_GS(:,ib,ik)-zu_GS(:,ibt,ik)*zov  !?? correct?? out of loop?
+      zu_GS(:,ib,ik)=zu_GS(:,ib,ik)-zu_GS(:,ibt,ik)*zov
     enddo
     s=sum(abs(zu_GS(:,ib,ik))**2)*Hxyz
     zu_GS(:,ib,ik)=zu_GS(:,ib,ik)/sqrt(s)
@@ -53,7 +54,7 @@ Subroutine Gram_Schmidt_ompk
   return
 End Subroutine Gram_Schmidt_ompk
 
-Subroutine Gram_Schmidt_ompr
+Subroutine Gram_Schmidt_ompb
   !This subroutine follows the algorithm developed 
   !in RSDFT for efficient parallelization
   !(but not perfectly the same to avoid complication.
@@ -135,6 +136,6 @@ Subroutine Gram_Schmidt_ompr
   call timer_end(LOG_GRAM_SCHMIDT)
 
   return
-End Subroutine Gram_Schmidt_ompr
+End Subroutine Gram_Schmidt_ompb
 
 

--- a/src/ARTED/GS/Gram_Schmidt.f90
+++ b/src/ARTED/GS/Gram_Schmidt.f90
@@ -19,6 +19,17 @@
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
 Subroutine Gram_Schmidt
   use Global_Variables
+
+  if( NK_e-NK_s+1 .lt. NB ) then !change as you like
+     call Gram_Schmidt_ompr
+  else
+     call Gram_Schmidt_ompk
+  endif
+
+End Subroutine Gram_Schmidt
+
+Subroutine Gram_Schmidt_ompk
+  use Global_Variables
   use timer
   implicit none
   integer :: ik,ib,ibt
@@ -31,7 +42,7 @@ Subroutine Gram_Schmidt
   do ib=1,NB
     do ibt=1,ib-1
       zov=sum(conjg(zu_GS(:,ibt,ik))*zu_GS(:,ib,ik))*Hxyz
-      zu_GS(:,ib,ik)=zu_GS(:,ib,ik)-zu_GS(:,ibt,ik)*zov
+      zu_GS(:,ib,ik)=zu_GS(:,ib,ik)-zu_GS(:,ibt,ik)*zov  !?? correct?? out of loop?
     enddo
     s=sum(abs(zu_GS(:,ib,ik))**2)*Hxyz
     zu_GS(:,ib,ik)=zu_GS(:,ib,ik)/sqrt(s)
@@ -40,4 +51,90 @@ Subroutine Gram_Schmidt
   call timer_end(LOG_GRAM_SCHMIDT)
 
   return
-End Subroutine Gram_Schmidt
+End Subroutine Gram_Schmidt_ompk
+
+Subroutine Gram_Schmidt_ompr
+  !This subroutine follows the algorithm developed 
+  !in RSDFT for efficient parallelization
+  !(but not perfectly the same to avoid complication.
+  ! If further tuning is necessary, you can revise refering the algorithm.
+  use Global_Variables
+  use timer
+  implicit none
+  integer :: i,ik,ib,ibt
+  real(8) :: s1,s2
+  complex(8) :: zov,zov1a,zov1b,zov2a,zov2b
+  complex(8),allocatable :: zu_GSold(:,:,:),zov_omp(:,:,:)
+  integer :: thr_id,omp_get_thread_num
+  thr_id=0
+
+  call timer_begin(LOG_GRAM_SCHMIDT)
+  allocate(zu_GSold(NL,NB,NK_s:NK_e))
+  allocate(zov_omp(2,NB,0:NUMBER_THREADS-1))
+
+
+  do ik=NK_s,NK_e
+
+  zu_GSold(:,:,ik) = zu_GS(:,:,ik)
+
+  do ib=1,NB-1,2
+     zov = sum(conjg(zu_GS(:,ib,ik))*zu_GSold(:,ib+1,ik))*Hxyz
+     zu_GS(:,ib+1,ik) = zu_GS(:,ib+1,ik) - zu_GS(:,ib,ik)*zov
+
+     s1=0d0
+     s2=0d0
+!$omp parallel do private(i) reduction(+:s1,s2)
+     do i=1,NL
+        s1 = s1 + abs(zu_GS(i,ib,  ik))**2
+        s2 = s2 + abs(zu_GS(i,ib+1,ik))**2
+     enddo
+!$omp end parallel do
+     s1 = 1d0/sqrt(s1*Hxyz)
+     s2 = 1d0/sqrt(s2*Hxyz)
+
+     zu_GS(:,ib,  ik) = zu_GS(:,ib,  ik)*s1
+     zu_GS(:,ib+1,ik) = zu_GS(:,ib+1,ik)*s2
+
+     zov_omp(:,:,:)=0d0
+!$omp parallel private(thr_id)
+!$  thr_id=omp_get_thread_num()
+!$omp do private(ibt,i) collapse(2)
+     do ibt=ib+2,NB-1,2
+        do i=1,NL
+            zov_omp(1,ibt,  thr_id) = zov_omp(1,ibt,  thr_id)+ conjg(zu_GS(i,ib,  ik)) * zu_GS(i,ibt,  ik)
+            zov_omp(2,ibt,  thr_id) = zov_omp(2,ibt,  thr_id)+ conjg(zu_GS(i,ib+1,ik)) * zu_GS(i,ibt,  ik)
+            zov_omp(1,ibt+1,thr_id) = zov_omp(1,ibt+1,thr_id)+ conjg(zu_GS(i,ib,  ik)) * zu_GS(i,ibt+1,ik)
+            zov_omp(2,ibt+1,thr_id) = zov_omp(2,ibt+1,thr_id)+ conjg(zu_GS(i,ib+1,ik)) * zu_GS(i,ibt+1,ik)
+        enddo
+     enddo
+!$omp end do
+
+     do ibt=ib+2,NB-1,2
+        zov1a = sum(zov_omp(1,ibt,  :))*Hxyz
+        zov1b = sum(zov_omp(2,ibt,  :))*Hxyz
+        zov2a = sum(zov_omp(1,ibt+1,:))*Hxyz
+        zov2b = sum(zov_omp(2,ibt+1,:))*Hxyz
+
+!$omp do private(i)
+        do i=1,NL
+           zu_GS(i,ibt,  ik)= zu_GS(i,ibt,  ik)- zu_GS(i,ib,ik)*zov1a-zu_GS(i,ib+1,ik)*zov1b
+           zu_GS(i,ibt+1,ik)= zu_GS(i,ibt+1,ik)- zu_GS(i,ib,ik)*zov2a-zu_GS(i,ib+1,ik)*zov2b
+        enddo
+!$omp end do
+
+     enddo
+!$omp end parallel
+
+  enddo
+
+  enddo !ik
+
+
+  deallocate(zov_omp)
+  deallocate(zu_GSold)
+  call timer_end(LOG_GRAM_SCHMIDT)
+
+  return
+End Subroutine Gram_Schmidt_ompr
+
+

--- a/src/ARTED/GS/diag.f90
+++ b/src/ARTED/GS/diag.f90
@@ -105,6 +105,44 @@ Subroutine diag_omp
   enddo
   deallocate(za,zutmp,work_lp,rwork)
 #else
+
+
+  if( NK_e-NK_s+1 .lt. NB ) then !change as you like
+  !!---Openmp is for orbital---
+
+  allocate(za(NB,NB),zutmp(NL,NB))
+  allocate(work_lp(lwork),rwork(3*NB-2),w(NB))
+  do ik=NK_s,NK_e
+!$omp parallel private(thr_id)
+!$ thr_id = omp_get_thread_num()
+!$omp do private(ib1,ib2)
+    do ib1=1,NB
+      tpsi_omp(1:NL,thr_id)=zu_GS(1:NL,ib1,ik)
+      call hpsi_omp_KB_GS(ik,tpsi_omp(:,thr_id),ttpsi_omp(:,thr_id),htpsi_omp(:,thr_id))
+      do ib2=ib1+1,NB
+        za(ib2,ib1)=sum(conjg(zu_GS(:,ib2,ik))*htpsi_omp(:,thr_id))*Hxyz
+        za(ib1,ib2)=conjg(za(ib2,ib1))
+      end do
+      za(ib1,ib1)=real(sum(conjg(zu_GS(:,ib1,ik))*htpsi_omp(:,thr_id))*Hxyz)
+    end do
+!$omp end do
+!$omp end parallel
+    call zheev('V', 'U', NB, za, NB, w, work_lp, lwork, rwork, info)
+
+    zutmp=0.d0
+    do ib1=1,NB
+    do ib2=1,NB
+      zutmp(:,ib1)=zutmp(:,ib1)+zu_GS(:,ib2,ik)*za(ib2,ib1)
+    end do
+    end do
+    zu_GS(:,:,ik)=zutmp(:,:)
+    esp(:,ik)=w(:)
+  enddo
+  deallocate(za,zutmp,work_lp,rwork)
+
+  else  
+  !!---Openmp is for k-points---
+
 !$omp parallel private(thr_id,za,zutmp,work_lp,rwork,w)
 !$ thr_id = omp_get_thread_num()
   allocate(za(NB,NB),zutmp(NL,NB))
@@ -134,6 +172,9 @@ Subroutine diag_omp
 !$omp end do
   deallocate(za,zutmp,work_lp,rwork)
 !$omp end parallel
+
+  endif
+
 #endif
   call timer_end(LOG_DIAG)
 

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -291,7 +291,9 @@ contains
       & subspace_diagonalization, &
       & convergence, &
       & threshold, &
-      & threshold_pot
+      & threshold_pot, &
+      & omp_loop, &
+      & skip_gsortho
 
     namelist/emfield/ &
       & trans_longi, &
@@ -546,6 +548,9 @@ contains
     convergence   = 'rho_dng'
     threshold     = 1d-17/ulength_from_au**3  ! a.u., 1d-17 a.u. = 6.75d-17 AA**(-3)
     threshold_pot = -1d0*uenergy_from_au**2*uenergy_from_au**3  ! a.u., -1 a.u. = -1.10d2 eV**2*AA**3
+    omp_loop      = 'k'
+    skip_gsortho  = 'n'
+
 !! == default for &emfield
     trans_longi    = 'tr'
     ae_shape1      = 'none'
@@ -840,6 +845,8 @@ contains
     threshold = threshold / (ulength_to_au)**3
     call comm_bcast(threshold_pot           ,nproc_group_global)
     threshold_pot = threshold_pot * (uenergy_to_au)**2 * (ulength_to_au)**3 
+    call comm_bcast(omp_loop                ,nproc_group_global)
+    call comm_bcast(skip_gsortho            ,nproc_group_global)
 !! == bcast for &emfield
     call comm_bcast(trans_longi,nproc_group_global)
     call comm_bcast(ae_shape1  ,nproc_group_global)
@@ -1340,6 +1347,8 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'convergence', convergence
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'threshold', threshold
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'threshold_pot', threshold_pot
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'omp_loop', omp_loop
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'skip_gsortho', skip_gsortho
 
       if(inml_emfield >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'emfield', inml_emfield

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -128,6 +128,8 @@ module salmon_global
   character(8)   :: convergence
   real(8)        :: threshold
   real(8)        :: threshold_pot
+  character(1)   :: omp_loop
+  character(1)   :: skip_gsortho
 
 !! &emfield
   character(2)   :: trans_longi


### PR DESCRIPTION
OpenMP parallelization by space grids and orbitals in ground-state calc (ARTED side)

OpenMP parallelization in ground-state calculation was revised. If the number of k-points in a node is larger than the number of orbital, openmp works as k-points parallelization as before (no change in the case), but if the orbital number is larger than the k-point number, openmp parallelization works for space grid points and orbitals loops. As for the calculation time, if gamma point calculation of large system for example, the calculation time of GS option was reduced to 1/10 on OFP (256 threads in a node) (....I think it can be faster if further tuning is done in future). 
The revised subroutines are
(1) Gram_Schmidt
      Referring algorithm developed in RSDFT, openmp parallelization by orbital and space grid was implemented. (but not perfectly the same as RSDFT to avoid complication, so efficiency is not as good as RSDFT)
(2) CG
      Following Iwata-san's comment, Gram-Schmidt orthogonalization in the CG loop is removed. Then, openmp with orbitals are introduced. (orthogonalization is done before and after CG)
(3) diag
      Openmp by orbitals are introduced.
