### PR TITLE
Optimized non-local pseudopotential operations

### DIFF
--- a/src/ARTED/GS/CG.f90
+++ b/src/ARTED/GS/CG.f90
@@ -56,7 +56,7 @@ Subroutine CG_ompk(iter_cg_max)
   thr_id=0
 
   call timer_begin(LOG_CG)
-  call projector_update(kac)
+  call update_projector(kac)
 
   esp_var_l(:,:)=0.d0
 !$omp parallel private(thr_id)
@@ -163,7 +163,7 @@ Subroutine CG_ompb(iter_cg_max)
   thr_id=0
 
   call timer_begin(LOG_CG)
-  call projector_update(kac)
+  call update_projector(kac)
   esp_var_l(:,:)=0.d0
 
 

--- a/src/ARTED/GS/CG.f90
+++ b/src/ARTED/GS/CG.f90
@@ -49,7 +49,7 @@ Subroutine CG_ompk(iter_cg_max)
   real(8) :: esp_var_l(1:NB,1:NK)
   complex(8) :: zs
 ! sato
-  integer :: ia,j,i,ix,iy,iz
+  integer :: j,i,ix,iy,iz
   real(8) :: kr
 ! omp
   integer :: thr_id,omp_get_thread_num
@@ -61,7 +61,7 @@ Subroutine CG_ompk(iter_cg_max)
   esp_var_l(:,:)=0.d0
 !$omp parallel private(thr_id)
 !$  thr_id=omp_get_thread_num()
-!$omp do private(ia,j,i,ix,iy,iz,kr,ib,ibt,s,xkHxk,xkTxk,iter,uk,gkgk,xkHpk,pkHpk,ev,cx,cp,zs)
+!$omp do private(j,i,ix,iy,iz,kr,ib,ibt,s,xkHxk,xkTxk,iter,uk,gkgk,xkHpk,pkHpk,ev,cx,cp,zs)
   do ik=NK_s,NK_e
   do ib=1,NB
     select case (skip_gsortho)
@@ -156,7 +156,7 @@ Subroutine CG_ompb(iter_cg_max)
   real(8) :: esp_var_l(1:NB,1:NK)
   complex(8) :: zs
 ! sato
-  integer :: ia,j,i,ix,iy,iz
+  integer :: j,i,ix,iy,iz
   real(8) :: kr
 ! omp
   integer :: thr_id,omp_get_thread_num

--- a/src/ARTED/GS/diag.f90
+++ b/src/ARTED/GS/diag.f90
@@ -28,8 +28,7 @@ Subroutine diag_omp
   implicit none
   integer,parameter :: matz=1
   integer           :: ik,ib1,ib2
-  integer           :: ia,j,i,ix,iy,iz,thr_id
-  real(8)           :: kr
+  integer           :: thr_id
 
 !LAPACK
   integer                :: lwork,info

--- a/src/ARTED/GS/diag.f90
+++ b/src/ARTED/GS/diag.f90
@@ -24,6 +24,7 @@ Subroutine diag_omp
   use timer
   use omp_lib
   use hpsi, only: hpsi_omp_KB_GS
+  use projector
   implicit none
   integer,parameter :: matz=1
   integer           :: ik,ib1,ib2

--- a/src/ARTED/GS/diag.f90
+++ b/src/ARTED/GS/diag.f90
@@ -46,21 +46,7 @@ Subroutine diag_omp
   thr_id=0
 
   call timer_begin(LOG_DIAG)
-!$omp parallel private(thr_id)
-!$ thr_id = omp_get_thread_num()
-!$omp do private(ia,j,i,ix,iy,iz,kr) collapse(2)
-!Constructing nonlocal part ! sato
-  do ik=NK_s,NK_e
-  do ia=1,NI
-  do j=1,Mps(ia)
-    i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-    kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-    ekr_omp(j,ia,ik)=exp(zI*kr)
-  end do
-  end do
-  end do
-!$omp end do
-!$omp end parallel
+  call update_projector(kac)
 
 ! FIXME: For Fujitsu's parallelized BLAS routines, the application crashes when
 !        invoking a routine under OpenMP parallelized loop.

