### PR TITLE
Reduced memory pressure when updating non-local pseudopotential.

### DIFF
--- a/src/ARTED/common/hpsi.f90
+++ b/src/ARTED/common/hpsi.f90
@@ -97,8 +97,13 @@ contains
 
   subroutine hpsi_omp_KB_base(ik,tpsi,htpsi,ttpsi)
     use timer
-    use Global_Variables, only: NLx,NLy,NLz,kAc,lapx,lapy,lapz,nabx,naby,nabz,Vloc,Mps,iuV,Hxyz,Nlma,a_tbl,zproj
+    use Global_Variables, only: NLx,NLy,NLz,kAc,lapx,lapy,lapz,nabx,naby,nabz,Vloc,Mps,iuV,Hxyz,Nlma,zproj
     use opt_variables, only: lapt,PNLx,PNLy,PNLz,PNL
+#ifdef ARTED_STENCIL_PADDING
+      use opt_variables, only: zJxyz => zKxyz
+#else
+      use opt_variables, only: zJxyz
+#endif
 #ifdef ARTED_USE_NVTX
     use nvtx
 #endif
@@ -126,7 +131,7 @@ contains
     LOG_END(LOG_HPSI_STENCIL)
 
     LOG_BEG(LOG_HPSI_PSEUDO)
-      call pseudo_pt(ik,tpsi,htpsi)
+      call pseudo_pt(ik,zJxyz,zproj(:,:,ik),tpsi,htpsi)
     LOG_END(LOG_HPSI_PSEUDO)
 
     NVTX_END()
@@ -150,33 +155,53 @@ contains
       end do
     end subroutine
 
-    subroutine pseudo_pt(ik,tpsi,htpsi)
-#ifdef ARTED_STENCIL_PADDING
-      use opt_variables, only: zJxyz => zKxyz
-#else
-      use opt_variables, only: zJxyz
-#endif
+    !Calculating nonlocal part
+    subroutine pseudo_pt(ik,idx_proj,zproj,tpsi,htpsi)
+      use opt_variables, only: NP,NPI,pseudo_start_idx
+      use global_variables, only: NI,Nps
       implicit none
       integer,    intent(in)  :: ik
+      integer,    intent(in)  :: idx_proj(NPI)
+      complex(8), intent(in)  :: zproj(Nps,Nlma)
       complex(8), intent(in)  :: tpsi(0:PNL-1)
       complex(8), intent(out) :: htpsi(0:PNL-1)
-      integer    :: ilma,ia,j,i
+
+      integer    :: ia,i,j,ip,ioffset
       complex(8) :: uVpsi
 
-      !Calculating nonlocal part
-      do ilma=1,Nlma
-        ia=a_tbl(ilma)
-        uVpsi=0.d0
+      complex(8) :: pseudo(NPI)
+      complex(8) :: dpseudo(NPI)
+
+      dpseudo = cmplx(0.d0)
+
+      ! gather (load) pseudo potential point
+      do i=1,NPI
+        pseudo(i) = tpsi(idx_proj(i))
+      end do
+
+      do ia=1,NI
+      do ip=1,NP
+        i = NP*(ia-1) + ip
+
+        ! summarize vector
+        uVpsi   = 0.d0
+        ioffset = pseudo_start_idx(ia)
         do j=1,Mps(ia)
-          i=zJxyz(j,ia)
-          uVpsi=uVpsi+conjg(zproj(j,ilma,ik))*tpsi(i)
+          uVpsi = uVpsi + conjg(zproj(j,i)) * pseudo(ioffset+j)
         end do
-        uVpsi=uVpsi*Hxyz*iuV(ilma)
-!dir$ ivdep
+        uVpsi = uVpsi * Hxyz * iuV(i)
+
+        ! apply vector
+        ioffset = pseudo_start_idx(ia)
         do j=1,Mps(ia)
-          i=zJxyz(j,ia)
-          htpsi(i)=htpsi(i)+zproj(j,ilma,ik)*uVpsi
+          dpseudo(ioffset+j) = dpseudo(ioffset+j) + zproj(j,i) * uVpsi
         end do
+      end do
+      end do
+
+      ! scatter (store) pseudo potential point
+      do i=1,NPI
+        htpsi(idx_proj(i)) = htpsi(idx_proj(i)) + dpseudo(i)
       end do
     end subroutine
   end subroutine

