### PR TITLE
Print rt wfn k

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -96,16 +96,22 @@ Default is the current directoy, <code>./</code>.
 <dd>Name of a filename for the restart calculation.
 </dd>
 
-<dt>read_initial_guess; <code>Character</code>; 3d</dt>
+<dt>read_gs_wfn_k; <code>Character</code>; 3d</dt>
 <dd>
-Option to read wave function as initial guess (pre-calculated "gs_wfn_k" directory) if this is <code>y</code>.
+Read ground state wave function as initial guess (pre-calculated "gs_wfn_k" directory printed by <code>calc_mode=GS</code>) if this is <code>y</code>.
 Default is <code>n</code>.
 </dd>
 
-<dt>modify_initial_guess; <code>Character</code>; 3d</dt>
+<dt>modify_gs_wfn_k; <code>Character</code>; 3d</dt>
 <dd>
-Option to modify initial guess wave function (pre-calculated "gs_wfn_k" directory) in combination with <code>read_initial_guess = y</code>.
+Option to modify initial guess wave function (pre-calculated "gs_wfn_k" directory) in combination with <code>read_gs_wfn_k = y</code>.
 If <code>copy_1stk_to_all</code> is set, the first k-point data file, wfn_gs_k0000001.wfn (supposed to be obtained by gamma-point calculation), is copied to all other points.