--- a/src/ARTED/GS/sp_energy.f90
+++ b/src/ARTED/GS/sp_energy.f90
@@ -36,7 +36,7 @@ Subroutine sp_energy_omp
   call timer_begin(LOG_SP_ENERGY)
   esp_l=0.d0
   thr_id=0
-  call projector_update(kac)
+  call update_projector(kac)
 !$omp parallel private(thr_id)
 !$  thr_id=omp_get_thread_num()
 !$omp do private(ik,ia,j,i,ix,iy,iz,kr,ib)

--- a/src/ARTED/GS/sp_energy.f90
+++ b/src/ARTED/GS/sp_energy.f90
@@ -23,6 +23,7 @@ Subroutine sp_energy_omp
   use salmon_communication, only: comm_summation
   use timer
   use hpsi, only: hpsi_omp_KB_GS
+  use projector
   implicit none
   integer :: ik,ib
   real(8) :: esp_l(NB,NK)
@@ -35,18 +36,11 @@ Subroutine sp_energy_omp
   call timer_begin(LOG_SP_ENERGY)
   esp_l=0.d0
   thr_id=0
+  call projector_update(kac)
 !$omp parallel private(thr_id)
 !$  thr_id=omp_get_thread_num()
 !$omp do private(ik,ia,j,i,ix,iy,iz,kr,ib)
   do ik=NK_s,NK_e
-!Constructing nonlocal part ! sato
-  do ia=1,NI
-    do j=1,Mps(ia)
-      i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-      kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-      ekr_omp(j,ia,ik)=exp(zI*kr)
-    enddo
-  enddo
     do ib=1,NB
       tpsi_omp(1:NL,thr_id)=zu_GS(1:NL,ib,ik)
       call hpsi_omp_KB_GS(ik,tpsi_omp(:,thr_id),ttpsi_omp(:,thr_id),htpsi_omp(:,thr_id))

--- a/src/ARTED/RT/current.f90
+++ b/src/ARTED/RT/current.f90
@@ -254,10 +254,10 @@ contains
         iy=Jyy(j,ia); y=Ly(i)*Hy-iy*aLy
         iz=Jzz(j,ia); z=Lz(i)*Hz-iz*aLz
 
-        uVpsi =uVpsi +uV(j,ilma)*ekr_omp(j,ia,ik)  *zutmp(i)
-        uVpsix=uVpsix+uV(j,ilma)*ekr_omp(j,ia,ik)*x*zutmp(i)
-        uVpsiy=uVpsiy+uV(j,ilma)*ekr_omp(j,ia,ik)*y*zutmp(i)
-        uVpsiz=uVpsiz+uV(j,ilma)*ekr_omp(j,ia,ik)*z*zutmp(i)
+        uVpsi =uVpsi +conjg(zproj(j,ilma,ik))  *zutmp(i)
+        uVpsix=uVpsix+conjg(zproj(j,ilma,ik))*x*zutmp(i)
+        uVpsiy=uVpsiy+conjg(zproj(j,ilma,ik))*y*zutmp(i)
+        uVpsiz=uVpsiz+conjg(zproj(j,ilma,ik))*z*zutmp(i)
       end do
       uVpsi =uVpsi *Hxyz*iuV(ilma)
       uVpsix=uVpsix*Hxyz

--- a/src/ARTED/RT/current.f90
+++ b/src/ARTED/RT/current.f90
@@ -105,6 +105,7 @@ subroutine current(mode,NBtmp,zutmp)
 contains
   subroutine impl(mode, NBtmp, zutmp, jxs, jys, jzs)
     use Global_Variables
+    use projector
     implicit none
     character(2),intent(in) :: mode
     integer,intent(in)      :: NBtmp
@@ -121,23 +122,12 @@ contains
 
     IaLxyz = 1.0 / aLxyz
 
+    call projector_update(kac)
+
     jxs=0.d0
     jys=0.d0
     jzs=0.d0
 !$omp parallel reduction(+:jxs,jys,jzs)
-
-    !Constructing nonlocal part
-!$omp do private(ik,ia,j,i,ix,iy,iz,kr) collapse(2)
-    do ik=NK_s,NK_e
-    do ia=1,NI
-    do j=1,Mps(ia)
-      i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-      kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-      ekr_omp(j,ia,ik)=exp(zI*kr)
-    end do
-    end do
-    end do
-!$omp end do
 
     if (mode == 'ZE' .or. mode == 'GS') then
 !$omp do private(ikb,ik,ib,jx,jy,jz)

