### PR TITLE
Add Linear Response Example

### DIFF
--- a/examples/bulk_Si/input_lr_Si.inp
+++ b/examples/bulk_Si/input_lr_Si.inp
@@ -1,0 +1,74 @@
+&calculation
+  calc_mode = 'GS_RT'
+/
+
+&control
+  sysname = 'Si'
+/
+
+&system
+  iperiodic = 3
+  al = 10.26d0,10.26d0,10.26d0
+  isym = 8 
+  crystal_structure = 'diamond'
+  nstate = 32
+  nelec = 32
+  nelem = 1
+  natom = 8
+/
+
+
+&pseudo
+  iZatom(1)=14
+  pseudo_file(1) = './Si_rps.dat'
+  Lloc_ps(1)=2
+/
+
+&functional
+  xc ='BJ_PW'
+  cval = 1d0
+/
+
+&rgrid
+  num_rgrid = 12,12,12
+/
+
+&kgrid
+  num_kgrid = 8,8,8
+/
+
+&tgrid
+ nt=3000
+ dt=0.16  
+/
+
+&propagation
+  propagator='etrs'
+/
+
+&scf
+  ncg = 5
+  nscf = 120
+/
+
+&emfield
+  trans_longi = 'tr'
+  ae_shape1 = 'impulse'
+  epdir_re1 = 0.,0.,1.
+/
+
+&analysis
+ nenergy=1000
+ de=0.001
+/
+
+&atomic_red_coor
+	'Si'	.0	.0	.0	1
+	'Si'	.25	.25	.25	1
+	'Si'	.5	.0	.5	1
+	'Si'	.0	.5	.5	1
+	'Si'	.5	.5	.0	1
+	'Si'	.75	.25	.75	1
+	'Si'	.25	.75	.75	1
+	'Si'	.75	.75	.25	1
+	/


### PR DESCRIPTION
## Overview

This PR appends the example of linear response calculation in ARTED part.

- Add the example inputfile `/examples/bulk_si/input_lr_Si.inp`

```
&calculation
  calc_mode = 'GS_RT'
/

&control
  sysname = 'Si'
/

&system
  iperiodic = 3
  al = 10.26d0,10.26d0,10.26d0
  isym = 8 
  crystal_structure = 'diamond'
  nstate = 32
  nelec = 32
  nelem = 1
  natom = 8
/


&pseudo
  iZatom(1)=14
  pseudo_file(1) = './Si_rps.dat'
  Lloc_ps(1)=2
/

&functional
  xc ='BJ_PW'
  cval = 1d0
/

&rgrid
  num_rgrid = 12,12,12
/

&kgrid
  num_kgrid = 8,8,8
/

&tgrid
 nt=3000
 dt=0.16  
/

&propagation
  propagator='etrs'
/

&scf
  ncg = 5
  nscf = 120
/

&emfield
  trans_longi = 'tr'
  ae_shape1 = 'impulse'
  epdir_re1 = 0.,0.,1.
/

&analysis
 nenergy=1000
 de=0.001
/

&atomic_red_coor
	'Si'	.0	.0	.0	1
	'Si'	.25	.25	.25	1
	'Si'	.5	.0	.5	1
	'Si'	.0	.5	.5	1
	'Si'	.5	.5	.0	1
	'Si'	.75	.25	.75	1
	'Si'	.25	.75	.75	1
	'Si'	.75	.75	.25	1
	/
```
