### PR TITLE
fix a bug and modify automatic assignment of processes in lsda calculations

### DIFF
--- a/gnu_makefiles/make.body
+++ b/gnu_makefiles/make.body
@@ -183,6 +183,7 @@ F_SRCS = \
 	GCEED/rt/dip.f90 \
 	GCEED/rt/projection.f90 \
 	GCEED/rt/set_numcpu_rt.f90 \
+	GCEED/rt/set_numcpu_rt_sp.f90 \
 	GCEED/rt/time_evolution_step.f90 \
 	GCEED/rt/xc_fast.f90 \
 	GCEED/scf/convert_input_scf.f90 \

--- a/src/GCEED/common/check_numcpu.f90
+++ b/src/GCEED/common/check_numcpu.f90
@@ -54,4 +54,11 @@ if(mod(nproc_Mxin_s(3),nproc_Mxin(3))/=0)then
 end if
 nproc_Mxin_s_dm(1:3)=nproc_Mxin_s(1:3)/nproc_Mxin(1:3)
 
+if(ilsda==1)then
+  if(nproc_ob>1)then
+    write(*,*) "Orbital parallelization is not currently supported. It will be supported in future."
+    stop
+  end if
+end if
+
 end subroutine check_numcpu

--- a/src/GCEED/rt/CMakeLists.txt
+++ b/src/GCEED/rt/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     read_rt.f90
     real_time_dft.f90
     set_numcpu_rt.f90
+    set_numcpu_rt_sp.f90
     set_vonf_sd.f90
     taylor_coe.f90
     taylor${HPSI_TEST_SUFFIX}.f90

--- a/src/GCEED/rt/convert_input_rt.f90
+++ b/src/GCEED/rt/convert_input_rt.f90
@@ -24,6 +24,7 @@ integer :: Ntime
 real(8) :: dip_spacing
 
 ik_oddeven=2
+ilsda=ispin
 
 if(comm_is_root(nproc_id_global))then
    open(fh_namelist, file='.namelist.tmp', status='old')
@@ -70,7 +71,11 @@ nproc_Mxin_s = nproc_domain_s
 
 if(nproc_ob==0.and.nproc_mxin(1)==0.and.nproc_mxin(2)==0.and.nproc_mxin(3)==0.and.  &
                    nproc_mxin_s(1)==0.and.nproc_mxin_s(2)==0.and.nproc_mxin_s(3)==0) then
-  call set_numcpu_rt
+  if(ilsda==0)then
+    call set_numcpu_rt
+  else if(ilsda==1)then
+    call set_numcpu_rt_sp
+  end if
 else
   call check_numcpu
 end if

--- a/src/GCEED/rt/set_numcpu_rt_sp.f90
+++ b/src/GCEED/rt/set_numcpu_rt_sp.f90
@@ -1,0 +1,106 @@
+!
+!  Copyright 2018 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+subroutine set_numcpu_rt_sp
+  use salmon_parallel, only: nproc_size_global
+  use scf_data
+  use new_world_sub
+  implicit none
+  integer :: ii
+  integer :: nproc_size_global_tmp
+  integer :: nproc_mxin_tmp(3)
+  
+  integer :: num_factor2
+  integer :: num_factor3
+  integer :: num_factor5
+
+  integer :: icount
+ 
+  nproc_size_global_tmp=nproc_size_global
+  
+  ! this code treats the situation that nproc_size_global is less than or equal to 48,828,125
+  
+  num_factor2=0
+  do ii=1,26
+    if(mod(nproc_size_global_tmp,2)==0)then
+      num_factor2=num_factor2+1
+      nproc_size_global_tmp=nproc_size_global_tmp/2
+    end if
+  end do
+  
+  num_factor3=0
+  do ii=1,17
+    if(mod(nproc_size_global_tmp,3)==0)then
+      num_factor3=num_factor3+1
+      nproc_size_global_tmp=nproc_size_global_tmp/3
+    end if
+  end do
+  
+  num_factor5=0
+  do ii=1,11
+    if(mod(nproc_size_global_tmp,5)==0)then
+      num_factor5=num_factor5+1
+      nproc_size_global_tmp=nproc_size_global_tmp/5
+    end if
+  end do
+  
+  if(nproc_size_global_tmp/=1)then
+    stop "In automatic process assignment, prime factors for number of processes must be combination of 2, 3 or 5."
+  end if
+
+  nproc_mxin_tmp(1:3)=1
+ 
+  icount=0
+
+  do ii=1,num_factor5
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_tmp(3)=nproc_mxin_tmp(3)*5
+    else if(mod(icount,3)==2)then
+      nproc_mxin_tmp(2)=nproc_mxin_tmp(2)*5
+    else
+      nproc_mxin_tmp(1)=nproc_mxin_tmp(1)*5
+    end if
+  end do
+
+  do ii=1,num_factor3
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_tmp(3)=nproc_mxin_tmp(3)*3
+    else if(mod(icount,3)==2)then
+      nproc_mxin_tmp(2)=nproc_mxin_tmp(2)*3
+    else
+      nproc_mxin_tmp(1)=nproc_mxin_tmp(1)*3
+    end if
+  end do
+
+  do ii=1,num_factor2
+    icount=icount+1
+    if(mod(icount,3)==1)then
+      nproc_mxin_tmp(3)=nproc_mxin_tmp(3)*2
+    else if(mod(icount,3)==2)then
+      nproc_mxin_tmp(2)=nproc_mxin_tmp(2)*2
+    else
+      nproc_mxin_tmp(1)=nproc_mxin_tmp(1)*2
+    end if
+  end do
+
+  nproc_k=1
+  nproc_ob=1
+  nproc_mxin(1:3)=nproc_mxin_tmp(1:3)
+  nproc_mxin_s(1:3)=nproc_mxin_tmp(1:3)
+  nproc_mxin_s_dm(1:3)=nproc_mxin_s(1:3)/nproc_mxin(1:3)
+  
+end subroutine set_numcpu_rt_sp

--- a/src/GCEED/scf/convert_input_scf.f90
+++ b/src/GCEED/scf/convert_input_scf.f90
@@ -29,6 +29,7 @@ real(8) :: dip_spacing
 
 ik_oddeven=2
 iterVh = 0         ! Iteration counter
+ilsda = ispin
 
 if(comm_is_root(nproc_id_global))then
    open(fh_namelist, file='.namelist.tmp', status='old')
@@ -56,8 +57,6 @@ iDiter(1:maxntmg)=1000
 Harray(1:3,1)=dl(1:3)
 rLsize(1:3,1)=al(1:3)
 iDiter(1) = nscf
-
-ilsda = ispin
 
 if(ispin == 0)then
   MST(1)=nstate


### PR DESCRIPTION
It seems that bugs appear in real-time propagation for lsda calculations when orbital parallelization is used. So I modify the assignment of processes not to use the orbital parallelization in the lsda calculations. @tt-ims san, could you check? 