--- a/src/ARTED/RT/current.f90
+++ b/src/ARTED/RT/current.f90
@@ -122,7 +122,7 @@ contains
 
     IaLxyz = 1.0 / aLxyz
 
-    call projector_update(kac)
+    call update_projector(kac)
 
     jxs=0.d0
     jys=0.d0

--- a/src/ARTED/RT/current.f90
+++ b/src/ARTED/RT/current.f90
@@ -112,8 +112,8 @@ contains
     complex(8),intent(in)   :: zutmp(0:NL-1,NBtmp,NK_s:NK_e)
     real(8),intent(out)     :: jxs,jys,jzs
 
-    integer :: ikb,ib,ik,i,j,ix,iy,iz,ia
-    real(8) :: kr,jx,jy,jz,IaLxyz
+    integer :: ikb,ib,ik
+    real(8) :: jx,jy,jz,IaLxyz
     real(8) :: nabt(12)
 
     nabt( 1: 4) = nabx(1:4)

--- a/src/ARTED/RT/dt_evolve.f90
+++ b/src/ARTED/RT/dt_evolve.f90
@@ -109,6 +109,7 @@ end subroutine
 
 Subroutine dt_evolve_omp_KB(zu)
   use Global_Variables
+  use projector
   use timer
 #ifdef ARTED_USE_NVTX
   use nvtx
@@ -124,34 +125,13 @@ Subroutine dt_evolve_omp_KB(zu)
   NVTX_BEG('dt_evolve_omp_KB()',1)
   call timer_begin(LOG_DT_EVOLVE)
 
+
+
 !$acc data pcopy(zu, vloc) pcopyout(ekr_omp)
 
 !Constructing nonlocal part
   NVTX_BEG('dt_evolve_omp_KB(): nonlocal part',2)
-#ifdef _OPENACC
-!$acc kernels pcopy(ekr_omp) pcopyin(Mps, Jxyz,Jxx,Jyy,Jzz, kAc, Lx,Ly,Lz)
-!$acc loop collapse(2) independent gang
-#else
-  thr_id=0
-!$omp parallel private(thr_id)
-!$  thr_id=omp_get_thread_num()
-!$omp do private(ik,ia,j,i,ix,iy,iz,kr) collapse(2)
-#endif
-  do ik=NK_s,NK_e
-  do ia=1,NI
-!$acc loop independent vector(128)
-  do j=1,Mps(ia)
-    i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-    kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-    ekr_omp(j,ia,ik)=exp(zI*kr)
-  end do
-  end do
-  end do
-#ifdef _OPENACC
-!$acc end kernels
-#else
-!$omp end parallel
-#endif
+  call update_projector(kac)
   NVTX_END()
 
 ! yabana
@@ -242,6 +222,7 @@ End Subroutine dt_evolve_omp_KB
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
 Subroutine dt_evolve_etrs_omp_KB(zu)
   use Global_Variables
+  use projector
   use timer
 #ifdef ARTED_USE_NVTX
   use nvtx
@@ -263,30 +244,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
 
 !Constructing nonlocal part
   NVTX_BEG('dt_evolve_omp_KB(): nonlocal part',2)
-#ifdef _OPENACC
-!$acc kernels pcopy(ekr_omp) pcopyin(Mps, Jxyz,Jxx,Jyy,Jzz, kAc, Lx,Ly,Lz)
-!$acc loop collapse(2) independent gang
-#else
-  thr_id=0
-!$omp parallel private(thr_id)
-!$  thr_id=omp_get_thread_num()
-!$omp do private(ik,ia,j,i,ix,iy,iz,kr) collapse(2)
-#endif
-  do ik=NK_s,NK_e
-  do ia=1,NI
-!$acc loop independent vector(128)
-  do j=1,Mps(ia)
-    i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-    kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-    ekr_omp(j,ia,ik)=exp(zI*kr)
-  end do
-  end do
-  end do
-#ifdef _OPENACC
-!$acc end kernels
-#else
-!$omp end parallel
-#endif
+  call projector_update(kac)
   NVTX_END()
 
 
