### PR TITLE
changed print of force

### DIFF
--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -473,7 +473,15 @@ contains
   End Subroutine Read_data
   Subroutine init_md
     use Global_Variables
+    use salmon_communication
+    use salmon_parallel
     implicit none    
+
+    if(out_rvf_rt=='n') then
+       if (comm_is_root(nproc_id_global)) &
+       write(*,*)" out_rvf_rt --> y : changed for md option"
+       out_rvf_rt='y'
+    endif
 
     if(restart_option == 'new') then
        if(set_ini_velocity=='y' .or. step_velocity_scaling>=1) &
@@ -559,6 +567,7 @@ contains
     !write(*,*)"    Temperature: befor-scaling",real(Temperature_ion)
 
     scale_v = sqrt(temperature0_ion/Temperature_ion)
+    if(temperature0_ion==0d0) scale_v=0d0
     velocity(:,:) = velocity(:,:) * scale_v
 
     !(check)

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -373,7 +373,9 @@ contains
       & out_ms_step, &
       & format3d, &
       & numfiles_out_3d, &
-      & timer_process
+      & timer_process, &
+      & out_rvf_rt, &
+      & out_rvf_rt_step
 
     namelist/hartree/ &
       & meo, &
@@ -646,6 +648,9 @@ contains
     format3d            = 'cube'
     numfiles_out_3d     = 1
     timer_process       = 'n'
+    out_rvf_rt          = 'n'
+    out_rvf_rt_step     = 10
+
 !! == default for &hartree
     meo          = 3
     num_pole_xyz = 0
@@ -974,6 +979,9 @@ contains
     call comm_bcast(format3d           ,nproc_group_global)
     call comm_bcast(numfiles_out_3d    ,nproc_group_global)
     call comm_bcast(timer_process      ,nproc_group_global)
+    call comm_bcast(out_rvf_rt         ,nproc_group_global)
+    call comm_bcast(out_rvf_rt_step    ,nproc_group_global)
+
 !! == bcast for &hartree
     call comm_bcast(meo         ,nproc_group_global)
     call comm_bcast(num_pole_xyz,nproc_group_global)
@@ -1495,6 +1503,8 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'format3d', format3d
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'numfiles_out_3d', numfiles_out_3d
       write(fh_variables_log, '("#",4X,A,"=",A)') 'timer_process', timer_process
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'out_rvf_rt', out_rvf_rt
+      write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_rvf_rt_step', out_rvf_rt_step
 
       if(inml_hartree >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'hartree', inml_hartree

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -213,6 +213,8 @@ module salmon_global
   character(16)  :: format3d
   integer        :: numfiles_out_3d
   character(1)   :: timer_process
+  character(1)   :: out_rvf_rt
+  integer        :: out_rvf_rt_step
 
 !! &hartree
   integer        :: meo


### PR DESCRIPTION
I changed way of force printing (ARTED side) like:
(1) In RT mode, force is not printed by default (but printed in md option by default)
Then, force is not calculated reducing calculation time (not necessary).
(2) Force is printed in "xxxx_trj.xyz" file together with xyz and velocity (instead of xxx_force_dRion.out is not used). 
(3) Time step interval for force printing can be controlled by using new input variables in &analysis, like:
     out_rvf_rt="y", 
     out_rvf_rt_step=10

BTW, after latest maintenance of OFP, intel module has been updated and default version is intel/2018.1.163. If you use it for compiling SALMON, the force calculation does not work printing "infinity" or "*******". I don't know why nor how to solve. So, currently, please change to the previous module version like
module purge
module load intel/2017.4.196

Sorry for asking in winter vacation. You can review it next year of course. Thanks. Have a nice holiday!