### PR TITLE
Rotation of microscopic system

### DIFF
--- a/src/ARTED/control/control_ms.f90
+++ b/src/ARTED/control/control_ms.f90
@@ -338,8 +338,9 @@ subroutine tddft_maxwell_ms
       iy_m = macropoint(2, imacro)
       iz_m = macropoint(3, imacro)
       !! Map the local macropoint current into the jm field
-      Jm_new_ms(1:3, ix_m, iy_m, iz_m) = Jm_new_ms(1:3, ix_m, iy_m, iz_m) & 
-                                     & + Jm_new_m(1:3, imacro)
+      !Jm_new_ms(1:3, ix_m, iy_m, iz_m) = Jm_new_ms(1:3, ix_m, iy_m, iz_m) & 
+      !                               & + Jm_new_m(1:3, imacro)
+      Jm_new_ms(1:3, ix_m, iy_m, iz_m) = matmul(trans_inv(1:3,1:3), Jm_new_m(1:3, imacro))
     end do
 !$omp end parallel do
     call timer_end(LOG_OTHER)
@@ -542,8 +543,11 @@ contains
       iiy_m = macropoint(2, iimacro)
       iiz_m = macropoint(3, iimacro)
       !! Assign the vector potential into the local macropoint variables
-      Ac_m(1:3, iimacro) = Ac_ms(1:3, iix_m, iiy_m, iiz_m)
-      Ac_new_m(1:3, iimacro) = Ac_new_ms(1:3, iix_m, iiy_m, iiz_m)
+      !Ac_m(1:3, iimacro) = Ac_ms(1:3, iix_m, iiy_m, iiz_m)
+      !Ac_new_m(1:3, iimacro) = Ac_new_ms(1:3, iix_m, iiy_m, iiz_m)
+      
+      Ac_m(1:3, iimacro) = matmul(trans_mat(1:3,1:3), Ac_ms(1:3, iix_m, iiy_m, iiz_m))
+      Ac_new_m(1:3, iimacro) = matmul(trans_mat(1:3,1:3), Ac_new_ms(1:3, iix_m, iiy_m, iiz_m))
     end do
 !$omp end parallel do
   end subroutine assign_mp_variables_omp

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -243,6 +243,9 @@ Module Global_Variables
   real(8) :: total_energy_absorb_old, total_energy_absorb
   real(8) :: total_energy_elec_old, total_energy_elec
   real(8) :: total_energy_em_old, total_energy_em  
+  
+  real(8) :: ms_angle_x, ms_angle_y, ms_angle_z
+  real(8) :: trans_mat(3, 3), trans_inv(3, 3)
 
   !! Calculate Pure FDTD Calculation without TDDFT:
   !! NOTE: This switch will be removed after marging the common FDTD routine..


### PR DESCRIPTION
## Overview

This pull request enables to specify the rotation (coordinate transformation) of the microscopic system in the multiscale calculation. By set the new options ```ms_angle_(x|y|z)`` representing the eular angle of the transformation, the user can control the relation between the coordinate system of macroscopic system and microscopic system.

I believe this is useful to describe the angular-dependensty to light scattering / propagations.