### PR TITLE
Fix initialization problem of rho_nlcc in ARTED part

### DIFF
--- a/src/ARTED/common/Exc_Cor.f90
+++ b/src/ARTED/common/Exc_Cor.f90
@@ -53,7 +53,6 @@ subroutine exec_salmon_xc_lda()
   real(8) :: rho_tmp(NL, 1, 1)
   real(8) :: eexc_tmp(NL, 1, 1)
   real(8) :: vexc_tmp(NL, 1, 1)
-  real(8) :: rho_nlcc(NL, 1, 1)
   real(8) :: rho_nlcc_tmp(NL, 1, 1)
   
   rho_tmp = reshape(rho, (/NL, 1, 1/))


### PR DESCRIPTION
This pull request provides a bugfix in the exchange-correlation calculation in ARTED part. I found an initialization error of the NLCC (nonlocal core correction) charge densities. Due to this problem, the present version causes the NaN overflow when a certain pseudopotential (which uses NLCC) is employed. 