### PR TITLE
reimplement openmp in pseudopotential calculation

### DIFF
--- a/src/GCEED/rt/hpsi_groupob.f90
+++ b/src/GCEED/rt/hpsi_groupob.f90
@@ -201,6 +201,7 @@ if(iflag_ps==1) then
   do iob=1,iobmax
     do iatom=1,MI
     ikoa=Kion(iatom)
+!$OMP parallel do private(jj,lm)
       do jj=1,Mps(iatom)
         do lm=1,(Mlps(ikoa)+1)**2
           htpsi(Jxyz(1,jj,iatom),Jxyz(2,jj,iatom),Jxyz(3,jj,iatom),iob,1)= &


### PR DESCRIPTION
In PR#216, total elapsed time of an optical response calculation in the isolated system slowed down from `165.2` sec to `169.7` sec with 12 nodes on the K computer . By this implementation, it recovers to `164.0` sec.

@syamada0 san, could you check this PR?