### PR TITLE
modify lmax and lloc for H atom in the C2H2 example

### DIFF
--- a/examples/C2H2/C2H2_gs.inp
+++ b/examples/C2H2/C2H2_gs.inp
@@ -21,9 +21,9 @@
   pseudo_file(1)='C_rps.dat'
   pseudo_file(2)='H_rps.dat'
   lmax_ps(1)=1
-  lmax_ps(2)=0
+  lmax_ps(2)=1
   lloc_ps(1)=1
-  lloc_ps(2)=0
+  lloc_ps(2)=1
 /
 &rgrid
   dl = 0.25d0, 0.25d0, 0.25d0

--- a/examples/C2H2/C2H2_rt_pulse.inp
+++ b/examples/C2H2/C2H2_rt_pulse.inp
@@ -21,9 +21,9 @@
   pseudo_file(1)='C_rps.dat'
   pseudo_file(2)='H_rps.dat'
   lmax_ps(1)=1
-  lmax_ps(2)=0
+  lmax_ps(2)=1
   lloc_ps(1)=1
-  lloc_ps(2)=0
+  lloc_ps(2)=1
 /
 &tgrid
   dt=1.25d-3

--- a/examples/C2H2/C2H2_rt_response.inp
+++ b/examples/C2H2/C2H2_rt_response.inp
@@ -21,9 +21,9 @@
   pseudo_file(1)='C_rps.dat'
   pseudo_file(2)='H_rps.dat'
   lmax_ps(1)=1
-  lmax_ps(2)=0
+  lmax_ps(2)=1
   lloc_ps(1)=1
-  lloc_ps(2)=0
+  lloc_ps(2)=1
 /
 &tgrid
   dt=1.25d-3

--- a/testsuites/102_C2H2_rt_response/verification
+++ b/testsuites/102_C2H2_rt_response/verification
@@ -20,7 +20,7 @@ checklist = {
     # Oscillator strength
     "Oscillator Strength (z-direction, 9.28eV)": [
         -100, # Temporary value for result
-        1.2081861,  # Reference value 
+        1.2166657,  # Reference value 
         0.001,  # Permissible error 
     ], 
 } 

--- a/testsuites/103_C2H2_rt_pulse/verification
+++ b/testsuites/103_C2H2_rt_pulse/verification
@@ -20,7 +20,7 @@ checklist = {
     # Dipole moment
     "Dipole Moment": [
         -100, # Temporary value for result
-        -0.0035455339,  # Reference value 
+        -0.0035677947,  # Reference value 
         0.0001,  # Permissible error 
     ], 
 } 


### PR DESCRIPTION
When Prof. Yabana generated H_rps.dat, he wrote a column of l=1 in the file because he intended to calculate nonlocal term. So I modify input files to follow Prof. Yabana's idea.