### PR TITLE
tiny fix: deallocation in GS

### DIFF
--- a/src/ARTED/control/ground_state.f90
+++ b/src/ARTED/control/ground_state.f90
@@ -281,7 +281,7 @@ contains
     endif
     
     deallocate(rho_in,rho_out)
-    deallocate(Eall_GS,esp_var_ave,esp_var_max,ddns)
+    deallocate(Eall_GS,esp_var_ave,esp_var_max,ddns,ddns_abs_1e)
 
   contains
     subroutine reset_gs_timer


### PR DESCRIPTION
I just found that one variable in GS subroutine was not deallocated (the variable was added in the recent revise). I fixed.
