### PR TITLE
[WIP] Reduce calculation frequency of total energy

### DIFF
--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -186,14 +186,14 @@ subroutine tddft_sc
     if (use_ehrenfest_md == 'y') then
 !$acc update self(zu_t)
       call Ion_Force_omp(Rion_update_rt,calc_mode_rt)
-      ! if (iter/10*10 == iter) then
+      if (iter/10*10 == iter) then
         call Total_Energy_omp(Rion_update_rt,calc_mode_rt)
-      ! end if
+      end if
     else
 !$acc update self(zu_t)
-      call Total_Energy_omp(Rion_update_rt,calc_mode_rt)
+      ! call Total_Energy_omp(Rion_update_rt,calc_mode_rt)
       if (iter/10*10 == iter) then
-        ! call Total_Energy_omp(Rion_update_rt,calc_mode_rt)
+        call Total_Energy_omp(Rion_update_rt,calc_mode_rt)
         call Ion_Force_omp(Rion_update_rt,calc_mode_rt)
       end if
     end if
@@ -206,7 +206,7 @@ subroutine tddft_sc
     E_tot(iter,:)=-(Ac_tot(iter+1,:)-Ac_tot(iter-1,:))/(2*dt)
 
     Eelemag=aLxyz*sum(E_tot(iter,:)**2)/(8.d0*Pi)
-    Eall=Eall+Eelemag
+    ! Eall=Eall+Eelemag
     do ia=1,NI
       force_ion(:,ia)=Zps(Kion(ia))*E_tot(iter,:)
     enddo
@@ -241,9 +241,14 @@ subroutine tddft_sc
       dRion(:,:,iter+1)=0.d0
       Tion=0.d0
     endif
-    Eall=Eall+Tion
+    ! Eall=Eall+Tion
     
-    Eall_t(iter) = Eall
+    Eall_t(iter) = Eall + Tion + Eelemag
+    if (0 < iter .and. mod(iter, 10) == 0) then
+      do i = 1, 9
+        Eall_t(iter-i) = Eall_t(iter-10)*(i*0.1) + Eall_t(iter)*(1.0-i*0.1) 
+      end do
+    end if
     Tion_t(iter) = Tion
     Temperature_ion_t(iter) = Temperature_ion
 


### PR DESCRIPTION
This is PR contains a modification to speed up the total energy calculation claimed on issue #252.
At v.1.0.0, the total energy calculation is performed on every time steps, and now its frequency  `Total_Energy_omp` is reduced to 1/10 which is same to the previous implementation.

![result](https://user-images.githubusercontent.com/5200546/33507302-5fb81aee-d737-11e7-8f08-1d931efb4d59.png)

| Version | Total [sec] | Energy [sec]  |
| ------------- |:-------------:| -----:|
| This PR |  66.32 | 0.24 |
| v.1.0.0  | 70.96 | 2.18 |
| Before v.1.0.0  | 69.72 | 0.27 |

In the figure and tables above, the calculation result and computation time of the older implementation is reproduced. `SALMON/examples/Si_bulk_bench/input_sc.inp` is employed for this benchmark.