--- a/src/ARTED/modules/opt_variables.f90
+++ b/src/ARTED/modules/opt_variables.f90
@@ -32,6 +32,10 @@ module opt_variables
 
   real(8),allocatable :: zcx(:,:),zcy(:,:),zcz(:,:)
 
+  integer                :: NP                  ! # of projector
+  integer                :: NPI                 ! size of pseudo-vector (packed vector)
+  integer,allocatable    :: pseudo_start_idx(:) ! start index of pseudo-vector
+
 #ifdef ARTED_STENCIL_ORIGIN
   integer,allocatable :: zifdx(:,:),zifdy(:,:),zifdz(:,:)
 #endif
@@ -163,6 +167,8 @@ contains
 #ifdef ARTED_STENCIL_ENABLE_LOOP_BLOCKING
     call auto_blocking
 #endif
+
+    call init_projector
   end subroutine
 
   subroutine init_for_padding
@@ -203,6 +209,21 @@ contains
       end do
     end do
   end subroutine
+
+  subroutine init_projector
+    use global_variables
+    implicit none
+    integer :: i
+
+    NP = Nlma / NI
+    NPI = Nps * NI
+
+    allocate(pseudo_start_idx(NI))
+    do i=1,NI
+      pseudo_start_idx(i) = Nps*(i-1)
+    end do
+  end subroutine
+
 
 #ifdef ARTED_LBLK
   subroutine opt_vars_init_t4ppt

--- a/src/ARTED/modules/opt_variables.f90
+++ b/src/ARTED/modules/opt_variables.f90
@@ -32,8 +32,10 @@ module opt_variables
 
   real(8),allocatable :: zcx(:,:),zcy(:,:),zcz(:,:)
 
-  integer                :: NP                  ! # of projector
+  integer,allocatable    :: nprojector(:)       ! # of projector
   integer                :: NPI                 ! size of pseudo-vector (packed vector)
+  integer,allocatable    :: idx_proj(:)         ! projector element index
+  integer,allocatable    :: idx_lma(:)          ! start index of lma
   integer,allocatable    :: pseudo_start_idx(:) ! start index of pseudo-vector
 
 #ifdef ARTED_STENCIL_ORIGIN
@@ -162,13 +164,14 @@ contains
 
 #ifdef ARTED_STENCIL_PADDING
     call init_for_padding
+    call init_projector(zKxyz)
+#else
+    call init_projector(zJxyz)
 #endif
 
 #ifdef ARTED_STENCIL_ENABLE_LOOP_BLOCKING
     call auto_blocking
 #endif
-
-    call init_projector
   end subroutine
 
   subroutine init_for_padding
@@ -210,17 +213,46 @@ contains
     end do
   end subroutine
 
-  subroutine init_projector
+  function count_if_integer(vec, val) result(n)
+    implicit none
+    integer,intent(in) :: vec(:)
+    integer,intent(in) :: val
+    integer :: n, i
+    n = 0
+    do i=1,size(vec)
+      if (vec(i) == val) then
+        n = n + 1
+      end if
+    end do
+  end function
+
+  subroutine init_projector(zJxyz)
     use global_variables
     implicit none
-    integer :: i
+    integer,intent(in) :: zJxyz(Nps,NI)
+    integer :: i,ioffset
 
-    NP = Nlma / NI
-    NPI = Nps * NI
+    NPI = sum(Mps)
 
-    allocate(pseudo_start_idx(NI))
+    allocate(nprojector(NI),idx_lma(NI))
+
     do i=1,NI
-      pseudo_start_idx(i) = Nps*(i-1)
+      nprojector(i) = count_if_integer(a_tbl, i)
+    end do
+
+    idx_lma(1) = 0
+    do i=2,NI
+      idx_lma(i) = idx_lma(i-1) + nprojector(i-1)
+    end do
+
+    allocate(idx_proj(NPI))
+    allocate(pseudo_start_idx(NI))
+
+    ioffset = 0
+    do i=1,NI
+      pseudo_start_idx(i) = ioffset
+      idx_proj(ioffset+1:ioffset+1+Mps(i)) = zJxyz(1:Mps(i),i)
+      ioffset = ioffset + Mps(i)
     end do
   end subroutine
 


### PR DESCRIPTION
I optimized non-local pseudopotential update from the point of view of a memory pressure.
They pack (gather) pseudopotential vector before updating a domain. After computing, they unpack (scatter) to 3D space grid.

I check the performance with 16 KNL nodes and ``examples/bulk_Si/input_sc_Si.inp``

1. the performance of pseudopotential improves up to 40%
2. the performance of hamiltonian improves up to 12%