### PR TITLE
Bug fix probe field in Ecos2 option (missing polarization vector...)

### DIFF
--- a/src/ARTED/RT/init_Ac.f90
+++ b/src/ARTED/RT/init_Ac.f90
@@ -195,7 +195,7 @@ Subroutine init_Ac
       tt=iter*dt - 0.5d0*pulse_tw1 - T1_T2
       if (abs(tt)<0.5d0*pulse_tw2) then
         Ac_ext(iter,:)=Ac_ext(iter,:) &
-          -f0_2/(8d0*pi**2*omega2 - 2d0*pulse_tw2**2*omega2**3) &
+          -epdir_re2(:)*f0_2/(8d0*pi**2*omega2 - 2d0*pulse_tw2**2*omega2**3) &
           *( &
           (-4d0*pi**2+pulse_tw2**2*omega2**2 + pulse_tw2**2*omega2**2*cos(2d0*pi*tt/pulse_tw2))*cos(omega2*tt) &
           +2d0*pi*(2d0*pi*cos(pulse_tw2*omega2/2d0) &


### PR DESCRIPTION
Bug in Ecos2 probe field (in ARTED) was fixed (polarization vector was missing like the recent found bug of pump field of Ecos2 ....)