### PR TITLE
Deallocate id(x|y|z) in Ion_Force_omp

### DIFF
--- a/src/ARTED/common/ion_force.f90
+++ b/src/ARTED/common/ion_force.f90
@@ -156,6 +156,8 @@ contains
     enddo
     enddo
 !$omp end parallel do
+    
+    deallocate(idx, idy, idz)
 
     !Force from Vlocal with wave-func gradient --
     ftmp_l_kl= 0.d0


### PR DESCRIPTION
This PR provides the bugfix of the memory leaks in the force calculation. It will helps to reduce memory consumption in the large system.