### PR TITLE
improve allocate for large system to avoid crash

### DIFF
--- a/src/ARTED/common/hpsi.f90
+++ b/src/ARTED/common/hpsi.f90
@@ -162,10 +162,9 @@ contains
 
       integer    :: ia,i,j,ip,ioffset
       complex(8) :: uVpsi
+      complex(8),allocatable :: pseudo(:),dpseudo(:)
 
-      complex(8) :: pseudo(NPI)
-      complex(8) :: dpseudo(NPI)
-
+      allocate(pseudo(NPI),dpseudo(NPI))
       dpseudo = cmplx(0.d0)
 
       ! gather (load) pseudo potential point
@@ -197,6 +196,7 @@ contains
       do i=1,NPI
         htpsi(idx_proj(i)) = htpsi(idx_proj(i)) + dpseudo(i)
       end do
+      deallocate(pseudo,dpseudo)
     end subroutine
   end subroutine
 end module


### PR DESCRIPTION
Allocation of two variables for pseudopotential in hpsi.f90 was improved: When large system with small spacing is calculated, the calculation crashes even though (probably) the used memory size is smaller than the memory of the node machine. It occurs around the variables of "psendo" and "dpseudo" in subroutine "pseudo_pt", and it seems due to something their memory or allocation. I empirically fix such a case by using allocate sentence instead of declaration sentence. 