### PR TITLE
Fixed OpenMP reduction error.

### DIFF
--- a/src/ARTED/common/ion_force.f90
+++ b/src/ARTED/common/ion_force.f90
@@ -44,6 +44,7 @@ contains
     use timer
     use salmon_math
     use projector
+    use opt_variables, only: NUMBER_THREADS_POW2
     implicit none
     logical,intent(in)       :: Rion_update
     integer,intent(in)       :: zu_NB
@@ -61,9 +62,10 @@ contains
     complex(8), allocatable :: dzudr(:,:,:,:)
 
     integer :: tid
-    real(8) :: ftmp_t(3,NI,0:NUMBER_THREADS-1)
+    real(8) :: ftmp_t(3,NI,0:NUMBER_THREADS_POW2-1)
 
     allocate(dzudr(3,NL,zu_NB,NK_s:NK_e))
+    ftmp_t(:,:,:) = 0.d0
 
 
     !flag_use_grad_wf_on_force is given in Gloval_Variable

--- a/src/ARTED/modules/opt_variables.f90
+++ b/src/ARTED/modules/opt_variables.f90
@@ -16,6 +16,8 @@
 module opt_variables
   implicit none
 
+  integer :: NUMBER_THREADS_POW2
+
   real(8) :: lapt(12)
 
   integer                :: PNLx,PNLy,PNLz,PNL
@@ -90,8 +92,9 @@ contains
         call err_finalize('functional: TPSS/VS98 versions not implemented.')
     end select
 
+    NUMBER_THREADS_POW2 = ceiling_pow2(NUMBER_THREADS)
 #ifdef ARTED_REDUCE_FOR_MANYCORE
-    tid_range = ceiling_pow2(NUMBER_THREADS) - 1
+    tid_range = NUMBER_THREADS_POW2 - 1
 #else
     tid_range = 0
 #endif


### PR DESCRIPTION
In ARTED part, SALMON outputs `NaN` error in GS calculation (forces on atoms) when executing number of thread is not power of two. I fixed it.
