### PR TITLE
Skip the atomic coordinates section in the input file for classical electromagnetic problem

### DIFF
--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -1234,7 +1234,7 @@ contains
     call comm_bcast(if_cartesian,nproc_group_global)
     call comm_bcast(iflag_atom_coor,nproc_group_global)
 
-    if(icount/=1)then
+    if(0 < natom .and. icount/=1)then
        if (comm_is_root(nproc_id_global))then
          write(*,"(A)")'Error in input: The following inputs are incompatible.'
          write(*,"(A)")'file_atom_coor, file_atom_red_coor, &atomic_coor, and &atomic_red_coor.'


### PR DESCRIPTION
This pull request contains a small modification which skip to read `atom_(red_)?coor`  section in the input file if the number of atom `natom` is specified to 0.  This change makes possible to simplify the input file when we use the classical electromagnetic problem which does not use the atomic structure.
