### PR TITLE
Add analysis options: prints of transition moment, transition difference density, no-update of Hamiltonian(functional)

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -880,16 +880,16 @@ If <code>'y'</code>, density is output.
 Default is <code>'n'</code>.
 </dd>
 
-<dt>out_elf; <code>Character</code>; 0d</dt>
-<dd>
-If <code>'y'</code>, electron localization function is output.
-Default is <code>'n'</code>.
-</dd>
-
 <dt>out_dns_rt/out_dns_rt_step; <code>Character/Integer</code>; 0d/3d</dt>
 <dd>
 If <code>'y'</code>, density during real-time time-propagation is output
 every <code>outdns_rt_step</code> time steps.
+Default is <code>'n'</code>.
+</dd>
+
+<dt>out_elf; <code>Character</code>; 0d</dt>
+<dd>
+If <code>'y'</code>, electron localization function is output.
 Default is <code>'n'</code>.
 </dd>
 
@@ -916,6 +916,12 @@ during real-time time-propagation are printed in <code>SYSname</code>_trj.xyz
 every <code>out_rvf_rt_step</code> time steps.
 If <code>use_ehrenfest_md='y'</code>, 
 the printing option is automatically turned on.
+Defaults are <code>'n'/10</code>.
+</dd>
+
+<dt>out_tm; <code>Character</code>; 3d</dt>
+<dd>
+If <code>'y'</code>, trandition moments between occupied and virtual orbitals are printed into <code>SYSname</code>_tm.data after the ground state calculation.
 Defaults are <code>'n'/10</code>.
 </dd>
 

--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -378,6 +378,12 @@ John P. Perdew and Yue Wang, Phys. Rev. B 45, 13244 (1992).
 by the formula in the original paper [Phys. Rev. Lett. 102, 226401 (2008)].
 Default is <code>'1.0'</code>.
 </dd>
+
+<dt>no_update_func; <code>character(1)</code>; 3d</dt>
+<dd>Option not to update functional (or Hamiltonian) in RT time step, i.e., keep ground state Hamiltonian during time-evolution.
+Default is <code>'n'</code>.
+</dd>
+
 </dl>
 
 ## &rgrid
@@ -886,6 +892,12 @@ Default is <code>'n'</code>.
 If <code>'y'</code>, density during real-time time-propagation is output
 every <code>outdns_rt_step</code> time steps.
 Default is <code>'n'</code>.
+</dd>
+
+<dt>out_dns_trans/out_dns_trans_energy; <code>Character/Real(8)</code>; 3d</dt>
+<dd>
+If <code>'y'</code>, transition in different density from the ground state at specified field frequency omega(given by <code>out_dns_trans_energy</code>) is calculated by drho(r,omega)=FT(rho(r,t)-rho_gs(r))/T.
+Default is <code>'n'/1.55eV</code>.
 </dd>
 
 <dt>out_elf; <code>Character</code>; 0d</dt>

--- a/src/ARTED/GS/write_GS_data.f90
+++ b/src/ARTED/GS/write_GS_data.f90
@@ -114,6 +114,7 @@ Subroutine write_GS_data
 
   call write_k_data
   call write_eigen_data
+  if(out_tm == 'y')call write_tm_data
   return
 
   contains
@@ -266,6 +267,44 @@ Subroutine write_GS_data
       end if
       call comm_sync_all
     end subroutine write_eigen_data
