### PR TITLE
geometry optimization(ARTED) was replaced by force-driven CG method

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -966,11 +966,13 @@ Default is <code>0.5</code>.
 
 ## &opt
 <dl>
+<!--
 <dt>cg_alpha_ini; <code>Real(8)</code>; 3d</dt>
 <dd>
-Parameter for initial step length in line search in conjugated gradient method.
+Parameter for initial step length in line search in conjugated gradient method. (currently not available)
 Default is <code>0.8</code>.
 </dd>
+-->
 <dt>cg_alpha_up; <code>Real(8)</code>; 3d</dt>
 <dd>
 Parameter for up-rate of step length in line search in conjugated gradient method.
@@ -983,25 +985,33 @@ Default is <code>0.5</code>.
 </dd>
 <dt>convrg_scf_ene; <code>Real(8)</code>; 3d</dt>
 <dd>
-Convergence threshold of SCF calculation in energy difference. If negative number no threshold (SCF loop is up to <code>Nscf</code>)
+Convergence threshold of SCF calculation in energy difference. If negative number no threshold (SCF loop is up to <code>Nscf</code>). The other SCF thresholds such as <code>threshold</code> in <code>&scf</code> are also applied (if you do not want to use it, set very small number). 
 Default is <code>-1.0</code>.
 </dd>
-<dt>convrg_opt_ene; <code>Real(8)</code>; 3d</dt>
+<dt>convrg_scf_force; <code>Real(8)</code>; 3d</dt>
 <dd>
-Convergence threshold of optimization in energy difference. 
-Default is <code>1d-6</code>.
+Convergence threshold of SCF calculation in force (average over atoms) difference. If negative number no threshold (SCF loop is up to <code>Nscf</code>). The other SCF thresholds such as <code>threshold</code> in <code>&scf</code> are also applied (if you do not want to use it, set very small number). 
+Default is <code>-1.0</code>.
 </dd>
 <dt>convrg_opt_fmax; <code>Real(8)</code>; 3d</dt>
 <dd>
-Convergence threshold of optimization in maximum force. (used in the initial optimization step only)
-Default is <code>1d-5</code>.
+Convergence threshold of optimization in maximum force.
+Default is <code>1d-3</code>.
 </dd>
+<!--
+<dt>convrg_opt_ene; <code>Real(8)</code>; 3d</dt>
+<dd>
+Convergence threshold of optimization in energy difference. (currently not available)
+Default is <code>1d-6</code>.
+</dd>
+-->
 
 
 ## &md
+<!--
 <dt>ensemble; <code>Character</code>; 3d</dt>
 <dd>
-Ensemble in MD option: "NVE", "NVT" or "NVP" (currently only "NVE" is available)
+Ensemble in MD option: "NVE", "NVT" or "NVP" (currently not available)
 Default is <code>"NVE"</code>.
 </dd>
 <dt>thermostat; <code>Character</code>; 3d</dt>
@@ -1009,6 +1019,7 @@ Default is <code>"NVE"</code>.
 Thermostat in "NVT" and "NPT" option: (currently not available)
 Default is <code>"nose-hoover"</code>.
 </dd>
+-->
 <dt>step_velocity_scaling; <code>Integer</code>; 3d</dt>
 <dd>
 Time step interval for velocity-scaling. Velocity-scaling is applied if this is set to positive.

--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -522,6 +522,354 @@ subroutine calc_opt_ground_state
   use ground_state
   use io_gs_wfn_k
 
