### PR TITLE
support restart of electric field using rt_wfn_k directory

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -117,7 +117,7 @@ Default is <code>n</code>.
 
 <dt>read_rt_wfn_k; <code>Character</code>; 3d</dt>
 <dd>
-Read RT wave function (pre-calculated "rt_wfn_k" directory printed by <code>calc_mode=RT</code>) if this is <code>y</code>. This is used for restarting <code>calc_mode=RT</code> (supporting <code>use_ehrenfest_md=y</code>, too: Coordinates and velocities of atoms for restarting are also included), then, "gs_wfn_k" directory is also necessary.
+Read RT wave function (pre-calculated "rt_wfn_k" directory printed by <code>calc_mode=RT</code>) if this is <code>y</code>. This is used for restarting <code>calc_mode=RT</code> (supporting <code>use_ehrenfest_md=y</code>, too: Coordinates and velocities of atoms for restarting are also included), then, "gs_wfn_k" directory is also necessary (actually used only for some analysis options). Field is taken over after restarting only if <code>ae_shape1=AcosX</code> type is used.
 Default is <code>n</code>.
 </dd>
 
@@ -695,6 +695,13 @@ Imaginary part of polarization vector the first/second pulse.
 <dd>
 Carrier emvelope phase of the first/second pulse.
 Default is <code>0d0/0d0</code>.
+</dd>
+
+<dt>t1_delay; <code>Real(8)</code>; 3d</dt>
+<dd>
+Time-delay of the first pulses.
+Unit of time can be chosen by <code>&units/unit_time</code>.
+Default is <code>0d0</code>.
 </dd>
 
 <dt>t1_t2; <code>Real(8)</code>; 0d/3d</dt>

--- a/src/ARTED/GS/io_gs_wfn_k.f90
+++ b/src/ARTED/GS/io_gs_wfn_k.f90
@@ -186,10 +186,11 @@ module io_rt_wfn_k
   implicit none
 
   character(256) :: rt_wfn_directory
-  character(256) :: rt_wfn_file, occ_file, md_file
+  character(256) :: rt_wfn_file, occ_file, md_file, ae_file
   integer,parameter :: nfile_rt_wfn = 41
   integer,parameter :: nfile_occ    = 42
   integer,parameter :: nfile_md     = 43
+  integer,parameter :: nfile_ae     = 44
 
   integer,parameter :: iflag_read_rt = 0
   integer,parameter :: iflag_write_rt= 1
@@ -223,6 +224,45 @@ contains
       case(iflag_read_rt ); read(nfile_md )Rion,velocity
       end select
       close(nfile_md)
+
+      ae_file = trim(rt_wfn_directory)//'ae_field'
+      open(nfile_ae,file=trim(ae_file),form='unformatted')
+      select case(iflag_read_write)
+      case(iflag_write_rt)
+         t1_delay = t1_delay - Nt*dt
+         write(nfile_ae) t1_delay, &
+                         trans_longi, &
+                         e_impulse, &
+                         ae_shape1, ae_shape2, &
+                         amplitude1,amplitude2, &
+                         pulse_tw1, pulse_tw2, &
+                         omega1,    omega2, &
+                         epdir_re1, epdir_im1, & 
+                         phi_cep1,  phi_cep2, &
+                         epdir_re2, epdir_im2, &
+                         rlaser_int_wcm2_1, rlaser_int_wcm2_2, &
+                         t1_t2, &
+                         quadrupole, quadrupole_pot, &
+                         rlaserbound_sta, rlaserbound_end, &
+                         alocal_laser
+      case(iflag_read_rt )
+         read(nfile_ae)  t1_delay, &
+                         trans_longi, &
+                         e_impulse, &
+                         ae_shape1, ae_shape2, &
+                         amplitude1,amplitude2, &
+                         pulse_tw1, pulse_tw2, &
+                         omega1,    omega2, &
+                         epdir_re1, epdir_im1, &
+                         phi_cep1,  phi_cep2, &
+                         epdir_re2, epdir_im2, &
+                         rlaser_int_wcm2_1, rlaser_int_wcm2_2, &
+                         t1_t2, &
+                         quadrupole, quadrupole_pot, &
+                         rlaserbound_sta, rlaserbound_end, &
+                         alocal_laser
+      end select
+      close(nfile_ae)
     end if
 
     select case(iflag_read_write)

--- a/src/ARTED/RT/init_Ac.f90
+++ b/src/ARTED/RT/init_Ac.f90
@@ -69,8 +69,11 @@ Subroutine init_Ac
       stop 'Error in init_Ac.f90'
     end select
 
