### PR TITLE
Improve the memory allocation in pseudo-pt.

### DIFF
--- a/src/ARTED/common/hpsi.f90
+++ b/src/ARTED/common/hpsi.f90
@@ -98,10 +98,11 @@ contains
   subroutine hpsi_omp_KB_base(ik,tpsi,htpsi,ttpsi)
     use timer
     use Global_Variables, only: NLx,NLy,NLz,kAc,lapx,lapy,lapz,nabx,naby,nabz,Vloc,Mps,iuV,Hxyz,Nlma,zproj
-    use opt_variables, only: lapt,PNLx,PNLy,PNLz,PNL
+    use opt_variables, only: lapt,PNLx,PNLy,PNLz,PNL,spseudo,dpseudo
 #ifdef ARTED_USE_NVTX
     use nvtx
 #endif
+    use salmon_parallel, only: get_thread_id
     implicit none
     integer,intent(in)              :: ik
     complex(8),intent(in)           ::  tpsi(0:PNLz-1,0:PNLy-1,0:PNLx-1)
@@ -109,6 +110,7 @@ contains
     complex(8),intent(out),optional :: ttpsi(0:PNLz-1,0:PNLy-1,0:PNLx-1)
     real(8) :: k2,k2lap0_2
     real(8) :: nabt(12)
+    integer :: tid
 
     NVTX_BEG('hpsi1()',3)
 
@@ -126,7 +128,8 @@ contains
     LOG_END(LOG_HPSI_STENCIL)
 
     LOG_BEG(LOG_HPSI_PSEUDO)
-      call pseudo_pt(ik,zproj(:,:,ik),tpsi,htpsi)
+      tid = get_thread_id()
+      call pseudo_pt(ik,zproj(:,:,ik),tpsi,htpsi,spseudo(:,tid),dpseudo(:,tid))
     LOG_END(LOG_HPSI_PSEUDO)
 
     NVTX_END()
@@ -151,7 +154,7 @@ contains
     end subroutine
 
     !Calculating nonlocal part
-    subroutine pseudo_pt(ik,zproj,tpsi,htpsi)
+    subroutine pseudo_pt(ik,zproj,tpsi,htpsi,spseudo,dpseudo)
       use opt_variables, only: NPI,pseudo_start_idx,idx_proj,nprojector,idx_lma
       use global_variables, only: NI,Nps
       implicit none
@@ -159,17 +162,16 @@ contains
       complex(8), intent(in)  :: zproj(Nps,Nlma)
       complex(8), intent(in)  :: tpsi(0:PNL-1)
       complex(8), intent(out) :: htpsi(0:PNL-1)
+      complex(8)              :: spseudo(NPI),dpseudo(NPI) ! working mem.
 
       integer    :: ia,i,j,ip,ioffset
       complex(8) :: uVpsi
-      complex(8),allocatable :: pseudo(:),dpseudo(:)
 
-      allocate(pseudo(NPI),dpseudo(NPI))
       dpseudo = cmplx(0.d0)
 
       ! gather (load) pseudo potential point
       do i=1,NPI
-        pseudo(i) = tpsi(idx_proj(i))
+        spseudo(i) = tpsi(idx_proj(i))
       end do
 
       do ia=1,NI
@@ -180,7 +182,7 @@ contains
         uVpsi   = 0.d0
         ioffset = pseudo_start_idx(ia)
         do j=1,Mps(ia)
-          uVpsi = uVpsi + conjg(zproj(j,i)) * pseudo(ioffset+j)
+          uVpsi = uVpsi + conjg(zproj(j,i)) * spseudo(ioffset+j)
         end do
         uVpsi = uVpsi * Hxyz * iuV(i)
 
@@ -196,7 +198,6 @@ contains
       do i=1,NPI
         htpsi(idx_proj(i)) = htpsi(idx_proj(i)) + dpseudo(i)
       end do
-      deallocate(pseudo,dpseudo)
     end subroutine
   end subroutine
 end module

--- a/src/ARTED/modules/opt_variables.f90
+++ b/src/ARTED/modules/opt_variables.f90
@@ -21,6 +21,7 @@ module opt_variables
   integer                :: PNLx,PNLy,PNLz,PNL
   complex(8),allocatable :: zhtpsi(:,:,:),zttpsi(:,:)
   complex(8),allocatable :: ghtpsi(:,:,:)
+  complex(8),allocatable :: spseudo(:,:),dpseudo(:,:)  ! (NPI, # of threads)
 
   real(8),allocatable :: zrhotmp(:,:)
 
@@ -254,6 +255,9 @@ contains
       idx_proj(ioffset+1:ioffset+Mps(i)) = zJxyz(1:Mps(i),i)
       ioffset = ioffset + Mps(i)
     end do
+
+    allocate(spseudo(NPI,0:NUMBER_THREADS-1))
+    allocate(dpseudo(NPI,0:NUMBER_THREADS-1))
   end subroutine
 
 


### PR DESCRIPTION
The working memories (`spseudo` and `dpseudo`) move to `opt_variables` module.
See also: PR #262 