@@ -308,30 +266,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
 
 !Constructing nonlocal part
   NVTX_BEG('dt_evolve_omp_KB(): nonlocal part',2)
-#ifdef _OPENACC
-!$acc kernels pcopy(ekr_omp) pcopyin(Mps, Jxyz,Jxx,Jyy,Jzz, kAc, Lx,Ly,Lz)
-!$acc loop collapse(2) independent gang
-#else
-  thr_id=0
-!$omp parallel private(thr_id)
-!$  thr_id=omp_get_thread_num()
-!$omp do private(ik,ia,j,i,ix,iy,iz,kr) collapse(2)
-#endif
-  do ik=NK_s,NK_e
-  do ia=1,NI
-!$acc loop independent vector(128)
-  do j=1,Mps(ia)
-    i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-    kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-    ekr_omp(j,ia,ik)=exp(zI*kr)
-  end do
-  end do
-  end do
-#ifdef _OPENACC
-!$acc end kernels
-#else
-!$omp end parallel
-#endif
+  call update_projector(kac)
   NVTX_END()
 
 !== predictor-corrector ==
@@ -419,6 +354,7 @@ End Subroutine dt_evolve_etrs_omp_KB
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
 Subroutine dt_evolve_omp_KB_MS(zu)
   use Global_Variables
+  use projector
   use timer
   use nvtx
   use opt_variables
@@ -436,29 +372,7 @@ Subroutine dt_evolve_omp_KB_MS(zu)
 
 !Constructing nonlocal part ! sato
   NVTX_BEG('dt_evolve_omp_KB_MS(): nonlocal part',2)
-#ifdef _OPENACC
-!$acc kernels pcopy(ekr_omp) pcopyin(Mps, Jxyz,Jxx,Jyy,Jzz, kAc, Lx,Ly,Lz)
-!$acc loop collapse(2) independent gang
-#else
-  thr_id=0
-!$omp parallel private(thr_id)
-!$  thr_id=omp_get_thread_num()
-!$omp do private(ik,ia,j,i,ix,iy,iz,kr) collapse(2)
-#endif
-  do ik=NK_s,NK_e
-  do ia=1,NI
-  do j=1,Mps(ia)
-    i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-    kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-    ekr_omp(j,ia,ik)=exp(zI*kr)
-  end do
-  end do
-  end do
-#ifdef _OPENACC
-!$acc end kernels
-#else
-!$omp end parallel
-#endif
+  call update_projector(kac)
 
 ! yabana
   select case(functional)

--- a/src/ARTED/RT/dt_evolve.f90
+++ b/src/ARTED/RT/dt_evolve.f90
@@ -244,7 +244,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
 
 !Constructing nonlocal part
   NVTX_BEG('dt_evolve_omp_KB(): nonlocal part',2)
-  call projector_update(kac)
+  call update_projector(kac)
   NVTX_END()
 
 

--- a/src/ARTED/RT/dt_evolve.f90
+++ b/src/ARTED/RT/dt_evolve.f90
@@ -117,10 +117,8 @@ Subroutine dt_evolve_omp_KB(zu)
   use opt_variables
   implicit none
   complex(8),intent(inout) :: zu(NL,NBoccmax,NK_s:NK_e)
-  integer    :: ik,ib
-  integer    :: ia,j,i,ix,iy,iz
-  real(8)    :: kr
-  integer    :: thr_id,omp_get_thread_num,ikb
+  integer    :: ik,ib,ikb
+  integer    :: i
 
   NVTX_BEG('dt_evolve_omp_KB()',1)
   call timer_begin(LOG_DT_EVOLVE)
@@ -230,10 +228,9 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
   use opt_variables
   implicit none
   complex(8),intent(inout) :: zu(NL,NBoccmax,NK_s:NK_e)
-  integer    :: ik,ib
-  integer    :: ia,j,i,ix,iy,iz
-  real(8)    :: kr,dt_t
-  integer    :: thr_id,omp_get_thread_num,ikb
+  integer    :: ik,ib,ikb
+  integer    :: i
+  real(8)    :: dt_t
 
   NVTX_BEG('dt_evolve_omp_KB()',1)
   call timer_begin(LOG_DT_EVOLVE)
