### PR TITLE
Add print option of orbital (wave function) in cube and vtk formats (ARTED side)

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -813,9 +813,10 @@ Energy spacing for analysis.
 Unit of energy can be chosen by <code>&units/unit_energy</code>
 </dd>
 
-<dt>out_psi; <code>Character</code>; 0d</dt>
+<dt>out_psi; <code>Character</code>; 0d/3d</dt>
 <dd>
 If <code>'y'</code>, wavefunctions are output.
+For periodic system (<code>iperiodic=3</code>), it works only for ground state calculation. The converged wave functions of all orbitals with all k-points are printed in gs_wfn_cube or gs_wfn_vtk directory. The format is speficied by <code>format3d</code>. 
 Default is <code>'n'</code>.
 </dd>
 

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -131,6 +131,7 @@ Module Global_Variables
   character(256) :: file_dns_gs
   character(256) :: file_dns_rt
   character(256) :: file_dns_dlt
+  character(256) :: file_psi_gs
   character(256) :: file_energy_transfer
   character(256) :: file_ac 
   character(256) :: file_k_data


### PR DESCRIPTION
Printing option of ground state orbitals (all occupied and unoccupied orbitals with all k-points) got to work in ARTED side. The keyword "out_psi" (prepared by GCEED side) is now available for periodic system.  The format is specified by format3d=cube or vtk, and the output files are put in gs_wfn_cube/ or gs_wfn_vtk/ . 

