### PR TITLE
Fixed compile error due to fortran free/fixed format.

### DIFF
--- a/gnu_makefiles/Makefile.gnu
+++ b/gnu_makefiles/Makefile.gnu
@@ -3,7 +3,7 @@
 TARGET = salmon.cpu
 FC = mpif90
 CC = mpicc
-FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-line-length-none
+FFLAGS = -O3 -fopenmp -Wall -cpp
 CFLAGS = -O3 -fopenmp -Wall
 LIBLAPACK = -llapack -lblas
 #LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5 -lm

--- a/gnu_makefiles/Makefile.gnu
+++ b/gnu_makefiles/Makefile.gnu
@@ -3,7 +3,7 @@
 TARGET = salmon.cpu
 FC = mpif90
 CC = mpicc
-FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-form -ffree-line-length-none
+FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-line-length-none
 CFLAGS = -O3 -fopenmp -Wall
 LIBLAPACK = -llapack -lblas
 #LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5 -lm

--- a/gnu_makefiles/Makefile.gnu-without-mpi
+++ b/gnu_makefiles/Makefile.gnu-without-mpi
@@ -3,7 +3,7 @@
 TARGET = salmon.cpu
 FC = gfortran
 CC = gcc
-FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-form -ffree-line-length-none
+FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-line-length-none
 CFLAGS = -O3 -fopenmp -Wall
 LIBLAPACK = -llapack -lblas
 #LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5 -lm

--- a/gnu_makefiles/Makefile.gnu-without-mpi
+++ b/gnu_makefiles/Makefile.gnu-without-mpi
@@ -3,7 +3,7 @@
 TARGET = salmon.cpu
 FC = gfortran
 CC = gcc
-FFLAGS = -O3 -fopenmp -Wall -cpp -ffree-line-length-none
+FFLAGS = -O3 -fopenmp -Wall -cpp
 CFLAGS = -O3 -fopenmp -Wall
 LIBLAPACK = -llapack -lblas
 #LIBLAPACK = -lmkl_intel_thread -lmkl_intel_lp64 -lmkl_core -lpthread -ldl -liomp5 -lm

--- a/src/ARTED/GS/io_gs_wfn_k.f90
+++ b/src/ARTED/GS/io_gs_wfn_k.f90
@@ -535,7 +535,8 @@ contains
           Rion_eq_m(:,:,imacro)  = Rion_m(:,:,imacro)
           velocity_m(:,:,imacro) = velocity(:,:)
 
-          call comm_summation(energy_joule_ms_tmp,energy_joule_ms,(nx2_m-nx1_m+1)*(ny2_m-ny1_m+1)*(nz2_m-nz1_m+1),nproc_group_global)
+          call comm_summation(energy_joule_ms_tmp,energy_joule_ms,&
+                             &(nx2_m-nx1_m+1)*(ny2_m-ny1_m+1)*(nz2_m-nz1_m+1),nproc_group_global)
           call comm_bcast(add_Ac_ms,     nproc_group_global)
           call comm_bcast(add_Ac_new_ms, nproc_group_global)
           call comm_bcast(Jm_new_ms,     nproc_group_global)


### PR DESCRIPTION
Fortran compiler detects the free/fixed format in each source file automatically.
But GCC `-ffree-form` option interprets that all source files are the free format even fortran77 file.

GNU Makefile for GCC happens compile error in FFTE extension (fortran77 file), I fixed it.
In addition, I fixed the compile error due to column length in the free form.