### PR TITLE
Add decomposition analysis option of projection: docompose the number of excited electron into atom

### DIFF
--- a/manual/input_variables.md
+++ b/manual/input_variables.md
@@ -30,13 +30,6 @@ and <code>'GS_RTPulse'</code>
 can be chosen.
 </dd>
 
-><dt>use_ehrenfest_md; <code>Character</code>; 0d/3d</dt>
-><dd>
->Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
->Ehrenfest molecular dynamics.
->Default is <code>'n'</code>.
-></dd>
-
 <dt>use_ms_maxwell; <code>Character</code>; 3d</dt>
 <dd>
 Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
@@ -51,6 +44,13 @@ force calculation.
 Default is <code>'n'</code>.
 </dd>
 
+><dt>use_ehrenfest_md; <code>Character</code>; 0d/3d</dt>
+><dd>
+>Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
+>Ehrenfest molecular dynamics.
+>Default is <code>'n'</code>.
+></dd>
+
 ><dt>use_geometry_opt; <code>Character</code>; 0d/3d</dt>
 ><dd>
 >Enable(<code>'y'</code>)/disable(<code>'n'</code>) 
@@ -62,6 +62,16 @@ Default is <code>'n'</code>.
 
 ## &control
 <dl>
+
+<dt>sysname; <code>Character</code>; 0d/3d</dt>
+<dd>Name of calculation. This is used for a prefix of output files.
+Default is <code>default</code>.
+</dd>
+
+<dt>directory; <code>Character</code>; 0d/3d</dt>
+<dd>Name of a default directory, where the basic results will be written down.
+Default is the current directoy, <code>./</code>.
+</dd>
 
 ><dt>restart_option; <code>Character</code>; 3d</dt>
 ><dd>Flag for restart. <code>'new'</code> or 
@@ -80,16 +90,6 @@ Default is <code>'n'</code>.
 >If negative time is chosen, the automatic shutdown is not performed.
 >Default is <code>-1</code> sec.
 ></dd>
-
-<dt>sysname; <code>Character</code>; 0d/3d</dt>
-<dd>Name of calculation. This is used for a prefix of output files.
-Default is <code>default</code>.
-</dd>
-
-<dt>directory; <code>Character</code>; 0d/3d</dt>
-<dd>Name of a default directory, where the basic results will be written down.
-Default is the current directoy, <code>./</code>.
-</dd>
 
 ><dt>dump_filename; <code>Character</code>; 3d</dt>
 ><dd>Name of a filename for the restart calculation.
@@ -448,12 +448,6 @@ Time step. Unit of time can be chosen by <code>
 ## &propagation
 <dl>
 
-><dt>n_hamil; <code>Integer</code>; 0d</dt>
-><dd>
->Order of Taylor expansion of a propagation operator.
->Default is <code>4</code>.
-></dd>
-
 <dt>propagator; <code>Character</code>; 3d</dt>
 <dd>
 Choice of Propagator.
@@ -466,10 +460,21 @@ Comput. Phys. Commun., 151 60 (2003)].
 Default is <code>middlepoint</code>.
 </dd>
 
+><dt>n_hamil; <code>Integer</code>; 0d</dt>
+><dd>
+>Order of Taylor expansion of a propagation operator.
+>Default is <code>4</code>.
+></dd>
+
 </dl>
 
 ## &scf
 <dl>
+
+<dt>nscf; <code>Integer</code>; 0d/3d</dt>
+<dd>
+Number of maximum scf cycle.
+</dd>
 
 <dt>amin_routine; <code>Character</code>; 0d</dt>
 <dd>
@@ -524,16 +529,6 @@ Default is <code>0.75</code>.
 ><dd>
 >Probably, we should remove this function
 >since we can replace it with occupaion smoothing with temepratre.
-></dd>
-
-<dt>nscf; <code>Integer</code>; 0d/3d</dt>
-<dd>
-Number of maximum scf cycle.
-</dd>
-
-><dt>ngeometry_opt; <code>Integer</code>; 0d</dt>
-><dd>
->Number of iteration of geometry optimization.
 ></dd>
 
 <dt>subspace_diagonalization; <code>Character</code>; 0d</dt>
@@ -607,6 +602,10 @@ Loop for OpenMP parallelization if periodic boundary system is used.
 >Default is <code>n</code>
 ></dd>
 
+><dt>ngeometry_opt; <code>Integer</code>; 0d</dt>
+><dd>
+>Number of iteration of geometry optimization.
+></dd>
 
 </dl>
 
@@ -807,6 +806,14 @@ Methods of projection.
 </li>
 </ul>
 </dd>
+
+><dt>projection_decomp; <code>Character</code>; 3d</dt>
+><dd>
+>If <code>'atom'</code> combined with <code>projection_option='gs'</code>, 
+>the number of excited electron is decomposed into each atom 
+>(this is printed in <code>SYSname</code>_nex_atom.data)
+>Default is <code>'n'</code>.
+></dd>
 
 <dt>out_projection_step; <code>Integer</code>; 3d</dt>
 <dd>

