### PR TITLE
Modify output format of floating point number

### DIFF
--- a/src/ARTED/GS/write_GS_data.f90
+++ b/src/ARTED/GS/write_GS_data.f90
@@ -192,7 +192,7 @@ Subroutine write_GS_data
           & 2, "DoS", trim(t_unit_energy_inv%name)
         do iw = 1, iout_dos_nenergy
           ww =  out_dos_start + (iw-1) * dw 
-          write(fh_dos,'(F16.8,99(1X,ES22.14E3))') &
+          write(fh_dos,'(F16.8,99(1X,E23.15E3))') &
             & ww * t_unit_energy%conv, &
             & dos(iw) * t_unit_energy_inv%conv
         end do
@@ -341,7 +341,7 @@ Subroutine write_GS_data
           & 4, "kz", "none", &
           & 5, "wk", "none"
         do ik = 1, NK
-          write(fh_k, '(I6,99(1X,ES22.14E3))') &
+          write(fh_k, '(I6,99(1X,E23.15E3))') &
             & ik, & 
             & kAc0(ik,1) / bLx, &
             & kAc0(ik,2) / bLy, &
@@ -376,7 +376,7 @@ Subroutine write_GS_data
           & 4, "occup", "none"
         do ik = 1, NK
           do ib = 1, NB
-            write(fh_eigen, '(I6,1X,I6,99(1X,ES22.14E3))') &
+            write(fh_eigen, '(I6,1X,I6,99(1X,E23.15E3))') &
               & ik, ib, esp(ib,ik)*t_unit_energy%conv, occ(ib,ik)/wk(ik)*NKxyz
           end do !ib
         end do !ik

--- a/src/ARTED/RT/Fourier_tr.f90
+++ b/src/ARTED/RT/Fourier_tr.f90
@@ -121,17 +121,17 @@ Subroutine Fourier_tr
     end if
     if (comm_is_root(nproc_id_global)) then
       if (ae_shape1 == 'impulse' .and. trans_Longi == 'lo') then
-        write(fh_lr,'(F16.8,99(1X,ES22.14E3))') hw * t_unit_energy%conv &
+        write(fh_lr,'(F16.8,99(1X,E23.15E3))') hw * t_unit_energy%conv &
              &,(real(zeps(ixyz)),ixyz=1,3)&
              &,(aimag(zeps(ixyz)),ixyz=1,3)
       else if (ae_shape1 == 'impulse' .and. Trans_Longi == 'tr') then
-        write(fh_lr,'(F16.8,99(1X,ES22.14E3))') hw * t_unit_energy%conv &
+        write(fh_lr,'(F16.8,99(1X,E23.15E3))') hw * t_unit_energy%conv &
              &,(real(zsigma_w(ixyz)),ixyz=1,3)&
              &,(aimag(zsigma_w(ixyz)),ixyz=1,3)&
              &,(real(zeps(ixyz)),ixyz=1,3)&
              &,(aimag(zeps(ixyz)),ixyz=1,3)
       else
-        write(fh_lr,'(F16.8,99(1X,ES22.14E3))') hw * t_unit_energy%conv &
+        write(fh_lr,'(F16.8,99(1X,E23.15E3))') hw * t_unit_energy%conv &
              &,(real(jav_w(ixyz)) * t_unit_current%conv, ixyz=1,3)&
              &,(aimag(jav_w(ixyz)) * t_unit_current%conv, ixyz=1,3)&
              &,(real(E_ext_w(ixyz)) * t_unit_elec%conv ,ixyz=1,3)&

--- a/src/ARTED/control/control_ms.f90
+++ b/src/ARTED/control/control_ms.f90
@@ -822,7 +822,7 @@ contains
       do iiz_m = nz1_m, nz2_m
         do iiy_m = ny1_m, ny2_m
           do iix_m = nx1_m, nx2_m
-            write(fh_ac,'(I6,1X,I6,1X,I6,99(1X,ES22.14E3))',advance='no')  &
+            write(fh_ac,'(I6,1X,I6,1X,I6,99(1X,E23.15E3))',advance='no')  &
               & iix_m, iiy_m, iiz_m, &
               & data_out(1:ndata_out_column, iix_m, iiy_m, iiz_m, ipos)
            !if(use_ehrenfest_md=='y') then
@@ -979,12 +979,12 @@ contains
           endif
           write(fh_ac_m,*)
           do iiter = 0, Nt
-            write(fh_ac_m, "(F16.8,6(1X,ES22.14E3,1X))",advance='no') &
+            write(fh_ac_m, "(F16.8,6(1X,E23.15E3,1X))",advance='no') &
             & iiter * dt * t_unit_time%conv, &
             & data_local_Ac(1:3, iimacro, iiter) * t_unit_ac%conv, &
             & data_local_jm(1:3, iimacro, iiter) * t_unit_current%conv
             if(use_ehrenfest_md=='y') then
