### PR TITLE
Support the Intel Nehalem Processer

### DIFF
--- a/cmakefiles/Platforms/intel.cmake
+++ b/cmakefiles/Platforms/intel.cmake
@@ -1,0 +1,32 @@
+### Intel Compiler for Nehalem
+set(TARGET_SUFFIX               ".cpu")
+
+set(ARCH                        "")
+set(SIMD_SET                    "")
+set(OPENMP_FLAGS                "-qopenmp")
+set(LAPACK_FLAGS                "-mkl=parallel")
+set(ScaLAPACK_FLAGS             "-mkl=cluster")
+set(ADDITIONAL_MACRO            "")
+set(ADDITIONAL_OPTIMIZE_FLAGS   "")
+
+set(Fortran_FLAGS_General       "-fpp -nogen-interface -std03 -warn all -diag-disable 6477,7025")
+set(C_FLAGS_General             "-Wall -restrict")
+
+set(CMAKE_Fortran_COMPILER      "mpiifort")
+set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g")
+set(CMAKE_Fortran_FLAGS_RELEASE "-ansi-alias -fno-alias -O3")
+set(CMAKE_C_COMPILER            "mpiicc")
+set(CMAKE_C_FLAGS_DEBUG         "-O2 -g")
+set(CMAKE_C_FLAGS_RELEASE       "-ansi-alias -fno-alias -O3")
+
+set(USE_MPI             ON)
+#set(EXPLICIT_VEC        ON)
+#set(REDUCE_FOR_MANYCORE ON)
+
+
+########
+# CMake Platform-specific variables
+########
+set(CMAKE_SYSTEM_NAME "Linux" CACHE STRING "Cross-compiling for Intel Nehalem")
+set(CMAKE_SYSTEM_PROCESSOR "intel")
+


### PR DESCRIPTION
This PR provides the cmake platform file for the Intel Processer which is older than Sandy Bridge architecture. This modification have been prepared for the request from one user who tried to use SALMON in the workstation with Nehalem architecture. This platform file make it possible to build without using AVX optimization.

In order to build in Nehalem, user `--arch=intel` switch as below:
```
$ configure.py --arch=intel
```


  