@@ -360,10 +357,8 @@ Subroutine dt_evolve_omp_KB_MS(zu)
   use opt_variables
   implicit none
   complex(8),intent(inout) :: zu(NL,NBoccmax,NK_s:NK_e)
-  integer    :: ik,ib
-  integer    :: ia,j,i,ix,iy,iz
-  real(8)    :: kr
-  integer    :: thr_id,omp_get_thread_num,ikb
+  integer    :: ik,ib,ikb
+  integer    :: i
 
   NVTX_BEG('dt_evolve_omp_KB_MS()',1)
   call timer_begin(LOG_DT_EVOLVE)

--- a/src/ARTED/common/CMakeLists.txt
+++ b/src/ARTED/common/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     preprocessor.f90
     restart.f90
     density_plot.f90
+    projector.f90
     )
 
 if (ENABLE_OPENACC)

--- a/src/ARTED/common/hpsi.f90
+++ b/src/ARTED/common/hpsi.f90
@@ -97,7 +97,7 @@ contains
 
   subroutine hpsi_omp_KB_base(ik,tpsi,htpsi,ttpsi)
     use timer
-    use Global_Variables, only: NLx,NLy,NLz,kAc,lapx,lapy,lapz,nabx,naby,nabz,Vloc,Mps,iuV,Hxyz,Nlma,a_tbl,proj
+    use Global_Variables, only: NLx,NLy,NLz,kAc,lapx,lapy,lapz,nabx,naby,nabz,Vloc,Mps,iuV,Hxyz,Nlma,a_tbl,zproj
     use opt_variables, only: lapt,PNLx,PNLy,PNLz,PNL
 #ifdef ARTED_USE_NVTX
     use nvtx
@@ -169,13 +169,13 @@ contains
         uVpsi=0.d0
         do j=1,Mps(ia)
           i=zJxyz(j,ia)
-          uVpsi=uVpsi+proj(j,ilma,ia,ik)*tpsi(i)
+          uVpsi=uVpsi+conjg(zproj(j,ilma,ik))*tpsi(i)
         end do
         uVpsi=uVpsi*Hxyz*iuV(ilma)
 !dir$ ivdep
         do j=1,Mps(ia)
           i=zJxyz(j,ia)
-          htpsi(i)=htpsi(i)+conjg(proj(j,ilma,ia,ik))*uVpsi
+          htpsi(i)=htpsi(i)+zproj(j,ilma,ik)*uVpsi
         end do
       end do
     end subroutine

--- a/src/ARTED/common/hpsi.f90
+++ b/src/ARTED/common/hpsi.f90
@@ -97,7 +97,7 @@ contains
 
   subroutine hpsi_omp_KB_base(ik,tpsi,htpsi,ttpsi)
     use timer
-    use Global_Variables, only: NLx,NLy,NLz,kAc,lapx,lapy,lapz,nabx,naby,nabz,Vloc,Mps,uV,iuV,Hxyz,ekr_omp,Nlma,a_tbl
+    use Global_Variables, only: NLx,NLy,NLz,kAc,lapx,lapy,lapz,nabx,naby,nabz,Vloc,Mps,iuV,Hxyz,Nlma,a_tbl,proj
     use opt_variables, only: lapt,PNLx,PNLy,PNLz,PNL
 #ifdef ARTED_USE_NVTX
     use nvtx
@@ -169,13 +169,13 @@ contains
         uVpsi=0.d0
         do j=1,Mps(ia)
           i=zJxyz(j,ia)
-          uVpsi=uVpsi+uV(j,ilma)*ekr_omp(j,ia,ik)*tpsi(i)
+          uVpsi=uVpsi+proj(j,ilma,ia,ik)*tpsi(i)
         end do
         uVpsi=uVpsi*Hxyz*iuV(ilma)
 !dir$ ivdep
         do j=1,Mps(ia)
           i=zJxyz(j,ia)
-          htpsi(i)=htpsi(i)+conjg(ekr_omp(j,ia,ik))*uVpsi*uV(j,ilma)
+          htpsi(i)=htpsi(i)+conjg(proj(j,ilma,ia,ik))*uVpsi
         end do
       end do
     end subroutine