-              write(fh_ac_m, "(F16.8,6(1X,ES22.14E3,1X))",advance='no') &
+              write(fh_ac_m, "(F16.8,6(1X,E23.15E3,1X))",advance='no') &
               data_local_jm_ion(1:3, iimacro, iiter) * t_unit_current%conv, &
               data_local_Tmp_ion(iimacro, iiter)
             endif
@@ -1029,7 +1029,7 @@ contains
         & 6, "Ac_y(R)", trim(t_unit_ac%name), &
         & 7, "Ac_z(R)", trim(t_unit_ac%name)
       do iiter = 0, Nt
-        write(fh_ac_vac, "(F16.8,6(1X,ES22.14E3,1X))") &
+        write(fh_ac_vac, "(F16.8,6(1X,E23.15E3,1X))") &
           & iiter * dt * t_unit_time%conv, &
           & data_vac_Ac(1:3, 1, iiter) * t_unit_ac%conv, &
           & data_vac_Ac(1:3, 2, iiter) * t_unit_ac%conv

--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -512,7 +512,7 @@ contains
       write(fh_rt,*)
 
       do iiter = 0, niter
-        write(fh_rt, "(F16.8,99(1X,ES22.14E3))",advance='no') &
+        write(fh_rt, "(F16.8,99(1X,E23.15E3))",advance='no') &
           & iiter * dt * t_unit_time%conv, &
           & Ac_ext(iiter, 1:3) * t_unit_ac%conv, &
           & E_ext(iiter, 1:3) * t_unit_elec%conv, &
@@ -522,12 +522,12 @@ contains
           & Eall_t(iiter) * t_unit_energy%conv, &
           & (Eall_t(iiter) - Eall0) * t_unit_energy%conv
         if(use_ehrenfest_md=='y') then
-        write(fh_rt, "(99(1X,ES22.14E3))",advance='no') &
+        write(fh_rt, "(99(1X,E23.15E3))",advance='no') &
           & Tion_t(iiter) * t_unit_energy%conv, &
           & Temperature_ion_t(iiter), &
           & Ework_integ_fdR(iiter) * t_unit_energy%conv
         if(ensemble=="NVT".and.thermostat=="nose-hoover")then
-        write(fh_rt, "(99(1X,ES22.14E3))",advance='no') &
+        write(fh_rt, "(99(1X,E23.15E3))",advance='no') &
           & Enh_t(iiter) * t_unit_energy%conv, &
           & Hnvt_t(iiter) * t_unit_energy%conv, &
           & (Tion_t(iiter)+Ework_integ_fdR(iiter)+Enh_t(iiter)) * t_unit_energy%conv
@@ -574,17 +574,17 @@ contains
 
       do iiter = 0, niter
         if( use_ehrenfest_md/='y' .and. mod(iiter,nstep_energy_calc)/=0)cycle
-        write(fh_rt_energy, "(F16.8,99(1X,ES22.14E3))",advance='no') &
+        write(fh_rt_energy, "(F16.8,99(1X,E23.15E3))",advance='no') &
           & iiter * dt * t_unit_time%conv, &
           & Eall_t(iiter) * t_unit_energy%conv, &
           & (Eall_t(iiter) - Eall0) * t_unit_energy%conv
         if(use_ehrenfest_md=='y') then
-        write(fh_rt_energy, "(99(1X,ES22.14E3))",advance='no') &
+        write(fh_rt_energy, "(99(1X,E23.15E3))",advance='no') &
           & Tion_t(iiter) * t_unit_energy%conv, &
           & Temperature_ion_t(iiter), &
           & Ework_integ_fdR(iiter) * t_unit_energy%conv
         if(ensemble=="NVT".and.thermostat=="nose-hoover")then
-        write(fh_rt_energy, "(99(1X,ES22.14E3))",advance='no') &
+        write(fh_rt_energy, "(99(1X,E23.15E3))",advance='no') &
           & Enh_t(iiter) * t_unit_energy%conv, &
           & Hnvt_t(iiter) * t_unit_energy%conv, &
           & (Tion_t(iiter)+Ework_integ_fdR(iiter)+Enh_t(iiter)) * t_unit_energy%conv

--- a/src/ARTED/control/md_gs.f90
+++ b/src/ARTED/control/md_gs.f90
@@ -241,7 +241,7 @@ end subroutine calc_md_ground_state
               & 10, "Temperature_ion", "K"
       endif
 
-      write(fh_rt, "(F16.8,99(1X,ES22.14E3))") &
+      write(fh_rt, "(F16.8,99(1X,E23.15E3))") &
           & it * dt    * t_unit_time%conv, &
           & Tion_gs_t  * t_unit_energy%conv, &
           & Vion_gs_t  * t_unit_energy%conv, &


### PR DESCRIPTION
In this pull request, the output format of the floating point number is changed from `ES22*` to `E23*`. It solves the problem in PGI Fortran environment to write the real number which is much smaller than 1E-99.

  