+
+  !! export SYSNAME_eigen.data file
+    subroutine write_tm_data()
+      implicit none
+      integer :: fh_tm
+      integer :: ik,ib
+    
+      if (comm_is_root(nproc_id_global)) then
+        fh_tm = open_filehandle(file_tm_data, status="replace")
+        write(fh_tm, '("#",1X,A)') "Transition Moment between occupied and unocupied orbitals in GS"
+        write(fh_tm, '("#",1X,A,":",1X,A)') "ik", "k-point index"
+        write(fh_tm, '("#",1X,A,":",1X,A)') "ib1,ib2", "Band index"
+        write(fh_tm, '("#",1X,A,":",1X,A)') "|tm|", "absolute value of transition moment"
+
+        write(fh_tm, '("#",99(1X,I0,":",A,"[",A,"]"))') &
+          & 1, "ik",  "none", &
+          & 2, "ib1", "none", &
+          & 3, "ib2", "none", &
+          & 4, "|tm|","au"
+      end if
+
+      do ik = NK_s,NK_e
+         do ib = 1,NB
+
+
+
+         end do !ib
+      end do !ik
+
+!            write(fh_tm, '(I6,1X,I6,99(1X,ES22.14E3))') &
+!              & ik, ib, esp(ib,ik)*t_unit_energy%conv, occ(ib,ik)/wk(ik)*NKxyz
+        
+
+      if (comm_is_root(nproc_id_global)) then
+        close(fh_tm)
+      end if
+      call comm_sync_all
+    end subroutine write_tm_data
     
 End Subroutine write_GS_data
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130

--- a/src/ARTED/RT/ana_RT_useGS.f90
+++ b/src/ARTED/RT/ana_RT_useGS.f90
@@ -17,6 +17,43 @@
 !This file contain a subroutine.
 !Subroutine k_shift_wf(iter,iter_GS_max)
 !--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120-------130
+Subroutine write_projection_header
+  use Global_Variables, only: NB
+  use inputoutput, only: t_unit_time, t_unit_energy
+  implicit none
+
+ !open(404, file=file_ovlp,position = position_option) 
+  write(404, '("#",1X,A)') "Projection"
+  write(404, '("#",1X,A,":",1X,A)') "ik", "k-point index"
+  write(404, '("#",1X,A,":",1X,A)') "ovlp_occup", "Occupation"
+  write(404, '("#",1X,A,":",1X,A)') "NB", "Number of bands"
+  write(404, '("#",99(1X,I0,":",A,"[",A,"]"))') &
+  &           1, "ik", "none", &
+  &           2, "ovlp_occup(NB)", "none"
+        
+ !open(408, file=file_nex, position = position_option) 
+   write(408, '("#",1X,A)') "Excitation"
+   write(408, '("#",1X,A,":",1X,A)') "nelec", "Number of excited electrons"
+   write(408, '("#",1X,A,":",1X,A)') "nhole", "Number of excited holes"
+   write(408, '("#",99(1X,I0,":",A,"[",A,"]"))')  &
+   &           1, "time", trim(t_unit_time%name), &
+   &           2, "nelec", "none", &
+   &           3, "nhole", "none"
+      
+  !open(409, file=file_last_band_map,position = position_option) 
+   write(409, '("#",1X,A)') "Last bandmap"
+   write(409, '("#",1X,A,":",1X,A)') "ik", "k-point index"
+   write(409, '("#",1X,A,":",1X,A)') "energy", "Electron energy"
+   write(409, '("#",1X,A,":",1X,A)') "ovlp_occup", "Occupation"
+   write(409, '("#",1X,A,":",1X,A)') "NB", "Number of bands"
+   write(409, '("#",99(1X,I0,":",A,"[",A,"]"))') &
+   &           1, "ik", "none", &
+   &           2, "energy(NB)", trim(t_unit_energy%name), &
+   &           2 + NB, "ovlp_occup(NB)", "none"      
+
+  return
+End Subroutine write_projection_header
+
 Subroutine analysis_RT_using_GS(Rion_xyz_update,iter_GS_max,zu,it,action)
 !(this subroutine was named "k_shift_wf" in past)
   use Global_Variables

--- a/src/ARTED/RT/dt_evolve.f90
+++ b/src/ARTED/RT/dt_evolve.f90
@@ -148,8 +148,10 @@ Subroutine dt_evolve_omp_KB(zu)
   call hamiltonian(zu,.false.)
 
   call psi_rho_RT(zu)
