### PR TITLE
Remove the parameters from examples/bulk_si

### DIFF
--- a/examples/bulk_Si/input_lr_Si.inp
+++ b/examples/bulk_Si/input_lr_Si.inp
@@ -9,8 +9,6 @@
 &system
   iperiodic = 3
   al = 10.26d0,10.26d0,10.26d0
-  isym = 8 
-  crystal_structure = 'diamond'
   nstate = 32
   nelec = 32
   nelem = 1

--- a/examples/bulk_Si/input_lr_Si.inp
+++ b/examples/bulk_Si/input_lr_Si.inp
@@ -23,7 +23,7 @@
 /
 
 &functional
-  xc ='BJ_PW'
+  xc ='PZ'
   cval = 1d0
 /
 
@@ -32,7 +32,7 @@
 /
 
 &kgrid
-  num_kgrid = 8,8,8
+  num_kgrid = 4,4,4
 /
 
 &tgrid

--- a/examples/bulk_Si/input_ms_Si.inp
+++ b/examples/bulk_Si/input_ms_Si.inp
@@ -10,8 +10,6 @@
 &system
   iperiodic = 3
   al = 10.26d0,10.26d0,10.26d0
-  isym = 8 
-  crystal_structure = 'diamond'
   nstate = 32
   nelec = 32
   nelem = 1
@@ -65,8 +63,6 @@
   nx_m  = 4
   ny_m  = 1
   hX_m = 250d0
-  nksplit = 2
-  nxysplit = 1
   nxvacl_m = -2000
   nxvacr_m = 256
 /

--- a/examples/bulk_Si/input_sc_Si.inp
+++ b/examples/bulk_Si/input_sc_Si.inp
@@ -9,8 +9,6 @@
 &system
   iperiodic = 3
   al = 10.26d0,10.26d0,10.26d0
-  isym = 8 
-  crystal_structure = 'diamond'
   nstate = 32
   nelec = 32
   nelem = 1

--- a/examples/bulk_Si/input_sc_Si.inp
+++ b/examples/bulk_Si/input_sc_Si.inp
@@ -23,7 +23,7 @@
 /
 
 &functional
-  xc ='BJ_PW'
+  xc = 'PZ'
   cval = 1d0
 /
 


### PR DESCRIPTION
I removed the symmetry parameters from the example input file `input_si_(sc|lr|ms).inp` to avoid the missleading of users (which is discussed in the previous meeting). And removed `nksplit` and `nxysplit` which is useless in the present version.
