### PR TITLE
Add deallocation of IPIV and WORK

### DIFF
--- a/src/ARTED/preparation/prep_ps.f90
+++ b/src/ARTED/preparation/prep_ps.f90
@@ -514,6 +514,8 @@ subroutine spline(Np,xn,yn,an,bn,cn,dn)
      cn(i) = dyn(i)/dxn(i) - dxn(i)*(u(i+1)+2d0*u(i))/6d0
   end do
   cn(Npm2) = dyn(Npm2)/dxn(Npm2) - dxn(Npm2)*(0d0+2d0*u(Npm2))/6d0
+  
+  deallocate(IPIV,WORK)
 
   return
 end subroutine spline


### PR DESCRIPTION
This PR is bugfix of memory leak in initialization of pseudopotential data.