--- a/src/ARTED/common/ion_force.f90
+++ b/src/ARTED/common/ion_force.f90
@@ -82,7 +82,7 @@ contains
 
     ftmp_l=0.d0
     ftmp_l_kl=0.d0
-    call projector_update(kac)
+    call update_projector(kac)
 
 !$omp parallel private(ia) reduction(+:ftmp_l, ftmp_l_kl)
 

--- a/src/ARTED/common/ion_force.f90
+++ b/src/ARTED/common/ion_force.f90
@@ -41,6 +41,7 @@ contains
     use salmon_communication, only: comm_summation
     use timer
     use salmon_math
+    use projector
     implicit none
     logical,intent(in)       :: Rion_update
     integer,intent(in)       :: zu_NB
@@ -81,6 +82,7 @@ contains
 
     ftmp_l=0.d0
     ftmp_l_kl=0.d0
+    call projector_update(kac)
 
 !$omp parallel private(ia) reduction(+:ftmp_l, ftmp_l_kl)
 
@@ -101,18 +103,6 @@ contains
 !$omp end do
     end do
 
-    !nonlocal
-!$omp do private(ik,j,i,ix,iy,iz,kr) collapse(2)
-    do ik=NK_s,NK_e
-    do ia=1,NI
-    do j=1,Mps(ia)
-      i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-      kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-      ekr_omp(j,ia,ik)=exp(zI*kr)
-    end do
-    end do
-    end do
-!$omp end do
 
 !$omp do private(ik,j,i,ib,ilma,uVpsi,duVpsi) collapse(2)
     do ik=NK_s,NK_e

--- a/src/ARTED/common/ion_force.f90
+++ b/src/ARTED/common/ion_force.f90
@@ -48,7 +48,7 @@ contains
     complex(8),intent(inout) :: zutmp(NL,zu_NB,NK_s:NK_e)
 
     integer      :: ia,ib,ilma,ik,ix,iy,iz,n,j,i
-    real(8)      :: rab(3),rab2,Gvec(3),G2,Gd,ftmp_l(3,NI),kr
+    real(8)      :: rab(3),rab2,Gvec(3),G2,Gd,ftmp_l(3,NI)
     complex(8)   :: uVpsi,duVpsi(3)
     real(8)      :: ftmp_l_kl(3,NI,NK_s:NK_e)
 

--- a/src/ARTED/common/projector.f90
+++ b/src/ARTED/common/projector.f90
@@ -24,6 +24,9 @@ contains
     integer :: ik, ia, j, i, ix, iy, iz, ilma
     real(8) :: kr
 
+
+!$omp parallel 
+!$omp do private(ik,ia,j,i,ix,iy,iz,kr) collapse(2)
     do ik=NK_s,NK_e
       do ia=1,NI
         do j=1,Mps(ia)
@@ -34,6 +37,7 @@ contains
        end do
     end do
 
+!$omp do private(ik,ilma,ia,j,i,ix,iy,iz,kr) collapse(2)
     do ik=NK_s,NK_e
       do ilma=1,Nlma
         ia=a_tbl(ilma)
@@ -42,6 +46,8 @@ contains
         end do
       end do
     end do
+
+!$omp end parallel 
 
   end subroutine update_projector
 end module projector

--- a/src/ARTED/common/projector.f90
+++ b/src/ARTED/common/projector.f90
@@ -34,13 +34,14 @@ contains
        end do
     end do
 
-    do ilma=1,Nlma
-      ia=a_tbl(ilma)
-      do j=1,Mps(ia)
-        zproj(j,ilma,ik) = conjg(ekr_omp(j,ia,ik))*uv(j,ilma)
+    do ik=NK_s,NK_e
+      do ilma=1,Nlma
+        ia=a_tbl(ilma)
+        do j=1,Mps(ia)
+          zproj(j,ilma,ik) = conjg(ekr_omp(j,ia,ik))*uv(j,ilma)
+        end do
       end do
     end do
-
 
   end subroutine update_projector
 end module projector

