### PR TITLE
amplitude is devided by omega in an Acos2 calculation

### DIFF
--- a/src/GCEED/rt/calc_env_trigon.f90
+++ b/src/GCEED/rt/calc_env_trigon.f90
@@ -51,7 +51,7 @@ subroutine calc_env_trigon(ipulse,tenv_trigon)
     tenv_trigon=cos(theta1)**2*cos(theta2)
   else if(tae_shape=='Acos2')then
     tenv_trigon=-(-alpha*sin(2.d0*theta1)*cos(theta2)   &
-                  -beta*cos(theta1)**2*sin(theta2))
+                  -beta*cos(theta1)**2*sin(theta2))/beta
   end if
     
   return


### PR DESCRIPTION
I found that an amplitude was not devided by omega in the GCEED part while it was in the ARTED part. So I fix. I also show a calculated result. 

![rt](https://user-images.githubusercontent.com/4902722/37640521-5f4081d8-2c59-11e8-93db-3fd0688978b4.jpg)
