### PR TITLE
Speed-up update of pseudopotential in md option

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -1054,10 +1054,10 @@ Default is <code>"nose-hoover"</code>.
 Time step interval for velocity-scaling. Velocity-scaling is applied if this is set to positive.
 Default is <code>-1</code>.
 </dd>
-<dt>step_update_ps; <code>Integer</code>; 3d</dt>
+<dt>step_update_ps/step_update_ps2; <code>Integer/Integer</code>; 3d</dt>
 <dd>
-Time step interval for updating pseudopotential (Larger number makes calculation time reduce greatly, but gets inaccurate)
-Default is <code>1</code>.
+Time step interval for updating pseudopotential (Larger number makes calculation time reduce greatly, but gets inaccurate). <code>step_update_ps</code> is for full update and <code>step_update_ps2</code> is for update without changing grid points array.
+Default is <code>10/1</code>.
 </dd>
 <dt>temperature0_ion; <code>Real(8)</code>; 3d</dt>
 <dd>

--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -229,7 +229,11 @@ subroutine tddft_sc
         Ework = Ework - sum(force(:,ia)*(dRion(:,ia,iter+1)-dRion(:,ia,iter)))
       enddo
       Temperature_ion = Tion * 2d0 / (3d0*NI) / (kB/hartree2J)
-      if (mod(iter,step_update_ps)==0 ) call prep_ps_periodic('not_initial')
+      if (mod(iter,step_update_ps)==0 ) then
+         call prep_ps_periodic('update_all       ')
+      else
+         call prep_ps_periodic('update_wo_realloc')
+      endif
     else
       dRion(:,:,iter+1)=0.d0
       Tion=0.d0
@@ -651,7 +655,7 @@ subroutine calc_opt_ground_state_useF
       call read_write_gs_wfn_k(iflag_read)
       Rion(:,:)   = Rion_save(:,:) + StepLen_line(i)* SearchDirection(:,:)
       Rion_eq(:,:)= Rion(:,:)
-      call prep_ps_periodic('not_initial')
+      call prep_ps_periodic('update_all       ')
       call calc_ground_state
       call Ion_Force_omp(rion_update_on,calc_mode_gs)
       call variable_3xNto3N(NI,force,force_1d)
@@ -689,7 +693,7 @@ subroutine calc_opt_ground_state_useF
     Rion(:,:)   = Rion_save(:,:) + StepLen_line(i)* SearchDirection(:,:)
     Rion_eq(:,:)= Rion(:,:)
     dRion_rmsd  = StepLen_line(i)*sqrt(sum(SearchDirection_1d(:)**2)/NI)
-    call prep_ps_periodic('not_initial')
+    call prep_ps_periodic('update_all       ')
     call calc_ground_state
     call Ion_Force_omp(rion_update_on,calc_mode_gs)
     call variable_3xNto3N(NI,force,force_1d)
@@ -732,7 +736,7 @@ subroutine calc_opt_ground_state_useF
        Rion_eq(:,:)= Rion(:,:)
        write(comment_line,110) iter_perp, iter_line
        call write_xyz(comment_line,"add","r  ")
-       call prep_ps_periodic('not_initial')
+       call prep_ps_periodic('update_all       ')
        call calc_ground_state
        call Ion_Force_omp(rion_update_on,calc_mode_gs)
        call variable_3xNto3N(NI,force,force_1d)
@@ -762,7 +766,7 @@ subroutine calc_opt_ground_state_useF
        dRion_rmsd  = StepLen_line_zero*sqrt(sum(SearchDirection_1d(:)**2)/NI)
        write(comment_line,110) iter_perp, iter_line
        call write_xyz(comment_line,"add","r  ")
-       call prep_ps_periodic('not_initial')
+       call prep_ps_periodic('update_all       ')
        call calc_ground_state
        call Ion_Force_omp(rion_update_on,calc_mode_gs)
        call variable_3xNto3N(NI,force,force_1d)
@@ -990,7 +994,7 @@ subroutine calc_opt_ground_state_useE
        call read_write_gs_wfn_k(iflag_read)
        Rion(:,:)= Rion_save(:,:) + StepLen_LineSearch(i)* SearchDirection(:,:)
        Rion_eq(:,:)= Rion(:,:)
-       call prep_ps_periodic('not_initial')
+       call prep_ps_periodic('update_all       ')
        call calc_ground_state
        Eall_3points(i) = Eall
        call add_alpha_save(nsave,alpha_save,ene_save,StepLen_LineSearch(i),Eall_3points(i))
@@ -1045,7 +1049,7 @@ subroutine calc_opt_ground_state_useE
           Rion_eq(:,:)= Rion(:,:)
           write(comment_line,110) iter_perp, iter_line2
           call write_xyz(comment_line,"add","r  ")
-          call prep_ps_periodic('not_initial')
+          call prep_ps_periodic('update_all       ')
           call calc_ground_state
           Eall_new = Eall
          !call add_alpha_save(nsave,alpha_save,ene_save,StepLen_LineSearch_new,Eall_new)