--- a/src/ARTED/common/projector.f90
+++ b/src/ARTED/common/projector.f90
@@ -1,0 +1,46 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
+module projector
+  implicit none
+
+contains
+  subroutine update_projector(kac_in)
+    use Global_Variables
+    real(8),intent(in) :: kac_in(NK,3)
+    integer :: ik, ia, j, i, ix, iy, iz
+    real(8) :: kr
+
+    do ik=NK_s,NK_e
+      do ia=1,NI
+        do j=1,Mps(ia)
+          i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
+          kr=kac_in(ik,1)*(Lx(i)*Hx-ix*aLx)+kac_in(ik,2)*(Ly(i)*Hy-iy*aLy)+kac_in(ik,3)*(Lz(i)*Hz-iz*aLz)
+          ekr_omp(j,ia,ik)=exp(zI*kr)
+         end do
+       end do
+    end do
+
+    do ilma=1,Nlma
+      ia=a_tbl(ilma)
+      do j=1,Mps(ia)
+        zproj(j,ilma,ik) = conjg(ekr_omp(j,ia,ik))*uv(j,ilma)
+      end do
+    end do
+
+
+  end subroutine update_projector
+end module projector

--- a/src/ARTED/common/projector.f90
+++ b/src/ARTED/common/projector.f90
@@ -21,7 +21,7 @@ contains
   subroutine update_projector(kac_in)
     use Global_Variables
     real(8),intent(in) :: kac_in(NK,3)
-    integer :: ik, ia, j, i, ix, iy, iz
+    integer :: ik, ia, j, i, ix, iy, iz, ilma
     real(8) :: kr
 
     do ik=NK_s,NK_e

--- a/src/ARTED/common/restart.f90
+++ b/src/ARTED/common/restart.f90
@@ -503,6 +503,7 @@ subroutine prep_backup_values(is_backup)
   BACKUP(ekr)
 
   BACKUP(ekr_omp)
+  BACKUP(zproj)
   BACKUP(tpsi_omp)
   BACKUP(ttpsi_omp)
   BACKUP(htpsi_omp)

--- a/src/ARTED/common/total_energy.f90
+++ b/src/ARTED/common/total_energy.f90
@@ -49,7 +49,7 @@ contains
     complex(8),intent(inout) :: zutmp(0:NL-1,zu_NB,NK_s:NK_e)
 
     integer      :: ik,ib,ia,ix,iy,iz,n,ilma,j,i
-    real(8)      :: rab(3),rab2,G2,Gd,kr
+    real(8)      :: rab(3),rab2,G2,Gd
     complex(8)   :: uVpsi
     real(8)      :: Ekin_l,Enl_l,Eh_l,Eion_l,sum_tmp(5),sum_result(5)
     real(8)      :: Eion_tmp1,Eion_tmp2,Eloc_l1,Eloc_l2

--- a/src/ARTED/common/total_energy.f90
+++ b/src/ARTED/common/total_energy.f90
@@ -117,7 +117,7 @@ contains
     Eloc_l2=0.d0
     Enl_l=0.d0
 
-    call projector_update(kac)
+    call update_projector(kac)
 
 !$omp parallel private(thr_id)
 !$  thr_id=omp_get_thread_num()

--- a/src/ARTED/common/total_energy.f90
+++ b/src/ARTED/common/total_energy.f90
@@ -42,6 +42,7 @@ contains
     use Opt_Variables
     use timer
     use salmon_math
+    use projector
     implicit none
     logical,intent(in)       :: Rion_update
     integer,intent(in)       :: zu_NB
@@ -116,6 +117,8 @@ contains
     Eloc_l2=0.d0
     Enl_l=0.d0
 
+    call projector_update(kac)
+
 !$omp parallel private(thr_id)
 !$  thr_id=omp_get_thread_num()
 
@@ -137,17 +140,6 @@ contains
     end do
 !$omp end do
 
