### PR TITLE
remove communicator

### DIFF
--- a/src/GCEED/modules/new_world.f90
+++ b/src/GCEED/modules/new_world.f90
@@ -93,10 +93,6 @@ end if
 nproc_group_kgrid = comm_create_group(nproc_group_global, icolor, ikey)
 call comm_get_groupinfo(nproc_group_kgrid, nproc_id_kgrid, nproc_size_kgrid)
 
-if(iobnum==0) icolor=icolor+nproc_Mxin_mul*nproc_k
-nproc_group_kgrid_except0 = comm_create_group(nproc_group_global, icolor, ikey)
-call comm_get_groupinfo(nproc_group_kgrid_except0, nproc_id_kgrid_except0, nproc_size_kgrid_except0)
-
 !only for identifying spin
 !new_world for comm_spin
 if(isequential==1)then

--- a/src/parallel/salmon_parallel.f90
+++ b/src/parallel/salmon_parallel.f90
@@ -59,10 +59,6 @@ module salmon_parallel
   integer, public :: nproc_id_h
   integer, public :: nproc_size_h
 
-  integer, public :: nproc_group_kgrid_except0
-  integer, public :: nproc_id_kgrid_except0
-  integer, public :: nproc_size_kgrid_except0
-
   integer, public :: nproc_group_korbital_vhxc
   integer, public :: nproc_id_korbital_vhxc
   integer, public :: nproc_size_korbital_vhxc


### PR DESCRIPTION
Communicator "nproc_group_kgrid_except0" is not used in whole program. On a FX machine, the run fails around the part which makes this communicator when debug option "-g -H aefosux" is specified. So I remove. 