### PR TITLE
Change version number to 1.1.0

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -31,21 +31,21 @@ program main
   end select
 
   call end_parallel
-
 contains
   subroutine print_software_version
     use salmon_xc, only: print_xc_info
     implicit none
     include 'versionf.h'
-    print '(A)',       '##############################################################################'
-    print '(A)',       '# SALMON: Scalable Ab-initio Light-Matter simulator for Optics and Nanoscience'
-    print '(A)',       '#'
-    print '(A,A,A,A)', '#                             Version 1.0.0                                   '
-    if (GIT_FOUND) then
+    print '(A)',         '##############################################################################'
+    print '(A)',         '# SALMON: Scalable Ab-initio Light-Matter simulator for Optics and Nanoscience'
+    print '(A)',         '#'
+    print '(A,I1,".",I1,".",I1)', &
+    &                    '#                             Version ', SALMON_VER_MAJOR, SALMON_VER_MINOR, SALMON_VER_MICRO
+    if (GIT_FOUND) then 
       print '(A)',       '#'
       print '(A,A,A,A)', '#   [Git revision] ', GIT_COMMIT_HASH, ' in ', GIT_BRANCH
     endif
-    print '(A)',       '##############################################################################'
+    print '(A)',         '##############################################################################'
     
     call print_xc_info()    
   end subroutine

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -5,4 +5,8 @@
 #define GIT_BRANCH      "@GIT_BRANCH@"
 #define GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
 
+#define SALMON_VER_MAJOR  1
+#define SALMON_VER_MINOR  0
+#define SALMON_VER_MICRO  1
+
 #endif

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -6,7 +6,7 @@
 #define GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
 
 #define SALMON_VER_MAJOR  1
-#define SALMON_VER_MINOR  0
-#define SALMON_VER_MICRO  1
+#define SALMON_VER_MINOR  1
+#define SALMON_VER_MICRO  0
 
 #endif

--- a/src/versionf.h.in
+++ b/src/versionf.h.in
@@ -1,3 +1,7 @@
 logical, parameter      :: GIT_FOUND       = .@GIT_FOUND@.
 character(*), parameter :: GIT_BRANCH      = '@GIT_BRANCH@'
 character(*), parameter :: GIT_COMMIT_HASH = '@GIT_COMMIT_HASH@'
+
+integer, parameter :: SALMON_VER_MAJOR = 1
+integer, parameter :: SALMON_VER_MINOR = 0
+integer, parameter :: SALMON_VER_MICRO = 1

--- a/src/versionf.h.in
+++ b/src/versionf.h.in
@@ -3,5 +3,5 @@ character(*), parameter :: GIT_BRANCH      = '@GIT_BRANCH@'
 character(*), parameter :: GIT_COMMIT_HASH = '@GIT_COMMIT_HASH@'
 
 integer, parameter :: SALMON_VER_MAJOR = 1
-integer, parameter :: SALMON_VER_MINOR = 0
-integer, parameter :: SALMON_VER_MICRO = 1
+integer, parameter :: SALMON_VER_MINOR = 1
+integer, parameter :: SALMON_VER_MICRO = 0


### PR DESCRIPTION
## Congratulations! 
![logo_fish](https://user-images.githubusercontent.com/5200546/42065569-a8e765ce-7b76-11e8-823a-de3ba7c20b3d.png)
This PR will be the final change before release of SALMON-v.1.1.0 !

```
##############################################################################
# SALMON: Scalable Ab-initio Light-Matter simulator for Optics and Nanoscience
#
#                             Version 1.1.0
```

- Change the version number printed out in the stdout
- Add macro variables `SALMON_VER_(MAJOR|MINOR|MICRO)` to set the version number in `src/version.h.in` 