-!$omp do private(ia,j,i,ix,iy,iz,kr) collapse(2)
-    do ik=NK_s,NK_e
-    do ia=1,NI
-    do j=1,Mps(ia)
-      i=Jxyz(j,ia); ix=Jxx(j,ia); iy=Jyy(j,ia); iz=Jzz(j,ia)
-      kr=kAc(ik,1)*(Lx(i)*Hx-ix*aLx)+kAc(ik,2)*(Ly(i)*Hy-iy*aLy)+kAc(ik,3)*(Lz(i)*Hz-iz*aLz)
-      ekr_omp(j,ia,ik)=exp(zI*kr)
-    end do
-    end do
-    end do
-!$omp end do
 
 !$omp do private(ik,ib,nabt,tpsum,i,j,ilma,uVpsi,ia) &
 !$omp   &reduction(+:Ekin_l,Enl_l) &

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -158,7 +158,7 @@ Module Global_Variables
 
 ! omp
   integer :: NUMBER_THREADS
-  complex(8),allocatable :: ekr_omp(:,:,:)
+  complex(8),allocatable :: ekr_omp(:,:,:), proj(:,:,:,:)
   complex(8),allocatable :: tpsi_omp(:,:),ttpsi_omp(:,:),htpsi_omp(:,:)
   complex(8),allocatable :: xk_omp(:,:),hxk_omp(:,:),gk_omp(:,:),pk_omp(:,:),pko_omp(:,:),txk_omp(:,:)
   integer :: NKB

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -158,7 +158,7 @@ Module Global_Variables
 
 ! omp
   integer :: NUMBER_THREADS
-  complex(8),allocatable :: ekr_omp(:,:,:), proj(:,:,:,:)
+  complex(8),allocatable :: ekr_omp(:,:,:), zproj(:,:,:)
   complex(8),allocatable :: tpsi_omp(:,:),ttpsi_omp(:,:),htpsi_omp(:,:)
   complex(8),allocatable :: xk_omp(:,:),hxk_omp(:,:),gk_omp(:,:),pk_omp(:,:),pko_omp(:,:),txk_omp(:,:)
   integer :: NKB

--- a/src/ARTED/preparation/prep_ps.f90
+++ b/src/ARTED/preparation/prep_ps.f90
@@ -249,7 +249,7 @@ Subroutine prep_ps_periodic(property)
   else if(property == 'not_initial') then
      narray=ubound(a_tbl,1)
      if(Nlma.gt.narray .or. flag_alloc1)then
-        deallocate(a_tbl,uV,duV,iuV,proj)
+        deallocate(a_tbl,uV,duV,iuV,zproj)
         flag_alloc2=.true.
      else
         flag_alloc2=.false.
@@ -257,7 +257,7 @@ Subroutine prep_ps_periodic(property)
   endif
   if(flag_alloc2)then
      allocate(a_tbl(Nlma),uV(Nps,Nlma),iuV(Nlma),duV(Nps,Nlma,3))
-     allocate(proj(Nps,Nlma,NI,NK_s:NK_e))
+     allocate(zproj(Nps,Nlma,NK_s:NK_e))
   endif
 
   lma=0

--- a/src/ARTED/preparation/prep_ps.f90
+++ b/src/ARTED/preparation/prep_ps.f90
@@ -249,7 +249,7 @@ Subroutine prep_ps_periodic(property)
   else if(property == 'not_initial') then
      narray=ubound(a_tbl,1)
      if(Nlma.gt.narray .or. flag_alloc1)then
-        deallocate(a_tbl,uV,duV,iuV)
+        deallocate(a_tbl,uV,duV,iuV,proj)
         flag_alloc2=.true.
      else
         flag_alloc2=.false.
@@ -257,6 +257,7 @@ Subroutine prep_ps_periodic(property)
   endif
   if(flag_alloc2)then
      allocate(a_tbl(Nlma),uV(Nps,Nlma),iuV(Nlma),duV(Nps,Nlma,3))
+     allocate(proj(Nps,Nlma,NI,NK_s:NK_e))
   endif
 
   lma=0


### PR DESCRIPTION
I optimized the nonlocal pseudopotential operations by introducing the projector array `zproj` and reducing the number of operations. I also gathered the scattered phase updates into `src/ARTED/common/projector.f90` to simplify the program.

For `examples/bulk_Si/input_sc_Si.inp` and `examples/bulk_Si/input_sc_Si.inp`, 
- the pseudopotential operation gets 20-30% speedup
- the hamiltonian operation gets 8-13% speedup
- the total dynamics time gets 4-9% speedup.

@yhirokawa san, could you have a look at this patch, please? I'm a bit afraid that I broke the timer in the code.