+  if(flag_use_grad_wf_on_force) then
+     call calc_opt_ground_state_useF
+  else
+     call calc_opt_ground_state_useE
+  endif
+  return
+
+contains
+
+!----------------------------------------------
+subroutine calc_opt_ground_state_useF
+
+  implicit none
+  integer :: i,j,k,iter_perp,iter_line, Nopt_perp,Nopt_line
+  real(8) :: gm, tmp1,tmp2,tmp3, Rion_save(3,NI),dRion_rmsd
+  real(8) :: StepLen_line0, StepLen_line(2), StepLen_line_small
+  real(8) :: StepLen_line_new, StepLen_line_zero, sl_zero
+  real(8) :: StepLen_line_Up, StepLen_line_Dw
+  real(8) :: SearchDirection(3,NI),SearchDirection_1d(3*NI)
+  real(8) :: Eall_prev,Eall_prev_line,Eall_zero,Eall_new,dEall
+  real(8) :: force_prev(3,NI), force_1d(3*NI), force_prev_1d(3*NI)
+  real(8) :: fmax,fave, fmax_conv, F_line_conv 
+  real(8) :: F_line_2pt(2), F_line,F_line_new,F_line_zero
+  logical :: flag_accept
+  character(100) :: comment_line
+
+  position_option='rewind'
+
+  !(check)
+  do i=1,NI
+     if(flag_geo_opt_atom(i)/='y')then
+        if(comm_is_root(nproc_id_global)) &
+        &  write(*,*)'ERROR: flag of geometry opt of all atoms must be y'
+        call end_parallel
+        stop
+     endif
+  enddo
+
+  if(comm_is_root(nproc_id_global)) then
+     write(*,*) "===== Grand State Optimization Start ====="
+     write(*,*) "       (CG method using Force only)       "
+  endif
+  PrLv_scf = 0
+ !if(convrg_scf_ene < 0d0) then
+ !   convrg_scf_ene = convrg_opt_fmax*1d-2
+ !   if(convrg_scf_ene.ge.1d-8) convrg_scf_ene=1d-8
+ !endif
+  iflag_gs_init_wf=1   !flag to skip giving randam number initial guess
+  Nopt_perp = 100
+  Nopt_line = 40
+  StepLen_line_small = 0.1d0   !(small step to guess initial step length)
+ !StepLen_line0      = cg_alpha_ini  !(not use now)
+  StepLen_line_Up    = cg_alpha_up
+  StepLen_line_Dw    = cg_alpha_down
+  F_line_conv        = convrg_opt_fmax
+  fmax_conv          = convrg_opt_fmax
+
+  if(comm_is_root(nproc_id_global)) then
+     write(*,*) "  [Set following in optimization]"
+     write(*,*) "  SCF convergence threshold(E)=",real(convrg_scf_ene)
+     write(*,*) "  SCF convergence threshold(F)=",real(convrg_scf_force)
+     write(*,*) "  Max optimization CG step    =",Nopt_perp
+     write(*,*) "  Max line search opt step    =",Nopt_line
+    !write(*,*) "  Ini. line-search step length param. =",real(StepLen_line0)
+     write(*,*) "  Up rate of line-search step length  =",real(StepLen_line_Up)
+     write(*,*) "  Down rate of line-search step length=",real(StepLen_line_Dw)
+     write(*,*) "  Convergence threshold of F_line =",real(F_line_conv)
+     write(*,*) "  Convergence threshold of Fmax   =",real(fmax_conv)
+  endif
+
+  call comm_sync_all
+
+  !Initial Step Procedure
+  call Ion_Force_omp(rion_update_on,calc_mode_gs)
+  SearchDirection(:,:) = force(:,:)
+  call variable_3xNto3N(NI,force,force_1d)
+  call variable_3xNto3N(NI,SearchDirection,SearchDirection_1d)
+  call cal_inner_product(3*NI,force_1d,SearchDirection_1d,F_line)
+
+  write(comment_line,110) 0, 0
+  call write_xyz(comment_line,"new","r  ")
+  call cal_mean_max_forces(NI,force,fave,fmax)
+  if(comm_is_root(nproc_id_global)) write(*,135) 0,0,fmax,fave,Eall,0d0
+
+  !(initial check of convergence: if force is enough small, exit before opt)
+  if(fmax .le. fmax_conv) then
+     if(comm_is_root(nproc_id_global)) &
+     &  write(*,*) " Max force is enough small: stop calculation"
+     call end_parallel
+     stop
+  endif
+
+  !==== Main Loop ====
+
+  !---iteration for perpendicular direction---
+  do iter_perp =1,Nopt_perp   
+
+    if(comm_is_root(nproc_id_global)) then
+       write(*,*) "==================================================="
+       write(*,*) "CG Optimization Step = ", iter_perp
+    endif
+
+    !previous value
+    force_prev(:,:) = force(:,:)
+    Eall_prev = Eall
+    Eall_prev_line = Eall
+
+    !(store)
+    Rion_save(:,:)= Rion(:,:)
+    call manipulate_wfn_data('save')
+
+    !Set initial region to be searched (=> set initial two points)
+    !(calculate forces at 2 points and adjust initial step length)
+    call cal_inner_product(3*NI,force_1d,SearchDirection_1d,F_line)
+    StepLen_line(1) = 0d0
+    F_line_2pt(1)   = F_line
+
+    if(F_line_2pt(1).le.0d0) then
+       if(comm_is_root(nproc_id_global)) &
+       &  write(*,*) "WARNING: Search Direction is opposite"
+       exit
+    endif
+
+    !(guess initial step length from numerical gradient of force)
+    i= 2
+    StepLen_line(i) = StepLen_line_small
+    do
+      call manipulate_wfn_data('load')
+      call read_write_gs_wfn_k(iflag_read)
+      Rion(:,:)   = Rion_save(:,:) + StepLen_line(i)* SearchDirection(:,:)
+      Rion_eq(:,:)= Rion(:,:)
+      call prep_ps_periodic('not_initial')
+      call calc_ground_state
+      call Ion_Force_omp(rion_update_on,calc_mode_gs)
+      call variable_3xNto3N(NI,force,force_1d)
+      call cal_inner_product(3*NI,force_1d,SearchDirection_1d,F_line)
+      F_line_2pt(i) = F_line
+      call get_predicted_zero(StepLen_line,F_line_2pt,sl_zero)
+      dRion_rmsd  = sl_zero*sqrt(sum(SearchDirection_1d(:)**2)/NI)
+      if(comm_is_root(nproc_id_global)) &
+      &  write(*,104) " guessed-initial-alpha=",sl_zero,"  dRion-RMSD=",dRion_rmsd
+
+      if(abs(dRion_rmsd).lt.1d-6 .or. dRion_rmsd.gt.1d0) then
+         ! just ad-hoc treatment (unusual case: I don't know why this case exists)
+         StepLen_line(i) = StepLen_line_small*5d0
+         if(comm_is_root(nproc_id_global)) then
+            write(*,*) " Could not find good guess of initial alpha: too small or large RMSD"
+            write(*,*) " --> put guessed initial alpha=",real(StepLen_line(i))
+         endif
+         exit
+      endif
+
+      if(sl_zero.lt.0d0) then
+         StepLen_line(i) = StepLen_line(i) * StepLen_line_Dw
+      else 
+         StepLen_line(i) = sl_zero
+         exit
+      endif
+    enddo
+
+    !(adjust initial step length)
+    call manipulate_wfn_data('load')
+10  continue
+    i= 2
+   !call manipulate_wfn_data('load')
+    call read_write_gs_wfn_k(iflag_read)
+    Rion(:,:)   = Rion_save(:,:) + StepLen_line(i)* SearchDirection(:,:)
+    Rion_eq(:,:)= Rion(:,:)
+    dRion_rmsd  = StepLen_line(i)*sqrt(sum(SearchDirection_1d(:)**2)/NI)
+    call prep_ps_periodic('not_initial')
+    call calc_ground_state
+    call Ion_Force_omp(rion_update_on,calc_mode_gs)
+    call variable_3xNto3N(NI,force,force_1d)
+    call cal_inner_product(3*NI,force_1d,SearchDirection_1d,F_line)
+    F_line_2pt(i) = F_line
+
+    !(adjust initial step length so as to include zero-force between 2 points)
+    if( F_line_2pt(1)*F_line_2pt(2).gt.0d0 ) then
+    !Here, this algorithm can be replaced by linearly predicted point(step length)
+    !if a lot of "up", modify here with prediction
+       StepLen_line(1) = StepLen_line(2)
+       F_line_2pt(1)   = F_line_2pt(2)
+       StepLen_line(2) = StepLen_line(2) * StepLen_line_Up
+       dRion_rmsd      = StepLen_line(2)*sqrt(sum(SearchDirection_1d(:)**2)/NI)
+       if(comm_is_root(nproc_id_global)) &
+       & write(*,104) " adjusting initial alpha(up)->",StepLen_line(2),"  dRion-RMSD=",dRion_rmsd
+       goto 10
+    else
+       if(comm_is_root(nproc_id_global)) &
+       & write(*,104) " initial alpha=",StepLen_line(2),"  dRion-RMSD=",dRion_rmsd
+    endif
+
+
+    !--- iteration loop for line search to find zero-force ---
+    do iter_line= 1,Nopt_line
+
+       !(narrow search range)
+       call get_predicted_zero(StepLen_line,F_line_2pt,sl_zero)
+
+       if(abs(F_line_2pt(1)/F_line_2pt(2)).gt.1d0) then
+          StepLen_line_new= 0.5d0*( StepLen_line(1) + sl_zero )
+       else
+          StepLen_line_new= StepLen_line(1) + 0.5d0*(StepLen_line(2)-sl_zero)
+       endif
+
+       !(calculate electronic state at the new point)
+       call manipulate_wfn_data('load')
+       call read_write_gs_wfn_k(iflag_read)
+       Rion(:,:)= Rion_save(:,:) + StepLen_line_new* SearchDirection(:,:)
+       Rion_eq(:,:)= Rion(:,:)
+       write(comment_line,110) iter_perp, iter_line
+       call write_xyz(comment_line,"add","r  ")
+       call prep_ps_periodic('not_initial')
+       call calc_ground_state
+       call Ion_Force_omp(rion_update_on,calc_mode_gs)
+       call variable_3xNto3N(NI,force,force_1d)
+       call cal_inner_product(3*NI,force_1d,SearchDirection_1d,F_line)
+       F_line_new = F_line
+       Eall_new   = Eall
+
+       flag_accept=.false.
+       if(abs(F_line_2pt(1)/F_line_2pt(2)).gt.1d0) then
+          if( F_line_new*F_line_2pt(1) .gt. 0d0 ) flag_accept=.true.
+       else
+          if( F_line_new*F_line_2pt(2) .gt. 0d0 ) flag_accept=.true.
+       endif
+
+       if(flag_accept) &
+       &  call update_2pt_line_search(StepLen_line,F_line_2pt,StepLen_line_new,F_line_new)
+
+
+       !(get predicted zero-crossin coordinate)
+       call get_predicted_zero(StepLen_line,F_line_2pt,StepLen_line_zero)
+
+       !(calculate electronic state at the predicted zero)
+       call manipulate_wfn_data('load')
+       call read_write_gs_wfn_k(iflag_read)
+       Rion(:,:)   = Rion_save(:,:) + StepLen_line_zero* SearchDirection(:,:)
+       Rion_eq(:,:)= Rion(:,:)
+       dRion_rmsd  = StepLen_line_zero*sqrt(sum(SearchDirection_1d(:)**2)/NI)
+       write(comment_line,110) iter_perp, iter_line
+       call write_xyz(comment_line,"add","r  ")
+       call prep_ps_periodic('not_initial')
+       call calc_ground_state
+       call Ion_Force_omp(rion_update_on,calc_mode_gs)
+       call variable_3xNto3N(NI,force,force_1d)
+       call cal_inner_product(3*NI,force_1d,SearchDirection_1d,F_line)
+       F_line_zero = F_line
+       Eall_zero   = Eall
+
+       !(log)
+       if(comm_is_root(nproc_id_global)) then
+          write(*,100) "   alpha-line:2pt=",(StepLen_line(i),i=1,2),&
+                     & " |predict-zero=",    StepLen_line_zero
+          write(*,100) "   force-line:2pt=",(F_line_2pt(i),i=1,2), &
+                     & " |predict-zero=",    F_line_zero
+       endif
+
+       !Judge Convergence for line search opt
+       dEall   = Eall_zero - Eall_prev_line
+       if(comm_is_root(nproc_id_global)) &
+       & write(*,130)iter_perp,iter_line,StepLen_line_zero,F_line_zero,dEall,dRion_RMSD
+
+       if(abs(F_line_zero) .le. F_line_conv)then
+          if(comm_is_root(nproc_id_global)) then
+             write(*,*)
+             write(*,*) "Converged(line search opt) in perpendicular-step",iter_perp
+          endif
+          call read_write_gs_wfn_k(iflag_write)
+          call read_write_gs_wfn_k(iflag_read)
+          call manipulate_wfn_data('save')
+          exit
+       else if(iter_line==Nopt_line) then
+          if(comm_is_root(nproc_id_global)) then
+             write(*,*) "Not Converged(line search opt) in perpendicular-step",iter_perp
+             write(*,*) "==================================================="
+          endif
+          exit
+       endif
+
+       !(update two points among current predicted-zero and two points)
+       call update_2pt_line_search(StepLen_line,F_line_2pt,StepLen_line_zero,F_line_zero)
+
+       !(preparation for next cycle)
+       call manipulate_wfn_data('load')
+       Eall_prev_line = Eall_zero
+
+    enddo
+
+    !Force calculation
+    call Ion_Force_omp(rion_update_on,calc_mode_gs)
+    call variable_3xNto3N(NI,force,force_1d)
+    call cal_mean_max_forces(NI,force,fave,fmax)
+
+    !Judge Convergence for perpendicular opt (main judge)
+    dEall = Eall - Eall_prev
+    if(comm_is_root(nproc_id_global)) &
+    &  write(*,135) iter_perp, iter_line, fmax,fave,Eall,dEall
+    if(abs(Fmax) .le. fmax_conv) then
+       if(comm_is_root(nproc_id_global)) then
+          write(*,*) "==================================================="
+          write(*,*)
+          write(*,*) "Optimization Converged"
+          write(*,150) iter_perp,fmax,fave,Eall
+          write(*,*) "==================================================="
+       endif
+       exit
+    else if(iter_perp==Nopt_perp) then
+       if(comm_is_root(nproc_id_global)) then
+          write(*,*) "==================================================="
+          write(*,*)
+          write(*,*) "Optimization Did Not Converged"
+          write(*,150) iter_perp,fmax,fave,Eall
+          write(*,*) "==================================================="
+       endif
+    endif
+
+
+    !Update search direction vector for perpendicular step
+    call variable_3xNto3N(NI,force,force_1d)
+    call variable_3xNto3N(NI,force_prev,force_prev_1d)
+    call cal_inner_product(3*NI,force_1d,force_1d,tmp1)
+    call cal_inner_product(3*NI,force_prev_1d,force_prev_1d,tmp2)
+    call cal_inner_product(3*NI,force_1d,force_prev_1d,tmp3)
+    !gm = tmp1/tmp2         !(by Fletcher-Reeves)
+    gm = (tmp1-tmp3)/tmp2   !(by Polak-Ribiere)--usually best, but sometimes direction is not downward.
+    SearchDirection(:,:) = force(:,:) + gm * SearchDirection(:,:)
+    call variable_3xNto3N(NI,SearchDirection,SearchDirection_1d)
+
+  enddo !end of opt iteraction========================
+
+
+100 format(a,2e13.5,a,e13.5)
+104 format(a,e13.5,a,e13.5)
+110 format("#opt   step-perp=",i4,"   step-line",i4)
+120 format(a,e14.6,a,e14.6)
+130 format(" step=",i3," -",i3,"  alpha=",e12.4,"  F-line=",e12.4,"  dE-line=",e12.4,"  dRion-RMSD=",e12.4)
+135 format(" step=(perp=",i3,", line=",i3,")  Fmax=",e11.4,"  Fave=",e11.4,"  E=",e16.8,"  dE-perp=",e12.4)
+150 format("    Iteration step=",i5,    / &
+    &      "    Force(maximum)=",e18.10," [a.u.]",/ &
+    &      "    Force(average)=",e18.10," [a.u.]",/ &
+    &      "    Total Energy  =",e18.10," [a.u.]" )
+
+end subroutine calc_opt_ground_state_useF
+
+!----------------------------------------------
+subroutine calc_opt_ground_state_useE
+
   implicit none
   integer :: i,j,k,iter_perp,iter_line,iter_line2, Nopt_perp,Nopt_line
   real(8) :: fmax,fave, gm, tmp1,tmp2,tmp3, dsl12,dsl23,ratio_too_much
@@ -532,6 +880,9 @@ subroutine calc_opt_ground_state
   real(8) :: Eall_prev,Eall_save,Eall_3points(3),Eall_min,Eall_new,Eall_prev_line
   real(8) :: dEall,dE_conv,dE_conv_LineSearch, fmax_conv  !,fave_conv
   real(8) :: force_prev(3,NI), force_1d(3*NI), force_prev_1d(3*NI)
+  integer :: nsave
+  real(8) :: alpha_save(9999), ene_save(9999)
+  logical :: flag_min_found
   character(100) :: comment_line
 
   position_option='rewind'
@@ -575,11 +926,6 @@ subroutine calc_opt_ground_state
      !write(*,*) "  Convergence threshold of F: only initial=",real(fave_conv)
   endif
 
-  !if (comm_is_root(nproc_id_global)) then
-  !  open(7,file=file_epst,    position = position_option)
-  !  open(8,file=file_dns,     position = position_option)
-  !  open(9,file=file_force_dR,position = position_option)
-  !endif
 
   call comm_sync_all
 
@@ -632,6 +978,9 @@ subroutine calc_opt_ground_state
     StepLen_LineSearch(2) = StepLen_LineSearch0 * 0.5d0
     StepLen_LineSearch(3) = StepLen_LineSearch0
     Eall_3points(1) = Eall
+    nsave=0
+    call add_alpha_save(nsave,alpha_save,ene_save,StepLen_LineSearch(1),Eall_3points(1))
+
 1   continue
     !! stop if StepLen_LineSearch is too small or too large(add later)
     !! write(*,*) "Initial structure is bad"
@@ -643,7 +992,17 @@ subroutine calc_opt_ground_state
        call prep_ps_periodic('not_initial')
        call calc_ground_state
        Eall_3points(i) = Eall
+       call add_alpha_save(nsave,alpha_save,ene_save,StepLen_LineSearch(i),Eall_3points(i))
     enddo
+
+!(open following if you want to find minimum from saved points)
+!    if(comm_is_root(nproc_id_global)) &
+!    & write(*,200) " alpha,Eall-1,2,3:",real(StepLen_LineSearch(3)),(dble(Eall_3points(i)),i=1,3)
+!200 format(a,4e16.8)
+!    call find_min_from_save(nsave,alpha_save,ene_save,StepLen_LineSearch,Eall_3points,flag_min_found)
+!    if(flag_min_found) goto 2
+
+
     !(adjust initial step length so that middle point has lowest energy)
     if(      Eall_3points(2).gt.Eall_3points(1) ) then
        StepLen_LineSearch(:) = StepLen_LineSearch(:) * StepLen_LineSearch_Dw
@@ -656,6 +1015,8 @@ subroutine calc_opt_ground_state
        & write(*,*) "alpha: adjusting initial ( up )--> ",real(StepLen_LineSearch(3))
        goto 1
     endif
+
+2   continue
     StepLen_LineSearch0 = StepLen_LineSearch(3) !for next initial step length
 
     iter_line2=0
@@ -686,6 +1047,7 @@ subroutine calc_opt_ground_state
           call prep_ps_periodic('not_initial')
           call calc_ground_state
           Eall_new = Eall
+         !call add_alpha_save(nsave,alpha_save,ene_save,StepLen_LineSearch_new,Eall_new)
 
           !(update three points: current min and two closest points)
           call update_three_points_for_line_min(StepLen_LineSearch,    Eall_3points,&
@@ -706,6 +1068,7 @@ subroutine calc_opt_ground_state
        call prep_ps_periodic('not_initial')
        call calc_ground_state
        Eall_min = Eall
+      !call add_alpha_save(nsave,alpha_save,ene_save,StepLen_LineSearch_min,Eall_min)
 
        !(log)
        if(comm_is_root(nproc_id_global)) then
@@ -782,17 +1145,13 @@ subroutine calc_opt_ground_state
     call cal_inner_product(3*NI,force_1d,force_1d,tmp1)
     call cal_inner_product(3*NI,force_prev_1d,force_prev_1d,tmp2)
     call cal_inner_product(3*NI,force_1d,force_prev_1d,tmp3)
+    !gm = 0d0               !just test
     !gm = tmp1/tmp2         !(by Fletcher-Reeves)
     gm = (tmp1-tmp3)/tmp2   !(by Polak-Ribiere)
     SearchDirection(:,:) = force(:,:) + gm * SearchDirection(:,:)
 
   enddo !end of opt iteraction========================
 
-  !if(comm_is_root(nproc_id_global)) then
-  !  close(7)
-  !  close(8)
-  !  close(9)
-  !endif
 
 100 format(a17,3e16.8,a17,e16.8)
 110 format("#opt   step-perp=",i4,"   step-line",i4)
@@ -800,7 +1159,7 @@ subroutine calc_opt_ground_state
 130 format(" step-perp=",i4,"  step-line=",i4,"  E=",e16.8,"  dE-line=",e16.8)
 135 format(" step-perp=",i4,"  step-line=",i4,"  E=",e16.8,"  dE-perp=",e16.8)
 
-contains
+end subroutine calc_opt_ground_state_useE
     
   subroutine manipulate_wfn_data(action)
     implicit none
@@ -872,6 +1231,53 @@ contains
 
   end subroutine
 
+  subroutine get_predicted_zero(sl,fl,sl_zero)
+    implicit none
+    real(8) :: sl(2),fl(2),sl_zero,dsl,dfldsl,b
+
+    dfldsl  = ( fl(2) - fl(1) ) / ( sl(2) - sl(1) )
+    b       = dfldsl * sl(1) - fl(1)
+    sl_zero = b / dfldsl
+
+    return
+  end subroutine
+
+  subroutine update_2pt_line_search(sl,fl,sl_add,fl_add)
+    implicit none
+    real(8) :: sl(2),fl(2),sl_add,fl_add
+    real(8) :: eps
+    eps=1d-15
+
+    !error check
+    if(sl_add            .lt.-eps   .or.  &
+    &  sl(1)             .lt.-eps   .or.  &
+    &  sl_add            .lt. sl(1) .or.  &
+    &  sl_add            .gt. sl(2) .or.  &
+    &  abs(sl(1)-sl_add) .lt. eps   .or.  &
+    &  abs(sl(2)-sl_add) .lt. eps   .or.  &
+    &  fl(1)             .lt.-eps   .or.  &
+    &  fl(1)*fl(2)       .gt. 0d0      ) then
+       if(comm_is_root(nproc_id_global))then
+          write(*,*) "Strange: Error1"
+          write(*,*) real(sl(1)),real(sl(2)),real(sl_add)
+          write(*,*) real(fl(1)),real(fl(2)),real(fl_add)
+          stop
+       endif
+    endif
+
+    if( sl_add.gt.sl(1) .and. sl_add.lt.sl(2) ) then
+       if(fl_add.gt.0d0) then
+          sl(1) = sl_add
+          fl(1) = fl_add
+       else
+          sl(2) = sl_add
+          fl(2) = fl_add
+       endif
+    endif
+
+    return
+  end subroutine
+
   subroutine get_minimum_by_interpolation(sl,ene,sl_min)
     implicit none
     real(8) :: sl(3),ene(3),sl_min,tmpA,tmpB,tmp21,tmp23,tmp21e,tmp23e
@@ -941,6 +1347,20 @@ contains
     return
   end subroutine
 
+  subroutine variable_3xNto3N(n,val_3xn,val_3n)
+    implicit none
+    integer :: i,j,k,n
+    real(8) :: val_3xn(3,n), val_3n(3*n)
+
+    do i=1,n
+    do j=1,3
+       k=3*(i-1)+j
+       val_3n(k) = val_3xN(j,i)
+    enddo
+    enddo
+
+  end subroutine
+
   subroutine cal_inner_product(n,vec1,vec2,inner_product)
     implicit none
     integer :: i,n
@@ -966,6 +1386,79 @@ contains
     fmax = sqrt(fmax)
     fave = sqrt(fave/NI)
   end subroutine
+
+subroutine add_alpha_save(nsave,alpha_save,ene_save,alpha,ene)
+! save alpha and it's Eall for line search
+  integer :: i,nsave,n
+  real(8) :: alpha_save(9999),ene_save(9999),alpha,ene
+  real(8) :: alpha_bk(nsave),ene_bk(nsave)
+
+
+  if(nsave.ne.0) then
+     alpha_bk(1:nsave) = alpha_save(1:nsave)
+     ene_bk(1:nsave)   = ene_save(1:nsave)
+  endif
+
+  n=nsave
+  do i=1,n
+     if(abs(alpha-alpha_bk(i)).le.1d-14) return  !not add
+
+     if(i==1 .and. alpha.lt.alpha_bk(i)) then
+        alpha_save(i)= alpha
+        ene_save(i)  = ene
+        alpha_save(i+1:nsave+1) = alpha_bk(i:nsave)
+        ene_save(i+1:nsave+1)   = ene_bk(i:nsave)
+        nsave=nsave+1
+        return
+     endif
+
+     if(i==nsave) then
+        alpha_save(nsave+1) = alpha
+        ene_save(nsave+1)   = ene
+        nsave=nsave+1
+        return
+     endif
+
+     if(alpha.gt.alpha_bk(i) .and. alpha.lt.alpha_bk(i+1)) then
+        alpha_save(i+1)= alpha
+        ene_save(i+1)  = ene
+        alpha_save(i+2:nsave+1) = alpha_bk(i+1:nsave)
+        ene_save(i+2:nsave+1)   = ene_bk(i+1:nsave)
+        nsave=nsave+1
+        return
+     endif
+  enddo
+
+end subroutine
+
+subroutine find_min_from_save(nsave,alpha_save,ene_save,alpha3p,ene3p,flag_min_found)
+! save alpha and it's Eall for line search
+  integer    i,nsave,i_min
+  real(8) :: alpha_save(9999),ene_save(9999),alpha3p(3),ene3p(3)
+  real(8) :: e_min,a_min
+  logical :: flag_min_found
+
+  e_min = 1d99
+  do i=1,nsave
+     if(e_min.gt.ene_save(i)) then
+        i_min = i
+        e_min = ene_save(i)
+        a_min = alpha_save(i)
+     endif
+  enddo
+
+  flag_min_found=.false.
+  if(i_min.ne.1 .and. i_min.ne.nsave) then
+     ene3p(i_min-1)   = ene_save(i_min-1)
+     ene3p(i_min)     = ene_save(i_min)
+     ene3p(i_min+1)   = ene_save(i_min+1)
+     alpha3p(i_min-1) = alpha_save(i_min-1)
+     alpha3p(i_min)   = alpha_save(i_min)
+     alpha3p(i_min+1) = alpha_save(i_min+1)
+     flag_min_found=.true.
+  endif
+
+end subroutine
 
 end subroutine calc_opt_ground_state
 

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -381,12 +381,13 @@ contains
       & aewald
 
     namelist/opt/ &
-      & cg_alpha_ini, &
+      & cg_alpha_ini, &     !not use now if flag_use_grad_wf_on_force=.T.
       & cg_alpha_up, &
       & cg_alpha_down, &
+      & convrg_scf_force, &
       & convrg_scf_ene, &
-      & convrg_opt_ene, &
-      & convrg_opt_fmax
+      & convrg_opt_fmax, &
+      & convrg_opt_ene      !not use now if flag_use_grad_wf_on_force=.T.
 
     namelist/md/ &
       & ensemble, &
@@ -646,15 +647,16 @@ contains
     newald = 4
     aewald = 0.5d0
 !! == default for &opt
-    cg_alpha_ini   =  0.8d0
-    cg_alpha_up    =  1.3d0
-    cg_alpha_down  =  0.5d0
-    convrg_scf_ene = -1d0
-    convrg_opt_ene =  1d-6
-    convrg_opt_fmax=  1d-5
+    cg_alpha_ini    =  0.8d0 !not use now
+    cg_alpha_up     =  1.3d0
+    cg_alpha_down   =  0.5d0
+    convrg_scf_force= -1d0
+    convrg_scf_ene  = -1d0
+    convrg_opt_fmax =  1d-3
+    convrg_opt_ene  =  1d-6  !not use now
 !! == default for &md
-    ensemble              = 'nve'
-    thermostat            = 'nose-hoover'
+    ensemble              = 'nve'         !currently not supported
+    thermostat            = 'nose-hoover' !currently not supported
     step_velocity_scaling = -1
     step_update_ps        = 1
     temperature0_ion      = 298.15d0
@@ -973,9 +975,10 @@ contains
     call comm_bcast(cg_alpha_ini     ,nproc_group_global)
     call comm_bcast(cg_alpha_up      ,nproc_group_global)
     call comm_bcast(cg_alpha_down    ,nproc_group_global)
+    call comm_bcast(convrg_scf_force ,nproc_group_global)
     call comm_bcast(convrg_scf_ene   ,nproc_group_global)
-    call comm_bcast(convrg_opt_ene   ,nproc_group_global)
     call comm_bcast(convrg_opt_fmax  ,nproc_group_global)
+    call comm_bcast(convrg_opt_ene   ,nproc_group_global)
 !! == bcast for &md
     call comm_bcast(ensemble               ,nproc_group_global)
     call comm_bcast(thermostat             ,nproc_group_global)
@@ -1495,17 +1498,17 @@ contains
 
       if(inml_opt >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'opt', inml_opt
-      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'cg_alpha_ini', cg_alpha_ini
+     !write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'cg_alpha_ini', cg_alpha_ini !not use now
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'cg_alpha_up', cg_alpha_up
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'cg_alpha_down', cg_alpha_down
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'convrg_scf_force', convrg_scf_force
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'convrg_scf_ene', convrg_scf_ene
-      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'convrg_opt_ene', convrg_opt_ene
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'convrg_opt_fmax',convrg_opt_fmax
-
+     !write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'convrg_opt_ene', convrg_opt_ene !not use now
       if(inml_md >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'md', inml_md
-      write(fh_variables_log, '("#",4X,A,"=",A)') 'ensemble', ensemble
-      write(fh_variables_log, '("#",4X,A,"=",A)') 'thermostat', thermostat
+     !write(fh_variables_log, '("#",4X,A,"=",A)') 'ensemble', ensemble
+     !write(fh_variables_log, '("#",4X,A,"=",A)') 'thermostat', thermostat
       write(fh_variables_log, '("#",4X,A,"=",I8)') 'step_velocity_scaling', step_velocity_scaling
       write(fh_variables_log, '("#",4X,A,"=",I8)') 'step_update_ps', step_update_ps
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'temperature0_ion', temperature0_ion

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -223,9 +223,10 @@ module salmon_global
   real(8)        :: cg_alpha_ini
   real(8)        :: cg_alpha_up
   real(8)        :: cg_alpha_down
+  real(8)        :: convrg_scf_force
   real(8)        :: convrg_scf_ene
-  real(8)        :: convrg_opt_ene
   real(8)        :: convrg_opt_fmax
+  real(8)        :: convrg_opt_ene
 
 !! &md
   character(10)  :: ensemble


### PR DESCRIPTION
Geometry optimization (ARTED side) was replaced into force-driven CG method instead of finding energy minimum. This is because force calculation was recently improved by using wave function gradient (instead of potential gradient). Then, according to OCTOPUS paper, optimization should be done based on force only (not energy) as energy and force are now not consistent completely each other (total energy is not smooth due to egg box effect but force is smooth -- actually I suffered that optimization based on energy did not work well after improving force calculation)

I attached a test input file (one water molecule system) in this message.

Convergence of optimization is judged with maximum force. The default threshold is 1.0e-3 [au]. 

You can check iteration step in standard log file like
%> grep  Fmax  out.log

[H2O_opt_test.tar.gz](https://github.com/SALMON-TDDFT/SALMON/files/1529937/H2O_opt_test.tar.gz)