@@ -1066,7 +1070,7 @@ subroutine calc_opt_ground_state_useE
        Rion_eq(:,:)= Rion(:,:)
        write(comment_line,110) iter_perp, iter_line2
        call write_xyz(comment_line,"add","r  ")
-       call prep_ps_periodic('not_initial')
+       call prep_ps_periodic('update_all       ')
        call calc_ground_state
        Eall_min = Eall
       !call add_alpha_save(nsave,alpha_save,ene_save,StepLen_LineSearch_min,Eall_min)

--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -231,7 +231,7 @@ subroutine tddft_sc
       Temperature_ion = Tion * 2d0 / (3d0*NI) / (kB/hartree2J)
       if (mod(iter,step_update_ps)==0 ) then
          call prep_ps_periodic('update_all       ')
-      else
+      else if (mod(iter,step_update_ps2)==0 ) then
          call prep_ps_periodic('update_wo_realloc')
       endif
     else

--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -77,7 +77,7 @@ contains
 
     call input_pseudopotential_YS !shinohara
 
-    call prep_ps_periodic('initial    ')
+    call prep_ps_periodic('initial          ')
 
 ! initialize for optimization.
     call opt_vars_initialize_p2

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -52,6 +52,7 @@ Module Global_Variables
   integer,parameter :: Nrmax=3000,Lmax=4
   character(2) :: ps_type
   integer :: Nps,Nlma
+  integer,allocatable :: lma_tbl(:,:)
   integer,allocatable :: Mps(:),Jxyz(:,:),Jxx(:,:),Jyy(:,:),Jzz(:,:)
   integer,allocatable :: Mlps(:),Lref(:),Zps(:),NRloc(:)
   integer,allocatable :: NRps(:),inorm(:,:),iuV(:),a_tbl(:)
@@ -59,6 +60,10 @@ Module Global_Variables
   real(8),allocatable :: radnl(:,:)
   real(8),allocatable :: Rloc(:),uV(:,:),duV(:,:,:),anorm(:,:)
   real(8),allocatable :: dvloctbl(:,:),dudVtbl(:,:,:)
+  real(8),allocatable :: save_udVtbl_a(:,:,:)
+  real(8),allocatable :: save_udVtbl_b(:,:,:)
+  real(8),allocatable :: save_udVtbl_c(:,:,:)
+  real(8),allocatable :: save_udVtbl_d(:,:,:)
 
 ! material
   integer :: NI,NE,NB,NBoccmax

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -399,6 +399,7 @@ contains
       & thermostat, &
       & step_velocity_scaling, &
       & step_update_ps, &
+      & step_update_ps2,&
       & temperature0_ion, &
       & set_ini_velocity, &
       & file_ini_velocity
@@ -669,7 +670,8 @@ contains
     ensemble              = 'nve'         !currently not supported
     thermostat            = 'nose-hoover' !currently not supported
     step_velocity_scaling = -1
-    step_update_ps        = 1
+    step_update_ps        = 10
+    step_update_ps2       = 1
     temperature0_ion      = 298.15d0
     set_ini_velocity      = 'n'
     file_ini_velocity     = 'none'
@@ -1001,6 +1003,7 @@ contains
     call comm_bcast(thermostat             ,nproc_group_global)
     call comm_bcast(step_velocity_scaling  ,nproc_group_global)
     call comm_bcast(step_update_ps         ,nproc_group_global)
+    call comm_bcast(step_update_ps2        ,nproc_group_global)
     call comm_bcast(temperature0_ion       ,nproc_group_global)
     call comm_bcast(set_ini_velocity       ,nproc_group_global)
     call comm_bcast(file_ini_velocity      ,nproc_group_global)
@@ -1533,6 +1536,7 @@ contains
      !write(fh_variables_log, '("#",4X,A,"=",A)') 'thermostat', thermostat
       write(fh_variables_log, '("#",4X,A,"=",I8)') 'step_velocity_scaling', step_velocity_scaling
       write(fh_variables_log, '("#",4X,A,"=",I8)') 'step_update_ps', step_update_ps
+      write(fh_variables_log, '("#",4X,A,"=",I8)') 'step_update_ps2', step_update_ps2
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'temperature0_ion', temperature0_ion
       write(fh_variables_log, '("#",4X,A,"=",A)') 'set_ini_velocity', set_ini_velocity
       write(fh_variables_log, '("#",4X,A,"=",A)') 'file_ini_velocity', trim(file_ini_velocity)

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -238,6 +238,7 @@ module salmon_global
   character(20)  :: thermostat
   integer        :: step_velocity_scaling
   integer        :: step_update_ps
+  integer        :: step_update_ps2
   real(8)        :: temperature0_ion
   character(1)   :: set_ini_velocity
   character(256) :: file_ini_velocity


### PR DESCRIPTION
Update of pseudopotential was speeded up in MD option (ARTED side). (subroutine prep_ps_periodic), as  the updates of pseudopotential are very often in MD option, which is bottle neck of calculation speed. One keyword for that step_update_ps2 was also added.

Please just check if the results of GS, RT (w/o md option) are the same as previous version. 

