### PR TITLE
Add switches to surpress the radiation / reflection in multiscale calculation

### DIFF
--- a/src/ARTED/control/control_ms.f90
+++ b/src/ARTED/control/control_ms.f90
@@ -220,6 +220,7 @@ subroutine tddft_maxwell_ms
     
     Macro_loop : do imacro = nmacro_s, nmacro_e
       
+      
       !===========================================================================
       !! Extract microscopic state of "imacro"-th macropoint
       call timer_begin(LOG_OTHER)
@@ -254,6 +255,16 @@ subroutine tddft_maxwell_ms
       if(Sym /= 1)then
         jav(1:2) = 0d0
       end if
+      
+      !===========================================================================
+      !! Special rule for debug mode (macroscopic system does not have a matter)
+      !! NOTE: This condition will be removed and replaced by FDTD mode
+      !!       after merging the common Maxwell calculation routine.
+      if (debug_switch_no_radiation) then
+        jav(:) = 0d0
+      end if
+      !===========================================================================
+      
       if (comm_is_root(nproc_id_tdks)) then
         jm_new_m_tmp(1:3, imacro) = jav(1:3)
       end if

--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -619,6 +619,11 @@ contains
     use Global_Variables
     use salmon_parallel
     implicit none
+    !! Special Rule for Debug and Calculation Check
+    if (nmacro < 1) then
+      nmacro = 1
+      debug_switch_no_radiation = .true.
+    end if
     !! Assign the macropoint into the every MPI procs    
     if (nproc_size_global <= nmacro) then
       !! Parallization Case 1:
@@ -793,13 +798,15 @@ contains
         & fdtddim, TwoD_shape, & 
         & nmacro, nmacro_attr, &
         & nbg_media, nbg_media_attr, &
-        & ninit_acfield
+        & ninit_acfield, &
+        & debug_switch_no_radiation
       
       nmacro = 1
       nmacro_attr = 0
       nbg_media = 0
       nbg_media_attr = 0
       ninit_acfield = 0
+      debug_switch_no_radiation = .false.
 
       if(comm_is_root(nproc_id_global)) then
         fh = open_filehandle(trim(directory) // trim(file_macropoint))
@@ -822,6 +829,7 @@ contains
       call comm_bcast(nbg_media,nproc_group_global)
       call comm_bcast(nbg_media_attr,nproc_group_global)
       call comm_bcast(ninit_acfield,nproc_group_global)
+      call comm_bcast(debug_switch_no_radiation,nproc_group_global)
 
       allocate(macropoint(1:4, nmacro))
       allocate(macropoint_attr(1:nattr_column, nmacro_attr))

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -243,6 +243,10 @@ Module Global_Variables
   real(8) :: total_energy_absorb_old, total_energy_absorb
   real(8) :: total_energy_elec_old, total_energy_elec
   real(8) :: total_energy_em_old, total_energy_em  
+
+  !! Calculate Pure FDTD Calculation without TDDFT:
+  !! NOTE: This switch will be removed after marging the common FDTD routine..
+  logical :: debug_switch_no_radiation
   
 #ifdef _OPENACC
   complex(8),allocatable,pinned :: zu_m(:,:,:,:)


### PR DESCRIPTION
##Overview

This PR provides a parameter `debug_switch_no_radiation` for the check/test of multiscale calculation.
If this switch enabled in input file (or the number of macropoints is set to 0), the macroscopic system calculation neglects the current density by microscopic system. It is used for the calculation check of the radiation and reflection field.

This modification is only for a temporal implementation before merging the common FDTD module.