+Default is <code>n</code>.
+</dd>
+
+<dt>read_rt_wfn_k; <code>Character</code>; 3d</dt>
+<dd>
+Read RT wave function (pre-calculated "rt_wfn_k" directory printed by <code>calc_mode=RT</code>) if this is <code>y</code>. This is used for restarting <code>calc_mode=RT</code> (supporting <code>use_ehrenfest_md=y</code>, too), then, "gs_wfn_k" directory is also necessary.
 Default is <code>n</code>.
 </dd>
 

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -102,6 +102,12 @@ Read ground state wave function as initial guess (pre-calculated "gs_wfn_k" dire
 Default is <code>n</code>.
 </dd>
 
+<dt>write_gs_wfn_k; <code>Character</code>; 3d</dt>
+<dd>
+Write ground state wave function into "gs_wfn_k" directory if this is <code>y</code>. (In the case of <code>calc_mode=GS</code> calculation, the data is always written) 
+Default is <code>n</code>.
+</dd>
+
 <dt>modify_gs_wfn_k; <code>Character</code>; 3d</dt>
 <dd>
 Option to modify initial guess wave function (pre-calculated "gs_wfn_k" directory) in combination with <code>read_gs_wfn_k = y</code>.
@@ -112,6 +118,12 @@ Default is <code>n</code>.
 <dt>read_rt_wfn_k; <code>Character</code>; 3d</dt>
 <dd>
 Read RT wave function (pre-calculated "rt_wfn_k" directory printed by <code>calc_mode=RT</code>) if this is <code>y</code>. This is used for restarting <code>calc_mode=RT</code> (supporting <code>use_ehrenfest_md=y</code>, too), then, "gs_wfn_k" directory is also necessary.
+Default is <code>n</code>.
+</dd>
+
+<dt>write_rt_wfn_k; <code>Character</code>; 3d</dt>
+<dd>
+Write RT wave function into "rt_wfn_k" directory if this is <code>y</code>.
 Default is <code>n</code>.
 </dd>
 

--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -87,8 +87,8 @@ contains
     endif
 
 ! modify initial guess if read and modify options = y
-    if(read_initial_guess=='y') then
-       if(modify_initial_guess=='copy_1stk_to_all') then
+    if(read_gs_wfn_k=='y') then
+       if(modify_gs_wfn_k=='copy_1stk_to_all') then
           call modify_initial_guess_copy_1stk_to_all
        endif
     endif
@@ -384,7 +384,7 @@ contains
     call comm_bcast(NBoccmax,nproc_group_global)
     call comm_sync_all
     NKB=(NK_e-NK_s+1)*NBoccmax ! sato
-    if(read_initial_guess=='y') iflag_gs_init_wf=2
+    if(read_gs_wfn_k=='y') iflag_gs_init_wf=2
 
     allocate(occ(NB,NK),wk(NK),esp(NB,NK))
     allocate(ovlp_occ_l(NB,NK),ovlp_occ(NB,NK))
@@ -445,9 +445,7 @@ contains
     allocate(udVtbl(Nrmax,0:Lmax,NE),dudVtbl(Nrmax,0:Lmax,NE))
     allocate(Floc(3,NI),Fnl(3,NI),Fion(3,NI))                         
     allocate(save_dVloc_G(NG_s:NG_e,NE))
-    if(use_ehrenfest_md=='y')then
-       allocate(velocity(3,NI)) ; velocity(:,:)=0d0
-    endif
+    allocate(velocity(3,NI)) ; velocity(:,:)=0d0
     
     select case(iflag_atom_coor)
     case(ntype_atom_coor_cartesian)

--- a/src/ARTED/main.f90
+++ b/src/ARTED/main.f90
@@ -43,6 +43,7 @@ subroutine arted
   use initialization
   use ground_state
   use io_gs_wfn_k
+  use io_rt_wfn_k
   
   implicit none
 
@@ -59,10 +60,11 @@ subroutine arted
     case(iflag_calc_mode_gs)
       call calc_ground_state
       call read_write_gs_wfn_k(iflag_write)
-      if(use_geometry_opt == 'y') call calc_opt_ground_state
+      if(use_geometry_opt=='y') call calc_opt_ground_state
       return
     case(iflag_calc_mode_rt)
       call read_write_gs_wfn_k(iflag_read)
+      if(read_rt_wfn_k=='y') call read_write_rt_wfn_k(iflag_read_rt)
     end select
   else if(restart_option == 'restart')then
   else
@@ -74,6 +76,7 @@ subroutine arted
     call tddft_maxwell_ms
   case ('n')
     call tddft_sc
+    call read_write_rt_wfn_k(iflag_write_rt)
   case default
     call Err_finalize("Invalid use_ms_maxwell parameter!")
   end select

--- a/src/ARTED/main.f90
+++ b/src/ARTED/main.f90
@@ -57,6 +57,7 @@ subroutine arted
     select case(iflag_calc_mode)
     case(iflag_calc_mode_gs_rt)
       call calc_ground_state
+      if(write_gs_wfn_k=='y') call read_write_gs_wfn_k(iflag_write)
     case(iflag_calc_mode_gs)
       call calc_ground_state
       call read_write_gs_wfn_k(iflag_write)
@@ -76,7 +77,7 @@ subroutine arted
     call tddft_maxwell_ms
   case ('n')
     call tddft_sc
-    call read_write_rt_wfn_k(iflag_write_rt)
+    if(write_rt_wfn_k=='y') call read_write_rt_wfn_k(iflag_write_rt)
   case default
     call Err_finalize("Invalid use_ms_maxwell parameter!")
   end select

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -219,9 +219,11 @@ contains
       & sysname, &
       & directory, &
       & dump_filename, &
-      & read_gs_wfn_k, &         !changed from read_initial_guess
+      & read_gs_wfn_k, &    !changed from read_initial_guess
+      & write_gs_wfn_k, &
       & modify_gs_wfn_k, &  !changed from modify_initial_guess
-      & read_rt_wfn_k
+      & read_rt_wfn_k, &
+      & write_rt_wfn_k
 
     namelist/units/ &
       & unit_system
@@ -500,8 +502,10 @@ contains
     directory        = './'
     dump_filename    = 'default'
     read_gs_wfn_k    = 'n'
+    write_gs_wfn_k   = 'n'
     modify_gs_wfn_k  = 'n'
     read_rt_wfn_k    = 'n'
+    write_rt_wfn_k   = 'n'
 !! == default for &parallel
     domain_parallel   = 'n'
     nproc_ob          = 0
@@ -803,8 +807,10 @@ contains
     call comm_bcast(directory       ,nproc_group_global)
     call comm_bcast(dump_filename   ,nproc_group_global)
     call comm_bcast(read_gs_wfn_k   ,nproc_group_global)
+    call comm_bcast(write_gs_wfn_k  ,nproc_group_global)
     call comm_bcast(modify_gs_wfn_k ,nproc_group_global)
     call comm_bcast(read_rt_wfn_k   ,nproc_group_global)
+    call comm_bcast(write_rt_wfn_k  ,nproc_group_global)
 
 !! == bcast for &parallel
     call comm_bcast(domain_parallel  ,nproc_group_global)
@@ -1298,8 +1304,10 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'directory', trim(directory)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'dump_filename', trim(dump_filename)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'read_gs_wfn_k', trim(read_gs_wfn_k)
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'write_gs_wfn_k', trim(write_gs_wfn_k)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'modify_gs_wfn_k', trim(modify_gs_wfn_k)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'read_rt_wfn_k', trim(read_rt_wfn_k)
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'write_rt_wfn_k', trim(write_rt_wfn_k)
 
       if(inml_units >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'units', inml_units

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -219,8 +219,9 @@ contains
       & sysname, &
       & directory, &
       & dump_filename, &
-      & read_initial_guess, &
-      & modify_initial_guess
+      & read_gs_wfn_k, &         !changed from read_initial_guess
+      & modify_gs_wfn_k, &  !changed from modify_initial_guess
+      & read_rt_wfn_k
 
     namelist/units/ &
       & unit_system
@@ -492,14 +493,15 @@ contains
     use_force        = 'n'
     use_geometry_opt = 'n'
 !! == default for &control
-    restart_option      = 'new'
-    backup_frequency    = 0
-    time_shutdown       = -1d0
-    sysname             = 'default'
-    directory           = './'
-    dump_filename       = 'default'
-    read_initial_guess  = 'n'
-    modify_initial_guess= 'n'
+    restart_option   = 'new'
+    backup_frequency = 0
+    time_shutdown    = -1d0
+    sysname          = 'default'
+    directory        = './'
+    dump_filename    = 'default'
+    read_gs_wfn_k    = 'n'
+    modify_gs_wfn_k  = 'n'
+    read_rt_wfn_k    = 'n'
 !! == default for &parallel
     domain_parallel   = 'n'
     nproc_ob          = 0
@@ -794,14 +796,15 @@ contains
     call comm_bcast(use_force       ,nproc_group_global)
     call comm_bcast(use_geometry_opt,nproc_group_global)
 !! == bcast for &control
-    call comm_bcast(restart_option      ,nproc_group_global)
-    call comm_bcast(backup_frequency    ,nproc_group_global)
-    call comm_bcast(time_shutdown       ,nproc_group_global)
-    call comm_bcast(sysname             ,nproc_group_global)
-    call comm_bcast(directory           ,nproc_group_global)
-    call comm_bcast(dump_filename       ,nproc_group_global)
-    call comm_bcast(read_initial_guess  ,nproc_group_global)
-    call comm_bcast(modify_initial_guess,nproc_group_global)
+    call comm_bcast(restart_option  ,nproc_group_global)
+    call comm_bcast(backup_frequency,nproc_group_global)
+    call comm_bcast(time_shutdown   ,nproc_group_global)
+    call comm_bcast(sysname         ,nproc_group_global)
+    call comm_bcast(directory       ,nproc_group_global)
+    call comm_bcast(dump_filename   ,nproc_group_global)
+    call comm_bcast(read_gs_wfn_k   ,nproc_group_global)
+    call comm_bcast(modify_gs_wfn_k ,nproc_group_global)
+    call comm_bcast(read_rt_wfn_k   ,nproc_group_global)
 
 !! == bcast for &parallel
     call comm_bcast(domain_parallel  ,nproc_group_global)
@@ -1294,8 +1297,9 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'sysname', trim(sysname)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'directory', trim(directory)
       write(fh_variables_log, '("#",4X,A,"=",A)') 'dump_filename', trim(dump_filename)
-      write(fh_variables_log, '("#",4X,A,"=",A)') 'read_initial_guess', trim(read_initial_guess)
-      write(fh_variables_log, '("#",4X,A,"=",A)') 'modify_initial_guess', trim(modify_initial_guess)
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'read_gs_wfn_k', trim(read_gs_wfn_k)
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'modify_gs_wfn_k', trim(modify_gs_wfn_k)
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'read_rt_wfn_k', trim(read_rt_wfn_k)
 
       if(inml_units >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'units', inml_units

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -51,8 +51,10 @@ module salmon_global
   character(256) :: directory
   character(256) :: dump_filename
   character(1)   :: read_gs_wfn_k
+  character(1)   :: write_gs_wfn_k
   character(20)  :: modify_gs_wfn_k
   character(1)   :: read_rt_wfn_k
+  character(1)   :: write_rt_wfn_k
 
 !! &units
   character(16)  :: unit_system

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -50,9 +50,10 @@ module salmon_global
   character(256) :: sysname
   character(256) :: directory
   character(256) :: dump_filename
-  character(1)   :: read_initial_guess
-  character(20)  :: modify_initial_guess
-                 
+  character(1)   :: read_gs_wfn_k
+  character(20)  :: modify_gs_wfn_k
+  character(1)   :: read_rt_wfn_k
+
 !! &units
   character(16)  :: unit_system
   character(16)  :: unit_time


### PR DESCRIPTION
I added a function of restarting RT (ARTED side) just using wave function (zu_t) but not using traditional option "restart_option" which print out all of huge data on memory. The new restarting way just prints minimal data and allow to change input keywords in the restart run if necessary.
The changes are followings:

(1)  wave function (zu_t) was printed out in "rt_wfn_k" directory after RT finished
(more exactly, occ, Rion, velocity are also printed in the directory)

(2) "read_rt_wfn_k=y/n" keyword was added (in &control).  
( then, similar keyword "read_initial_guess" was changed to "read_gs_wfn_k" )

How to restart RT:
(i) run with "GS" to get "gs_wfn_k" directory
(ii) run with "RT" (then use "gs_wfn_k")
(iii) Finaly, run with "RT" with "read_rt_wfn_k=y" option. (then must use "rt_wfn_k" and also "gs_wfn_k")

Please check that total energy is continuous. 
(but external field can not be taken over in restart run. This option does not work in multi-scale calculation)