-  call Hartree
-  call Exc_Cor(calc_mode_rt,NBoccmax,zu)
+  if(no_update_func=='n')then
+     call Hartree
+     call Exc_Cor(calc_mode_rt,NBoccmax,zu)
+  endif
 
 !$omp parallel do
   do i=1,NL
@@ -183,6 +185,7 @@ Subroutine dt_evolve_omp_KB(zu)
   call psi_rho_RT(zu)
   NVTX_END()
 
+  if(no_update_func=='n')then
   NVTX_BEG('dt_evolve_omp_KB(): Hartree',5)
   call Hartree
   NVTX_END()
@@ -192,7 +195,7 @@ Subroutine dt_evolve_omp_KB(zu)
   call Exc_Cor(calc_mode_rt,NBoccmax,zu)
   NVTX_END()
 ! yabana
-
+  endif
 
 #ifdef _OPENACC
 !$acc kernels pcopy(Vloc) pcopyin(Vh,Vpsl,Vexc)
@@ -276,6 +279,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
      call psi_rho_RT(zu)
      NVTX_END()
 
+     if(no_update_func=='n')then
      NVTX_BEG('dt_evolve_omp_KB(): Hartree',5)
      call Hartree
      NVTX_END()
@@ -283,6 +287,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
      NVTX_BEG('dt_evolve_omp_KB(): Exc_Cor',6)
      call Exc_Cor(calc_mode_rt,NBoccmax,zu)
      NVTX_END()
+     endif
 
 #ifdef _OPENACC
 !$acc kernels pcopy(Vloc) pcopyin(Vh,Vpsl,Vexc)
@@ -313,6 +318,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
   call psi_rho_RT(zu)
   NVTX_END()
 
+  if(no_update_func=='n')then
   NVTX_BEG('dt_evolve_omp_KB(): Hartree',5)
   call Hartree
   NVTX_END()
@@ -320,7 +326,7 @@ Subroutine dt_evolve_etrs_omp_KB(zu)
   NVTX_BEG('dt_evolve_omp_KB(): Exc_Cor',6)
   call Exc_Cor(calc_mode_rt,NBoccmax,zu)
   NVTX_END()
-
+  endif
 
 #ifdef _OPENACC
 !$acc kernels pcopy(Vloc) pcopyin(Vh,Vpsl,Vexc)
@@ -385,8 +391,10 @@ Subroutine dt_evolve_omp_KB_MS(zu)
   call hamiltonian(zu,.false.)
 
   call psi_rho_RT(zu)
-  call Hartree
-  call Exc_Cor(calc_mode_rt,NBoccmax,zu)
+  if(no_update_func=='n')then
+     call Hartree
+     call Exc_Cor(calc_mode_rt,NBoccmax,zu)
+  endif
 
 !$omp parallel do
   do i=1,NL
@@ -419,6 +427,7 @@ Subroutine dt_evolve_omp_KB_MS(zu)
   call psi_rho_RT(zu)
   NVTX_END()
 
+  if(no_update_func=='n')then
   NVTX_BEG('dt_evolve_omp_KB_MS(): Hartree',5)
   call Hartree
   NVTX_END()
@@ -428,6 +437,7 @@ Subroutine dt_evolve_omp_KB_MS(zu)
   call Exc_Cor(calc_mode_rt,NBoccmax,zu)
   NVTX_END()
 ! yabana
+  endif
 
 #ifdef _OPENACC
 !$acc kernels pcopy(Vloc) pcopyin(Vh,Vpsl,Vexc)

--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -84,51 +84,19 @@ subroutine tddft_sc
   ! Export electronic density
   if (out_dns == 'y') call write_density(iter,'gs')
 
+  ! Export transition electronic density at specified energy
+  if (out_dns_trans == 'y') call analysis_dns_trans(iter)
 
   if (comm_is_root(nproc_id_global)) then
     ! open(7,file=file_epst,    position = position_option) !! TODO: remove output of "_t.out" file future
-    
     if (projection_option /= 'no') then 