--- a/src/ARTED/control/ana_RT_useGS.f90
+++ b/src/ARTED/control/ana_RT_useGS.f90
@@ -192,7 +192,7 @@ Subroutine analysis_RT_using_GS(Rion_xyz_update,iter_GS_max,zu,it,action)
            do ik=1,NK
               write(404,20) ik,(ovlp_occ(ib,ik)*NKxyz,ib=1,NB)
            enddo
-           time = it*dt**t_unit_time%conv
+           time = it*dt*t_unit_time%conv
            nee  = sum(ovlp_occ(NBoccmax+1:NB,:))
            neh  = sum(occ)-sum(ovlp_occ(1:NBoccmax,:))
            write(408,30) time, nee, neh
@@ -245,7 +245,7 @@ Subroutine analysis_RT_using_GS(Rion_xyz_update,iter_GS_max,zu,it,action)
 
         !print
         if(comm_is_root(nproc_id_global)) then
-           time = it*dt**t_unit_time%conv
+           time = it*dt*t_unit_time%conv
            write(420,40) time, real(sum(nee_ia(:))), (nee_ia(ia),ia=1,NI)
 40         format(1x,1000e16.6E3)
         endif

--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -93,6 +93,8 @@ subroutine tddft_sc
       open(404, file=file_ovlp,         position = position_option) 
       open(408, file=file_nex,          position = position_option) 
       open(409, file=file_last_band_map,position = position_option) 
+      if(projection_option=='gs' .and. projection_decomp=='atom') &
+    & open(420, file=file_nex_atom,  position = position_option) 
       call write_projection_header
     end if
 

--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -140,6 +140,7 @@ contains
        write(file_dns,"(2A,'_dns.data')") trim(directory),trim(SYSname)
        write(file_ovlp,"(2A,'_ovlp.data')") trim(directory),trim(SYSname)
        write(file_nex,"(2A,'_nex.data')") trim(directory),trim(SYSname)
+       write(file_nex_atom,"(2A,'_nex_atom.data')") trim(directory),trim(SYSname)
        write(file_last_band_map,"(2A,'_last_band_map.data')") trim(directory),trim(SYSname)
        write(file_k_data,"(2A,'_k.data')") trim(directory),trim(SYSname)
        write(file_eigen_data,"(2A,'_eigen.data')") trim(directory),trim(SYSname)

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -89,6 +89,7 @@ Module Global_Variables
   real(8),allocatable :: velocity(:,:),force(:,:),esp(:,:)
   real(8),allocatable :: Floc(:,:),Fnl(:,:),Fion(:,:),FionAc(:,:)          
   real(8),allocatable :: ovlp_occ_l(:,:),ovlp_occ(:,:)
+  integer,allocatable :: assign_grid_atom(:) ! projection + decomp analysis
   integer,allocatable :: NBocc(:) !FS set
   real(8),allocatable :: esp_vb_min(:),esp_vb_max(:) !FS set
   real(8),allocatable :: esp_cb_min(:),esp_cb_max(:) !FS set
@@ -149,7 +150,7 @@ Module Global_Variables
   character(256) :: file_epst,file_epse
   character(256) :: file_force_dR,file_j_ac
   character(256) :: file_DoS,file_band
-  character(256) :: file_dns,file_ovlp,file_nex,file_last_band_map
+  character(256) :: file_dns,file_ovlp,file_nex,file_last_band_map,file_nex_atom
   character(256) :: file_dns_gs
   character(256) :: file_dns_rt
   character(256) :: file_dns_dlt

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -352,6 +352,7 @@ contains
 
     namelist/analysis/ &
       & projection_option, &
+      & projection_decomp, &
       & nenergy, &
       & de, &
       & out_psi, &
@@ -636,6 +637,7 @@ contains
     file_macropoint = ''
 !! == default for &analysis
     projection_option   = 'no'
+    projection_decomp   = 'n'
     nenergy             = 1000
     de                  = (0.01d0/au_energy_ev)*uenergy_from_au  ! eV
     out_psi             = 'n'
@@ -975,6 +977,7 @@ contains
     
 !! == bcast for &analysis
     call comm_bcast(projection_option,nproc_group_global)
+    call comm_bcast(projection_decomp,nproc_group_global)
     call comm_bcast(nenergy          ,nproc_group_global)
     call comm_bcast(de               ,nproc_group_global)
     de = de * uenergy_to_au
@@ -1515,6 +1518,7 @@ contains
       if(inml_analysis >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'analysis', inml_analysis
       write(fh_variables_log, '("#",4X,A,"=",A)') 'projection_option', projection_option
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'projection_decomp', projection_decomp
       write(fh_variables_log, '("#",4X,A,"=",I6)') 'nenergy', nenergy
       write(fh_variables_log, '("#",4X,A,"=",ES12.5)') 'de', de
       write(fh_variables_log, '("#",4X,A,"=",A)') 'out_psi', out_psi

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -191,6 +191,7 @@ module salmon_global
   
 !! &analysis
   character(2)   :: projection_option
+  character(4)   :: projection_decomp
   integer        :: nenergy
   real(8)        :: de
   character(1)   :: out_psi


### PR DESCRIPTION
A keyword "projection_decomp" was added. If "projection_decomp=atom" combined with "projection_option="gs",  decomposition of the number of excited electron into atoms is done and it's printed in SYSname_nex_atom.data. 
 
