### PR TITLE
Fixed runtime error when running single node (non-MPI) version.

### DIFF
--- a/src/GCEED/modules/init_sendrecv.f90
+++ b/src/GCEED/modules/init_sendrecv.f90
@@ -41,12 +41,34 @@ real(8),allocatable :: rmatbox4_x_h(:,:,:),rmatbox4_y_h(:,:,:),rmatbox4_z_h(:,:,
 complex(8),allocatable :: cmatbox1_x_h(:,:,:),cmatbox1_y_h(:,:,:),cmatbox1_z_h(:,:,:)
 complex(8),allocatable :: cmatbox2_x_h(:,:,:),cmatbox2_y_h(:,:,:),cmatbox2_z_h(:,:,:)
 
+public  :: init_updown
+public  :: init_itype
+public  :: init_sendrecv_matrix
+private :: init_updown_detail
+
 CONTAINS
 
 !=======================================================================
 !=======================================================================
 
-SUBROUTINE init_updown
+subroutine init_updown
+  use salmon_parallel
+  use salmon_communication, only: comm_proc_null
+  implicit none
+
+  if (is_distributed_parallel()) then
+    call init_updown_detail
+  else
+    iup_array(:) = comm_proc_null
+    idw_array(:) = comm_proc_null
+    jup_array(:) = comm_proc_null
+    jdw_array(:) = comm_proc_null
+    kup_array(:) = comm_proc_null
+    kdw_array(:) = comm_proc_null
+  end if
+end subroutine
+
+SUBROUTINE init_updown_detail
 use inputoutput, only: iperiodic
 use salmon_parallel
 use salmon_communication, only: comm_proc_null
@@ -367,7 +389,7 @@ if(isequential==2)then
   end if
 end if
 
-END SUBROUTINE init_updown
+END SUBROUTINE init_updown_detail
 
 !=====================================================================
 subroutine init_itype

--- a/src/parallel/salmon_communication.f90
+++ b/src/parallel/salmon_communication.f90
@@ -284,7 +284,10 @@ contains
     implicit none
     integer, intent(in) :: ngid, nprocs, key
     integer :: ngid_dst
-    ngid_dst = ngid + key * nprocs
+    UNUSED_VARIABLE(ngid)
+    UNUSED_VARIABLE(nprocs)
+    UNUSED_VARIABLE(key)
+    ngid_dst = COMM_WORLD_ID
 #endif
   end function
 

--- a/src/parallel/salmon_parallel.f90
+++ b/src/parallel/salmon_parallel.f90
@@ -94,6 +94,7 @@ module salmon_parallel
 
   ! util
   public :: get_thread_id
+  public :: is_distributed_parallel ! check MPI parallelization is enabled
 
 contains
   subroutine setup_parallel
@@ -120,5 +121,11 @@ contains
 #else
     nid = 0
 #endif
+  end function
+
+  function is_distributed_parallel() result(ret)
+    implicit none
+    logical :: ret
+    ret = (nproc_size_global > 1)
   end function
 end module


### PR DESCRIPTION
I found the runtime error in `testsuites 111, 112, and 113` when running single node (non-MPI) version.
This PR fixed the communicator initialization in `src/GCEED/modules/init_sendrecv.f90`, but `testsuites 112 and 113` with non-MPI version failed at the verification phase...