-      
-      open(404, file=file_ovlp,position = position_option) 
-      write(404, '("#",1X,A)') "Projection"
-      
-      write(404, '("#",1X,A,":",1X,A)') "ik", "k-point index"
-      write(404, '("#",1X,A,":",1X,A)') "ovlp_occup", "Occupation"
-      write(404, '("#",1X,A,":",1X,A)') "NB", "Number of bands"
-      
-      write(404, '("#",99(1X,I0,":",A,"[",A,"]"))') &
-        & 1, "ik", "none", &
-        & 2, "ovlp_occup(NB)", "none"
-        
-      open(408, file=file_nex, position = position_option) 
-      write(408, '("#",1X,A)') "Excitation"
-      
-      write(408, '("#",1X,A,":",1X,A)') "nelec", "Number of excited electrons"
-      write(408, '("#",1X,A,":",1X,A)') "nhole", "Number of excited holes"
-      
-      write(408, '("#",99(1X,I0,":",A,"[",A,"]"))') &
-        & 1, "time", trim(t_unit_time%name), &
-        & 2, "nelec", "none", &
-        & 3, "nhole", "none"
-      
+      open(404, file=file_ovlp,         position = position_option) 
+      open(408, file=file_nex,          position = position_option) 
       open(409, file=file_last_band_map,position = position_option) 
-      write(409, '("#",1X,A)') "Last bandmap"
-      
-      write(409, '("#",1X,A,":",1X,A)') "ik", "k-point index"
-      write(409, '("#",1X,A,":",1X,A)') "energy", "Electron energy"
-      write(409, '("#",1X,A,":",1X,A)') "ovlp_occup", "Occupation"
-      write(409, '("#",1X,A,":",1X,A)') "NB", "Number of bands"
-      
-      write(409, '("#",99(1X,I0,":",A,"[",A,"]"))') &
-        & 1, "ik", "none", &
-        & 2, "energy(NB)", trim(t_unit_energy%name), &
-        & 2 + NB, "ovlp_occup(NB)", "none"      
+      call write_projection_header
     end if
 
-    if (out_old_dns == 'y') then
-      open(8,file=file_dns,     position = position_option)
-    end if
+    if (out_old_dns == 'y') open(8,file=file_dns, position = position_option)
     
   endif
   call comm_sync_all
@@ -347,6 +315,9 @@ subroutine tddft_sc
     if(out_dns_rt=='y' .and. mod(iter,out_dns_rt_step)==0) then
        call write_density(iter,'rt')
     end if
+
+    ! Export transition electronic density at specified energy
+    if (out_dns_trans == 'y') call analysis_dns_trans(iter)
 
     ! Export analysis data(Adiabatic evolution) to file_ovlp,file_nex
     if(projection_option /='no' .and. mod(iter,out_projection_step)==0)then

--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -143,6 +143,7 @@ contains
        write(file_last_band_map,"(2A,'_last_band_map.data')") trim(directory),trim(SYSname)
        write(file_k_data,"(2A,'_k.data')") trim(directory),trim(SYSname)
        write(file_eigen_data,"(2A,'_eigen.data')") trim(directory),trim(SYSname)
+       write(file_tm_data,"(2A,'_tm.data')") trim(directory),trim(SYSname)
        write(file_rt_data,"(2A,'_rt.data')") trim(directory),trim(SYSname)
        write(file_lr_data,"(2A,'_lr.data')") trim(directory),trim(SYSname)
        
@@ -175,6 +176,7 @@ contains
     call comm_bcast(file_last_band_map,nproc_group_global)
     call comm_bcast(file_k_data,nproc_group_global)
     call comm_bcast(file_eigen_data,nproc_group_global)
+    call comm_bcast(file_tm_data,nproc_group_global)
     call comm_bcast(file_rt_data,nproc_group_global)
     call comm_bcast(file_kw,nproc_group_global)
 

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -135,6 +135,8 @@ Module Global_Variables
   real(8),allocatable :: weight_Ac_alocal(:),Ac_ext_al(:,:),Ac_tot_al(:,:)
   real(8),allocatable :: Ac1x_al(:),Ac1y_al(:),Ac1z_al(:),Ac2_al(:,:),divA_al(:)
   real(8) :: Ac_al_amp(3),Ac2_al_amp,nabt_al(12)
