### PR TITLE
Modify GNU Makefile

### DIFF
--- a/makefiles/make.body
+++ b/makefiles/make.body
@@ -36,6 +36,7 @@ F_SRC_IO=$(addprefix io/, \
 )
 
 F_SRC_MATH=$(addprefix math/, \
+	math_constants.f90 \
 	salmon_math.f90 \
 )
 


### PR DESCRIPTION
## Overview
This pull request contains the update of GNU makefiles, which is not working presently. In this time,  the Makefile are fixed in order to follow up the modification of the dependensy proposed on Pull Request #228.

- I have tested this makefiles works `gfortran` environment.

### How to build by GNU Makefile
Enter to the makefile directory:
```
$ cd SALMON/makefiles
```
and execute `make` command with the platform specified makefile:
```
$ make -f Makefile.PLATFORM
```
If the build is successfully finished, the binary is generated on `SALMON/bin/` directory.


### Supported Platform
- fujitsu
- gnu
- gnu-without-mpi
- intel
- intel-avx
- intel-avx2
- intel-knc
- intel-knl
- intel-without-mpi

### Command for Jenkins
```
testmode = skip
```