### PR TITLE
bug fix of PS allocation in MD

### DIFF
--- a/src/ARTED/modules/opt_variables.f90
+++ b/src/ARTED/modules/opt_variables.f90
@@ -256,6 +256,7 @@ contains
       ioffset = ioffset + Mps(i)
     end do
 
+    if(allocated(spseudo)) deallocate(spseudo,dpseudo)
     allocate(spseudo(NPI,0:NUMBER_THREADS-1))
     allocate(dpseudo(NPI,0:NUMBER_THREADS-1))
   end subroutine


### PR DESCRIPTION
A bug of PS allocation added just recently was fixed.  In the case of MD option, segmentation fault occurred because some variables of PS are already allocated but the subroutine is called in every MD time step. I added one line to fix it. 

For check, run "RT" or "GS_RT" mode but put one keyword
use_ehrenfest_md='y' 
in &calculation block