+  !analysis of transition density at omega
+  complex(8),allocatable :: rho_trans(:)
 
 ! control parameters
   real(8) :: dAc,domega

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -139,6 +139,7 @@ Module Global_Variables
   character(256) :: file_ac 
   character(256) :: file_k_data
   character(256) :: file_eigen_data
+  character(256) :: file_tm_data
   character(256) :: file_rt_data
   character(256) :: file_lr_data
   character(256) :: process_directory

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -366,6 +366,8 @@ contains
       & out_old_dns, &
       & out_dns_rt, &
       & out_dns_rt_step, &
+      & out_dns_trans, &
+      & out_dns_trans_energy, &
       & out_elf, &
       & out_elf_rt, &
       & out_elf_rt_step, &
@@ -647,6 +649,9 @@ contains
     out_old_dns         = 'n'
     out_dns_rt          = 'n'
     out_dns_rt_step     = 50
+    out_dns_trans       = 'n'
+    out_dns_trans_energy= 1.55d0 / au_energy_ev * uenergy_from_au  ! eV
+
     out_elf             = 'n'
     out_elf_rt          = 'n'
     out_elf_rt_step     = 50
@@ -969,22 +974,25 @@ contains
     call comm_bcast(nenergy          ,nproc_group_global)
     call comm_bcast(de               ,nproc_group_global)
     de = de * uenergy_to_au
-    call comm_bcast(out_psi            ,nproc_group_global)
-    call comm_bcast(out_dos            ,nproc_group_global)
-    call comm_bcast(out_dos_start      ,nproc_group_global)
+    call comm_bcast(out_psi             ,nproc_group_global)
+    call comm_bcast(out_dos             ,nproc_group_global)
+    call comm_bcast(out_dos_start       ,nproc_group_global)
     out_dos_start = out_dos_start * uenergy_to_au
-    call comm_bcast(out_dos_end        ,nproc_group_global)
+    call comm_bcast(out_dos_end         ,nproc_group_global)
     out_dos_end = out_dos_end * uenergy_to_au
-    call comm_bcast(iout_dos_nenergy   ,nproc_group_global)
-    call comm_bcast(out_dos_smearing   ,nproc_group_global)
+    call comm_bcast(iout_dos_nenergy    ,nproc_group_global)
+    call comm_bcast(out_dos_smearing    ,nproc_group_global)
     out_dos_smearing = out_dos_smearing * uenergy_to_au
-    call comm_bcast(out_dos_method     ,nproc_group_global)
-    call comm_bcast(out_dos_fshift     ,nproc_group_global)
-    call comm_bcast(out_pdos           ,nproc_group_global)
-    call comm_bcast(out_dns            ,nproc_group_global)
-    call comm_bcast(out_old_dns        ,nproc_group_global)
-    call comm_bcast(out_dns_rt         ,nproc_group_global)
-    call comm_bcast(out_dns_rt_step    ,nproc_group_global)
+    call comm_bcast(out_dos_method      ,nproc_group_global)
+    call comm_bcast(out_dos_fshift      ,nproc_group_global)
+    call comm_bcast(out_pdos            ,nproc_group_global)
+    call comm_bcast(out_dns             ,nproc_group_global)
+    call comm_bcast(out_old_dns         ,nproc_group_global)
+    call comm_bcast(out_dns_rt          ,nproc_group_global)
+    call comm_bcast(out_dns_rt_step     ,nproc_group_global)
+    call comm_bcast(out_dns_trans       ,nproc_group_global)
+    call comm_bcast(out_dns_trans_energy,nproc_group_global)
+    out_dns_trans_energy = out_dns_trans_energy * uenergy_to_au
     call comm_bcast(out_elf            ,nproc_group_global)
     call comm_bcast(out_elf_rt         ,nproc_group_global)
     call comm_bcast(out_elf_rt_step    ,nproc_group_global)
