### PR TITLE
Supports Intel AVX-512 processor families.

### DIFF
--- a/cmakefiles/Platforms/intel-avx512.cmake
+++ b/cmakefiles/Platforms/intel-avx512.cmake
@@ -1,0 +1,31 @@
+### Intel Compiler for AVX-512 processors (since Skylake-SP)
+set(TARGET_SUFFIX               ".cpu")
+
+set(ARCH                        "-xCORE-AVX512")
+set(SIMD_SET                    "IMCI")
+set(OPENMP_FLAGS                "-qopenmp")
+set(LAPACK_FLAGS                "-mkl=parallel")
+set(ScaLAPACK_FLAGS             "-mkl=cluster")
+set(ADDITIONAL_MACRO            "")
+set(ADDITIONAL_OPTIMIZE_FLAGS   "-ansi-alias -fno-alias")
+
+set(Fortran_FLAGS_General       "-fpp -nogen-interface -std03 -warn all -diag-disable 6477,7025")
+set(C_FLAGS_General             "-Wall -diag-disable=10388 -restrict")
+
+set(CMAKE_Fortran_COMPILER      "mpiifort")
+set(CMAKE_Fortran_FLAGS_DEBUG   "-O2 -g")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_C_COMPILER            "mpiicc")
+set(CMAKE_C_FLAGS_DEBUG         "-O2 -g")
+set(CMAKE_C_FLAGS_RELEASE       "-O3")
+
+set(USE_MPI             ON)
+set(EXPLICIT_VEC        ON)
+set(REDUCE_FOR_MANYCORE ON)
+
+
+########
+# CMake Platform-specific variables
+########
+set(CMAKE_SYSTEM_NAME "Linux" CACHE STRING "Cross-compiling for Intel AVX-512 processors")
+set(CMAKE_SYSTEM_PROCESSOR "skylake")

--- a/src/ARTED/stencil/F90/hpsi.f90
+++ b/src/ARTED/stencil/F90/hpsi.f90
@@ -16,7 +16,12 @@
 #define ENABLE_NONTEMPORAL_STORE
 
 #if defined(__KNC__) || defined(__AVX512F__) || defined(__HPC_ACE2__)
-# define ENABLE_OPTIMIZED_LOAD
+# if defined(__AVX512VL__)
+! The optimization is not efficient under Skylake-SP.
+! AVX-512VL (Vector Length) extension is implemented since Skylake-SP.
+# else
+#  define ENABLE_OPTIMIZED_LOAD
+# endif
 #endif
 
 subroutine hpsi1_RT_stencil(A,B,C,D,E,F)

--- a/src/ARTED/stencil/F90/total_energy.f90
+++ b/src/ARTED/stencil/F90/total_energy.f90
@@ -14,7 +14,12 @@
 !  limitations under the License.
 !
 #if defined(__KNC__) || defined(__AVX512F__) || defined(__HPC_ACE2__)
-# define ENABLE_OPTIMIZED_LOAD
+# if defined(__AVX512VL__)
+! The optimization is not efficient under Skylake-SP.
+! AVX-512VL (Vector Length) extension is implemented since Skylake-SP.
+# else
+#  define ENABLE_OPTIMIZED_LOAD
+# endif
 #endif
 
 subroutine total_energy_stencil(A,C,D,E,F)


### PR DESCRIPTION
I add `intel-avx512` cmake configuration file.

Current available AVX-512 processors:

1. Intel Xeon Phi (Knights Landing processor families), but please use `intel-knl` configuration file.
2. Intel Scalable Processor (Skylake-SP processor families)

I tested the performance under the ISSP System C, University of Tokyo (trial operation).