### PR TITLE
Fix bug in Ecos2 type incident field in ARTED & Made normalization of polarization vector

### DIFF
--- a/src/ARTED/RT/init_Ac.f90
+++ b/src/ARTED/RT/init_Ac.f90
@@ -90,7 +90,7 @@ Subroutine init_Ac
     do iter=0,Nt+1
       tt=iter*dt - 0.5d0*pulse_tw1
       if (abs(tt)<0.5d0*pulse_tw1) then
-        Ac_ext(iter,:)=-f0_1/(8d0*pi**2*omega1 - 2d0*pulse_tw1**2*omega1**3) &
+        Ac_ext(iter,:)=-epdir_re1(:)*f0_1/(8d0*pi**2*omega1 - 2d0*pulse_tw1**2*omega1**3) &
           *( &
           (-4d0*pi**2+pulse_tw1**2*omega1**2 + pulse_tw1**2*omega1**2*cos(2d0*pi*tt/pulse_tw1))*cos(omega1*tt) &
           +2d0*pi*(2d0*pi*cos(pulse_tw1*omega1/2d0) &

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -204,6 +204,7 @@ contains
     use salmon_file, only: get_filehandle
     implicit none
     integer :: ii
+    real(8) :: norm
 
     namelist/calculation/ &
       & calc_mode, &
@@ -926,6 +927,9 @@ contains
     omega1 = omega1 * uenergy_to_au
     call comm_bcast(epdir_re1 ,nproc_group_global)
     call comm_bcast(epdir_im1 ,nproc_group_global)
+    norm = sqrt(sum(epdir_re1(:)**2+epdir_im1(:)**2))
+    epdir_re1 = epdir_re1 / norm
+    epdir_im1 = epdir_im1 / norm
     call comm_bcast(phi_cep1  ,nproc_group_global)
     call comm_bcast(ae_shape2 ,nproc_group_global)
     call comm_bcast(amplitude2,nproc_group_global)
@@ -937,6 +941,9 @@ contains
     omega2 = omega2 * uenergy_to_au
     call comm_bcast(epdir_re2,nproc_group_global)
     call comm_bcast(epdir_im2,nproc_group_global)
+    norm = sqrt(sum(epdir_re2(:)**2+epdir_im2(:)**2))
+    epdir_re2 = epdir_re2 / norm
+    epdir_im2 = epdir_im2 / norm
     call comm_bcast(phi_cep2 ,nproc_group_global)
     call comm_bcast(t1_t2    ,nproc_group_global)
     t1_t2 = t1_t2 * utime_to_au


### PR DESCRIPTION
A bug of recently implemented "Ecos2" option of incident electric field in ARTED side was fixed: The polarization vector epdir_re1 was missing (i.e. equivalent to use of (1,1,1) polarization vector ). 

Also I added normalization of polarization vector (epdir_reX, epdir_imX) after reading input file to avoid confusing.  