@@ -1517,6 +1525,8 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_old_dns', out_old_dns
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dns_rt', out_dns_rt
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_dns_rt_step', out_dns_rt_step
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dns_trans', out_dns_trans
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'out_dns_trans_energy', out_dns_trans_energy
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_elf', out_elf
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_elf_rt', out_elf_rt
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_elf_rt_step', out_elf_rt_step

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -265,7 +265,8 @@ contains
 
     namelist/functional/ &
       & xc, &
-      & cval
+      & cval, &
+      & no_update_func
 
     namelist/rgrid/ &
       & dl, &
@@ -549,6 +550,7 @@ contains
 !! == default for &functional
     xc   = 'PZ'
     cval = -1d0
+    no_update_func = 'n'
 !! == default for &rgrid
     dl        = 0d0
     num_rgrid = 0
@@ -863,8 +865,9 @@ contains
     call comm_bcast(gamma_mask   ,nproc_group_global)
     call comm_bcast(eta_mask     ,nproc_group_global)
 !! == bcast for &functional
-    call comm_bcast(xc  ,nproc_group_global)
-    call comm_bcast(cval,nproc_group_global)
+    call comm_bcast(xc            ,nproc_group_global)
+    call comm_bcast(cval          ,nproc_group_global)
+    call comm_bcast(no_update_func,nproc_group_global)
 !! == bcast for &rgrid
     call comm_bcast(dl,nproc_group_global)
     dl = dl * ulength_to_au
