### PR TITLE
fixed access violation of PS variables in MD option

### DIFF
--- a/src/ARTED/preparation/prep_ps.f90
+++ b/src/ARTED/preparation/prep_ps.f90
@@ -21,7 +21,10 @@ Subroutine prep_ps_periodic(property)
   use Global_Variables
   use salmon_parallel, only: nproc_id_global, nproc_group_tdks
   use salmon_communication, only: comm_summation, comm_is_root
-  use opt_variables, only: zJxyz,zKxyz,init_for_padding
+  use opt_variables, only: zJxyz,zKxyz,init_for_padding, nprojector,idx_proj,idx_lma,pseudo_start_idx, init_projector
+#ifdef ARTED_LBLK
+  use opt_variables, only: t4ppt_nlma,t4ppt_nlma,t4ppt_i2vi,t4ppt_vi2i,t4ppt_ilma,t4ppt_j,  opt_vars_init_t4ppt
+#endif
   implicit none
   character(11) :: property
   logical :: flag_alloc1, flag_alloc2
@@ -40,9 +43,22 @@ Subroutine prep_ps_periodic(property)
   real(8) :: vloc_av
   real(8) :: ratio1,ratio2,rc
 
-! local potential
+
   if(property == 'not_initial' .and. use_ehrenfest_md=='y') then
-     dVloc_G(:,:)=save_dVloc_G(:,:)
+     dVloc_G(:,:)=save_dVloc_G(:,:)  ! local potential
+
+#define SAFE_DEALLOCATE(var) if(allocated(var)) deallocate(var)
+#ifdef ARTED_LBLK
+    SAFE_DEALLOCATE(t4ppt_nlma)
+    SAFE_DEALLOCATE(t4ppt_i2vi)
+    SAFE_DEALLOCATE(t4ppt_vi2i)
+    SAFE_DEALLOCATE(t4ppt_ilma)
+    SAFE_DEALLOCATE(t4ppt_j)
+#endif
+    SAFE_DEALLOCATE(nprojector)
+    SAFE_DEALLOCATE(idx_proj)
+    SAFE_DEALLOCATE(idx_lma)
+    SAFE_DEALLOCATE(pseudo_start_idx)
   else 
 
 !$omp parallel
@@ -396,6 +412,17 @@ Subroutine prep_ps_periodic(property)
       end do; end do; end do
     end do
   end if
+
+  if(property == 'not_initial' .and. use_ehrenfest_md=='y') then
+#ifdef ARTED_STENCIL_PADDING
+    call init_projector(zKxyz)
+#else
+    call init_projector(zJxyz)
+#endif
+#ifdef ARTED_LBLK
+     call opt_vars_init_t4ppt
+#endif
+  endif
 
   return
 End Subroutine prep_ps_periodic


### PR DESCRIPTION
I fixed access violation of recently introduced PS relevant variables which occurs only in MD option (i.e. when PS potential is updated in time evolve simulation).