### PR TITLE
added read option of initial velocity for restarting MD (ARTED side)

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -1024,8 +1024,21 @@ Default is <code>298.15</code>.
 </dd>
 <dt>set_ini_velocity; <code>Character</code>; 3d</dt>
 <dd>
-Flag of generating initial velocity (Maxwell-Bortzman distribution).
+Initial velocities are set.
 Default is <code>n</code>.
+<ul>
+<li>
+<code>y</code>: Generate initial velocity with Maxwell-Bortzman distribution.
+</li>
+<li>
+<code>r</code>: Read initial velocity from file specified by keyword of <code>file_ini_velocity</code>. This is, for example, used for restarting MD from the previous run. The last atomic coordinates and velocities are printed in <code>SYSname</code>_trj.xyz in that run. (atomic coordinate also should be copied from that and put in the next input file for restart)
+</li>
+</ul>
+</dd>
+<dt>file_ini_velocity; <code>Character</code>; 3d</dt>
+<dd>
+File name for initial velocities. This is read when <code>set_ini_velocity</code> is <code>'r'</code>. The format is simply vx(iatom) vy(iatom) vz(iatom) in each line. The order of atoms must be the same as the given coordinates in the main input file(atomic unit). 
+Default is <code>none</code>.
 </dd>
 
 

--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -519,6 +519,7 @@ contains
     if(restart_option == 'new') then
        if(set_ini_velocity=='y' .or. step_velocity_scaling>=1) &
        call set_initial_velocity
+       if(set_ini_velocity=='r') call read_initial_velocity
     endif
 
   End Subroutine init_md
@@ -608,4 +609,34 @@ contains
     call comm_bcast(velocity ,nproc_group_global)
 
   End Subroutine set_initial_velocity
+
+  Subroutine read_initial_velocity
+    use salmon_global
+    use Global_Variables
+    use salmon_parallel
+    use salmon_communication
+    use salmon_math
+    implicit none
+    integer :: ia,ixyz
+
+    if(comm_is_root(nproc_id_global)) then
+       write(*,*) "Read initial velocity for MD"
+       write(*,*) "file_ini_velocity=", trim(file_ini_velocity)
+       if(file_ini_velocity(1:4)=="none") then
+          write(*,*) "set file name in file_ini_velocity keyword"
+          call end_parallel
+          stop
+       endif
+
+       open(411, file=file_ini_velocity, status="old")
+       do ia=1,NI
+          read(411,*) (velocity(ixyz,ia),ixyz=1,3)
+       enddo
+       close(411)
+    endif
+    call comm_bcast(velocity,nproc_group_global)
+
+
+  End Subroutine read_initial_velocity
+
 end module initialization

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -387,7 +387,8 @@ contains
       & step_velocity_scaling, &
       & step_update_ps, &
       & temperature0_ion, &
-      & set_ini_velocity
+      & set_ini_velocity, &
+      & file_ini_velocity
 
     namelist/group_fundamental/ &
       & iditerybcg, &
@@ -645,6 +646,7 @@ contains
     step_update_ps        = 1
     temperature0_ion      = 298.15d0
     set_ini_velocity      = 'n'
+    file_ini_velocity     = 'none'
 !! == default for &group_fundamental
     iditerybcg             = 20
     iditer_nosubspace_diag = 10
@@ -958,6 +960,7 @@ contains
     call comm_bcast(step_update_ps         ,nproc_group_global)
     call comm_bcast(temperature0_ion       ,nproc_group_global)
     call comm_bcast(set_ini_velocity       ,nproc_group_global)
+    call comm_bcast(file_ini_velocity      ,nproc_group_global)
 !! == bcast for &group_fundamental
     call comm_bcast(iditerybcg            ,nproc_group_global)
     call comm_bcast(iditer_nosubspace_diag,nproc_group_global)
@@ -1473,6 +1476,7 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",I8)') 'step_update_ps', step_update_ps
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'temperature0_ion', temperature0_ion
       write(fh_variables_log, '("#",4X,A,"=",A)') 'set_ini_velocity', set_ini_velocity
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'file_ini_velocity', trim(file_ini_velocity)
 
       if(inml_group_fundamental >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'group_fundamental', inml_group_fundamental

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -223,6 +223,7 @@ module salmon_global
   integer        :: step_update_ps
   real(8)        :: temperature0_ion
   character(1)   :: set_ini_velocity
+  character(256) :: file_ini_velocity
 
 !! &group_fundamental
   integer        :: iditerybcg


### PR DESCRIPTION
New option of reading initial atomic velocities from external file was added in ARTED side. 