@@ -1390,6 +1393,7 @@ contains
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'functional', inml_functional
       write(fh_variables_log, '("#",4X,A,"=",A)') 'xc', trim(xc)
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'cval', cval
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'no_update_func', no_update_func
 
       if(inml_rgrid >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'rgrid', inml_rgrid

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -361,16 +361,17 @@ contains
       & out_dos_smearing, &
       & out_dos_method, &
       & out_dos_fshift, &
-      & out_elf, &
       & out_old_dns, &
       & out_dns_rt, &
       & out_dns_rt_step, &
+      & out_elf, &
       & out_elf_rt, &
       & out_elf_rt_step, &
       & out_estatic_rt, &
       & out_estatic_rt_step, &
       & out_rvf_rt, &
       & out_rvf_rt_step, &
+      & out_tm, &
       & out_projection_step, &
       & out_ms_step, &
       & format3d, &
@@ -635,16 +636,17 @@ contains
     out_dos_fshift      = 'n'
     out_pdos            = 'n'
     out_dns             = 'n'
-    out_elf             = 'n'
     out_old_dns         = 'n'
     out_dns_rt          = 'n'
     out_dns_rt_step     = 50
+    out_elf             = 'n'
     out_elf_rt          = 'n'
     out_elf_rt_step     = 50
     out_estatic_rt      = 'n'
     out_estatic_rt_step = 50
     out_rvf_rt          = 'n'
     out_rvf_rt_step     = 10
+    out_tm              = 'n'
     out_projection_step = 100
     out_ms_step      = 100
     format3d            = 'cube'
@@ -966,16 +968,17 @@ contains
     call comm_bcast(out_dos_fshift     ,nproc_group_global)
     call comm_bcast(out_pdos           ,nproc_group_global)
     call comm_bcast(out_dns            ,nproc_group_global)
-    call comm_bcast(out_elf            ,nproc_group_global)
     call comm_bcast(out_old_dns        ,nproc_group_global)
     call comm_bcast(out_dns_rt         ,nproc_group_global)
     call comm_bcast(out_dns_rt_step    ,nproc_group_global)
+    call comm_bcast(out_elf            ,nproc_group_global)
     call comm_bcast(out_elf_rt         ,nproc_group_global)
     call comm_bcast(out_elf_rt_step    ,nproc_group_global)
     call comm_bcast(out_estatic_rt     ,nproc_group_global)
     call comm_bcast(out_estatic_rt_step,nproc_group_global)
     call comm_bcast(out_rvf_rt         ,nproc_group_global)
     call comm_bcast(out_rvf_rt_step    ,nproc_group_global)
+    call comm_bcast(out_tm             ,nproc_group_global)
     call comm_bcast(out_projection_step,nproc_group_global)
     call comm_bcast(out_ms_step     ,nproc_group_global)
     call comm_bcast(format3d           ,nproc_group_global)
@@ -1490,16 +1493,17 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dos_fshift', out_dos_fshift
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_pdos', out_pdos
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dns', out_dns
-      write(fh_variables_log, '("#",4X,A,"=",A)') 'out_elf', out_elf
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_old_dns', out_old_dns
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_dns_rt', out_dns_rt
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_dns_rt_step', out_dns_rt_step
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'out_elf', out_elf
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_elf_rt', out_elf_rt
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_elf_rt_step', out_elf_rt_step
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_estatic_rt', out_estatic_rt
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_estatic_rt_step', out_estatic_rt_step
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_rvf_rt', out_rvf_rt
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_rvf_rt_step', out_rvf_rt_step
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'out_tm', out_tm
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_projection_step', out_projection_step
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'out_ms_step', out_ms_step
       write(fh_variables_log, '("#",4X,A,"=",A)') 'format3d', format3d

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -101,6 +101,7 @@ module salmon_global
 !! &functional
   character(32)  :: xc
   real(8)        :: cval
+  character(1)   :: no_update_func
 
 !! &rgrid
   real(8)        :: dl(3)

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -205,6 +205,8 @@ module salmon_global
   character(1)   :: out_old_dns
   character(1)   :: out_dns_rt
   integer        :: out_dns_rt_step
+  character(1)   :: out_dns_trans
+  real(8)        :: out_dns_trans_energy
   character(1)   :: out_elf
   character(1)   :: out_elf_rt
   integer        :: out_elf_rt_step

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -200,16 +200,17 @@ module salmon_global
   character(1)   :: out_dos_fshift
   character(1)   :: out_pdos
   character(1)   :: out_dns
-  character(1)   :: out_elf
   character(1)   :: out_old_dns
   character(1)   :: out_dns_rt
   integer        :: out_dns_rt_step
+  character(1)   :: out_elf
   character(1)   :: out_elf_rt
   integer        :: out_elf_rt_step
   character(1)   :: out_estatic_rt
   integer        :: out_estatic_rt_step
   character(1)   :: out_rvf_rt
   integer        :: out_rvf_rt_step
+  character(1)   :: out_tm
   integer        :: out_projection_step
   integer        :: out_ms_step
   character(16)  :: format3d


### PR DESCRIPTION
Three useful analysis options are implemented in ARTED side:

(1) Print transition moment between orbitals
Giving a new keyword, out_tm='y'  in &analysis block in 'GS' mode, transition moment <u_nk|p|u_mk> and relating values for non-local pseudopotential between Bloch orbitals are printed in SYSname_tm.data. It can be useful information as oscillator strength and absorption spectra (or conductivity and dielectric function) etc can be obtained from these values in the ground state. 

(2) Print cube/vtk files of transition difference density
Giving new keywords, out_dns_trans='y' and out_dns_trnas_energy=xxx in &analysis block in 'RT' mode (assuming use of Impulse field), different density involving transition by oscillating field is calculated, which is calculated as FT(rho(r,t)-rho_gs(rt)) at the user specified energy/omega value. Then, out_dns_trans_Re.cube/vtk and out_dns_trans_Im.cube/vtk are printed. This is useful to know what's happened in density at specific energy (especially at peak of absorption spectrum)

(3) Option to use ground state Hamiltonian in RT mode without updating functional during time evolution.
Giving a new keyword, no_update_func='y' in &functional block, Hamiltonian (more specifically Hartree & ExCor) is not updated during time-evolution in RT mode (i.e. use of ground state Hamiltonian), which is just for particular purpose to know how much important the time-dependent of Hamiltonian is.   

