### PR TITLE
Support Python3 environment

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -125,5 +125,5 @@ for var in args:
 
 ### configuration
 comm = '{2} cmake {0} {1}'.format(define, SOURCE_DIR, env)
-print '    $', comm
+print('    $ %s' % comm)
 os.system(comm)


### PR DESCRIPTION
Recently I received a question from one of the users to build SALMON in the environment which uses the Python 3 by default. This modification makes possible to execute "configure.py" script in version 3.