-    do iter=0,Nt+1
-      tt=iter*dt - 0.5d0*pulse_tw1
+   !do iter=0,Nt+1
+     !tt=iter*dt - 0.5d0*pulse_tw1
+    do iter=-1,Nt+1
+      if(iter==-1 .and. t1_delay.ge.0d0) cycle !only for restart of field using rt_wfn_k
+      tt=iter*dt - 0.5d0*pulse_tw1 - t1_delay
       if (abs(tt)<0.5d0*pulse_tw1) then
         Ac_ext(iter,:)=-f0_1/omega1*(cos(pi*tt/pulse_tw1))**npower &
           *aimag( (epdir_re1(:) + zI*epdir_im1(:)) &
@@ -78,6 +81,8 @@ Subroutine init_Ac
           )
       end if
     enddo
+    T1_T2 = T1_T2 + t1_delay
+
   case('Ecos2')
     if(phi_CEP1 /= 0.75d0)then
       call Err_finalize("Error: phi_cep1 should be 0.75 when ae_shape1 is 'Ecos2'.")

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -324,6 +324,7 @@ contains
       & epdir_im2, &
       & phi_cep2, &
       & t1_t2, &
+      & t1_delay, &
       & quadrupole, &
       & quadrupole_pot, &
       & alocal_laser , &
@@ -606,15 +607,16 @@ contains
     epdir_im2      = 0d0
     phi_cep2       = 0d0
     t1_t2          = 0d0
+    t1_delay       = 0d0
     quadrupole     = 'n'
     quadrupole_pot = ''
     alocal_laser    = 'n'
     rlaserbound_sta(1) = -1.d7*ulength_from_au ! a.u.
     rlaserbound_sta(2) = -1.d7*ulength_from_au ! a.u.
     rlaserbound_sta(3) = -1.d7*ulength_from_au ! a.u.
-    rlaserbound_end(1) = 1.d7*ulength_from_au ! a.u.
-    rlaserbound_end(2) = 1.d7*ulength_from_au ! a.u.
-    rlaserbound_end(3) = 1.d7*ulength_from_au ! a.u.
+    rlaserbound_end(1) =  1.d7*ulength_from_au ! a.u.
+    rlaserbound_end(2) =  1.d7*ulength_from_au ! a.u.
+    rlaserbound_end(3) =  1.d7*ulength_from_au ! a.u.
 !! == default for &multiscale
     fdtddim    = '1d'
     twod_shape = 'periodic'
@@ -938,6 +940,8 @@ contains
     call comm_bcast(phi_cep2 ,nproc_group_global)
     call comm_bcast(t1_t2    ,nproc_group_global)
     t1_t2 = t1_t2 * utime_to_au
+    call comm_bcast(t1_delay ,nproc_group_global)
+    t1_delay = t1_delay * utime_to_au
     call comm_bcast(quadrupole    ,nproc_group_global)
     call comm_bcast(quadrupole_pot,nproc_group_global)
     call comm_bcast(alocal_laser  ,nproc_group_global)
@@ -1477,6 +1481,7 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'epdir_im2(3)', epdir_im2(3)
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'phi_cep2', phi_cep2
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 't1_t2', t1_t2
+      write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 't1_delay', t1_delay
       write(fh_variables_log, '("#",4X,A,"=",A)') 'quadrupole', quadrupole
       write(fh_variables_log, '("#",4X,A,"=",A)') 'quadrupole_pot', quadrupole_pot
       write(fh_variables_log, '("#",4X,A,"=",A)') 'alocal_laser', alocal_laser
@@ -1698,8 +1703,12 @@ contains
       case default
         call stop_by_bad_input2('iperiodic','convergence')
       end select
+
     else if(iperiodic==3) then
       if(convergence.ne.'rho_dne') call stop_by_bad_input2('iperiodic','convergence')
+      if(abs(t1_delay).ge.1d-10)then
+         if(index(ae_shape1,'Acos')==0) call stop_by_bad_input2('t1_delay','ae_shape1')
+      endif
     endif
 
   end subroutine check_bad_input

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -159,6 +159,7 @@ module salmon_global
   real(8)        :: epdir_im2(3)
   real(8)        :: phi_cep2
   real(8)        :: t1_t2
+  real(8)        :: t1_delay
   character(1)   :: quadrupole
   character(8)   :: quadrupole_pot
   character(1)   :: alocal_laser


### PR DESCRIPTION
Recently so far, restarting of RT mode with minimum printing (in "rt_wfn_k" directory) instead of traditional "restart_option" has been implemented (ARTED side), but field had not been taken over after restarting. Now  this got to support the electric field, i.e. after restarting using "write_rt_wfn_k=y" & "read_rt_wfn_k=y", the field oscillation continues. (but currently only for ae_shape1=AcosX ). 
Relating that, "t1_delay" option was added (delay of the first pulse)
