### PR TITLE
Fixed strange runtime errors in several environments.

### DIFF
--- a/src/ARTED/FDTD/FDTD.f90
+++ b/src/ARTED/FDTD/FDTD.f90
@@ -380,7 +380,7 @@ subroutine dt_evolve_Ac_1d
 
   iz_m = nz_origin_m
   iy_m = ny_origin_m
-!$omp parallel do default(shared) private(ix_m)
+!$omp parallel do default(shared) private(ix_m,rr)
   do ix_m = nx1_m, nx2_m
     rr(1) = 0d0
     rr(2:3) = -( &

--- a/src/GCEED/common/exc_cor_ns.f90
+++ b/src/GCEED/common/exc_cor_ns.f90
@@ -128,7 +128,8 @@ subroutine exc_cor_ns
     end do
     end do
   end if
- 
+
+  tot_exc=0.d0
   do iz=1,ng_num(3)
   do iy=1,ng_num(2)
   do ix=1,ng_num(1)

--- a/src/GCEED/modules/CMakeLists.txt
+++ b/src/GCEED/modules/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     rmmdiis_eigen_lapack.f90
     scf_data.f90
     sendrecv.f90
+    sendrecv_self.f90
     sendrecv_tmp.f90
     sendrecv_groupob.f90
     sendrecv_groupob_ngp.f90

--- a/src/GCEED/modules/persistent_comm.f90
+++ b/src/GCEED/modules/persistent_comm.f90
@@ -38,18 +38,27 @@ contains
   subroutine init_comm_korbital
     use init_sendrecv_sub,    only: iup_array,idw_array,jup_array,jdw_array,kup_array,kdw_array
     use salmon_parallel,      only: icomm => nproc_group_korbital
-    use salmon_communication, only: comm_send_init, comm_recv_init
+    use salmon_communication, only: comm_send_init, comm_recv_init, comm_proc_null
     use pack_unpack,          only: create_array_shape
     use scf_data
     implicit none
     integer :: iup,idw,jup,jdw,kup,kdw
 
+#ifdef SALMON_USE_MPI
     iup=iup_array(1)
     idw=idw_array(1)
     jup=jup_array(1)
     jdw=jdw_array(1)
     kup=kup_array(1)
     kdw=kdw_array(1)
+#else
+    iup=comm_proc_null
+    idw=comm_proc_null
+    jup=comm_proc_null
+    jdw=comm_proc_null
+    kup=comm_proc_null
+    kdw=comm_proc_null
+#endif
 
     allocate(nreqs_rorbital(12))
     nreqs_rorbital( 1) = comm_send_init(srmatbox1_x_3d,iup,3,icomm)
@@ -88,18 +97,27 @@ contains
   subroutine init_comm_groupob
     use init_sendrecv_sub,    only: iup_array,idw_array,jup_array,jdw_array,kup_array,kdw_array
     use salmon_parallel,      only: icomm => nproc_group_korbital
-    use salmon_communication, only: comm_send_init, comm_recv_init
+    use salmon_communication, only: comm_send_init, comm_recv_init, comm_proc_null
     use pack_unpack,          only: create_array_shape
     use scf_data
     implicit none
     integer :: iup,idw,jup,jdw,kup,kdw
 
+#ifdef SALMON_USE_MPI
     iup=iup_array(1)
     idw=idw_array(1)
     jup=jup_array(1)
     jdw=jdw_array(1)
     kup=kup_array(1)
     kdw=kdw_array(1)
+#else
+    iup=comm_proc_null
+    idw=comm_proc_null
+    jup=comm_proc_null
+    jdw=comm_proc_null
+    kup=comm_proc_null
+    kdw=comm_proc_null
+#endif
 
     if(iSCFRT==1.and.icalcforce==1)then
       allocate(nreqs_rgroupob(12))
@@ -203,19 +221,28 @@ contains
   subroutine init_reqs_h(ireqs,itype)
     use init_sendrecv_sub
     use salmon_parallel,      only: nproc_group_global, nproc_group_h
-    use salmon_communication, only: comm_send_init, comm_recv_init
+    use salmon_communication, only: comm_send_init, comm_recv_init, comm_proc_null
     implicit none
     integer, intent(out) :: ireqs(12)
     integer, intent(in)  :: itype
     integer :: icomm
     integer :: iup,idw,jup,jdw,kup,kdw
 
+#ifdef SALMON_USE_MPI
     iup=iup_array(itype)
     idw=idw_array(itype)
     jup=jup_array(itype)
     jdw=jdw_array(itype)
     kup=kup_array(itype)
     kdw=kdw_array(itype)
+#else
+    iup=comm_proc_null
+    idw=comm_proc_null
+    jup=comm_proc_null
+    jdw=comm_proc_null
+    kup=comm_proc_null
+    kdw=comm_proc_null
+#endif
 
     if (itype == 1) then
       icomm = nproc_group_global

--- a/src/GCEED/modules/sendrecv_groupob_tmp.f90
+++ b/src/GCEED/modules/sendrecv_groupob_tmp.f90
@@ -18,6 +18,7 @@ module sendrecv_groupob_tmp_sub
 use scf_data
 use new_world_sub
 use init_sendrecv_sub
+use sendrecv_self_sub
 
 interface sendrecv_groupob_tmp
 
@@ -30,7 +31,7 @@ contains
 !==================================================================================================
 
 subroutine R_sendrecv_groupob_tmp(tpsi)
-use salmon_parallel, only: nproc_group_korbital
+use salmon_parallel, only: nproc_group_korbital, is_distributed_parallel
 use salmon_communication, only: comm_proc_null, comm_isend, comm_irecv, comm_wait_all
 implicit none
 real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
@@ -39,6 +40,15 @@ integer :: ix,iy,iz,iob,iik
 integer :: iup,idw,jup,jdw,kup,kdw
 integer :: ireq(12)
 integer :: icomm
+
+if (.not. is_distributed_parallel()) then
+  do iik=k_sta,k_end
+  do iob=1,iobnum
+    call sendrecv_self(tpsi(:,:,:,iob,iik),1)
+  end do
+  end do
+  return
+end if
 
 iup=iup_array(1)
 idw=idw_array(1)
@@ -265,7 +275,7 @@ end subroutine R_sendrecv_groupob_tmp
 !==================================================================================================
 
 subroutine C_sendrecv_groupob_tmp(tpsi)
-use salmon_parallel, only: nproc_group_korbital
+use salmon_parallel, only: nproc_group_korbital, is_distributed_parallel
 use salmon_communication, only: comm_proc_null, comm_isend, comm_irecv, comm_wait_all
 implicit none
 complex(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+1,mg_sta(2)-Nd:mg_end(2)+Nd, &
@@ -274,6 +284,15 @@ integer :: ix,iy,iz,iob,iik
 integer :: iup,idw,jup,jdw,kup,kdw
 integer :: icomm
 integer :: ireq(12)
+
+if (.not. is_distributed_parallel()) then
+  do iik=k_sta,k_end
+  do iob=1,iobnum
+    call sendrecv_self(tpsi(:,:,:,iob,iik),1)
+  end do
+  end do
+  return
+end if
 
 iup=iup_array(1)
 idw=idw_array(1)

--- a/src/GCEED/modules/sendrecv_self.f90
+++ b/src/GCEED/modules/sendrecv_self.f90
@@ -1,0 +1,186 @@
+!
+!  Copyright 2017 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+module sendrecv_self_sub
+
+  use scf_data
+  use new_world_sub
+  use init_sendrecv_sub
+  
+  interface sendrecv_self
+  
+    module procedure R_sendrecv_self, C_sendrecv_self
+  
+  end interface 
+
+contains
+
+!==================================================================================================
+
+subroutine R_sendrecv_self(tpsi,padding)
+  implicit none
+  integer :: padding
+  real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+padding, &
+                  mg_sta(2)-Nd:mg_end(2)+Nd, &
+                  mg_sta(3)-Nd:mg_end(3)+Nd)
+  integer :: ix,iy,iz
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,mg_num(3)
+  do iy=1,mg_num(2)
+  do ix=1,Nd
+    tpsi(mg_sta(1)-1-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1) = &
+    tpsi(mg_end(1)  -Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,mg_num(3)
+  do iy=1,mg_num(2)
+  do ix=1,Nd
+    tpsi(mg_end(1)+ix,  iy+mg_sta(2)-1,iz+mg_sta(3)-1) = &
+    tpsi(mg_sta(1)+ix-1,iy+mg_sta(2)-1,iz+mg_sta(3)-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,mg_num(3)
+  do iy=1,Nd
+  do ix=1,mg_num(1)
+    tpsi(ix+mg_sta(1)-1,mg_sta(2)-1-Nd+iy,iz+mg_sta(3)-1) = &
+    tpsi(ix+mg_sta(1)-1,mg_end(2)  -Nd+iy,iz+mg_sta(3)-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,mg_num(3)
+  do iy=1,Nd
+  do ix=1,mg_num(1)
+    tpsi(ix+mg_sta(1)-1,mg_end(2)+iy,  iz+mg_sta(3)-1) = &
+    tpsi(ix+mg_sta(1)-1,mg_sta(2)+iy-1,iz+mg_sta(3)-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,Nd
+  do iy=1,mg_num(2)
+  do ix=1,mg_num(1)
+    tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz) = &
+    tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)  -Nd+iz)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,Nd
+  do iy=1,mg_num(2)
+  do ix=1,mg_num(1)
+    tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz  ) = &
+    tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+end subroutine R_sendrecv_self
+
+!==================================================================================================
+
+subroutine C_sendrecv_self(tpsi,padding)
+  implicit none
+  integer    :: padding
+  complex(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd+padding, &
+                     mg_sta(2)-Nd:mg_end(2)+Nd, &
+                     mg_sta(3)-Nd:mg_end(3)+Nd)
+  integer :: ix,iy,iz
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,mg_num(3)
+  do iy=1,mg_num(2)
+  do ix=1,Nd
+    tpsi(mg_sta(1)-1-Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1) = &
+    tpsi(mg_end(1)  -Nd+ix,iy+mg_sta(2)-1,iz+mg_sta(3)-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,mg_num(3)
+  do iy=1,mg_num(2)
+  do ix=1,Nd
+    tpsi(mg_end(1)+ix,  iy+mg_sta(2)-1,iz+mg_sta(3)-1) = &
+    tpsi(mg_sta(1)+ix-1,iy+mg_sta(2)-1,iz+mg_sta(3)-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,mg_num(3)
+  do iy=1,Nd
+  do ix=1,mg_num(1)
+    tpsi(ix+mg_sta(1)-1,mg_sta(2)-1-Nd+iy,iz+mg_sta(3)-1) = &
+    tpsi(ix+mg_sta(1)-1,mg_end(2)  -Nd+iy,iz+mg_sta(3)-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,mg_num(3)
+  do iy=1,Nd
+  do ix=1,mg_num(1)
+    tpsi(ix+mg_sta(1)-1,mg_end(2)+iy,  iz+mg_sta(3)-1) = &
+    tpsi(ix+mg_sta(1)-1,mg_sta(2)+iy-1,iz+mg_sta(3)-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,Nd
+  do iy=1,mg_num(2)
+  do ix=1,mg_num(1)
+    tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)-1-Nd+iz) = &
+    tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)  -Nd+iz)
+  end do
+  end do
+  end do
+!$omp end parallel do
+
+!$omp parallel do default(none) private(iz,iy,ix) shared(mg_sta,mg_end,mg_num,tpsi)
+  do iz=1,Nd
+  do iy=1,mg_num(2)
+  do ix=1,mg_num(1)
+    tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_end(3)+iz  ) = &
+    tpsi(ix+mg_sta(1)-1,iy+mg_sta(2)-1,mg_sta(3)+iz-1)
+  end do
+  end do
+  end do
+!$omp end parallel do
+end subroutine C_sendrecv_self
+
+!==================================================================================================
+
+end module sendrecv_self_sub

--- a/src/GCEED/modules/sendrecv_tmp.f90
+++ b/src/GCEED/modules/sendrecv_tmp.f90
@@ -18,6 +18,7 @@ module sendrecv_tmp_sub
   use scf_data
   use new_world_sub
   use init_sendrecv_sub
+  use sendrecv_self_sub
   
   interface sendrecv_tmp
   
@@ -30,7 +31,7 @@ contains
 !==================================================================================================
 
 subroutine R_sendrecv_tmp(tpsi)
-  use salmon_parallel, only: nproc_group_korbital
+  use salmon_parallel, only: nproc_group_korbital, is_distributed_parallel
   use salmon_communication, only: comm_proc_null, comm_isend, comm_irecv, comm_wait_all
   implicit none
   real(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd,mg_sta(2)-Nd:mg_end(2)+Nd, &
@@ -39,6 +40,11 @@ subroutine R_sendrecv_tmp(tpsi)
   integer :: iup,idw,jup,jdw,kup,kdw
   integer :: ireq(12)
   integer :: icomm
+
+  if (.not. is_distributed_parallel()) then
+    call sendrecv_self(tpsi,0)
+    return
+  end if
   
   iup=iup_array(1)
   idw=idw_array(1)
@@ -217,7 +223,7 @@ end subroutine R_sendrecv_tmp
 !==================================================================================================
 
 subroutine C_sendrecv_tmp(tpsi)
-  use salmon_parallel, only: nproc_group_korbital
+  use salmon_parallel, only: nproc_group_korbital, is_distributed_parallel
   use salmon_communication, only: comm_proc_null, comm_isend, comm_irecv, comm_wait_all
   implicit none
   complex(8) :: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd,mg_sta(2)-Nd:mg_end(2)+Nd, &
@@ -226,6 +232,11 @@ subroutine C_sendrecv_tmp(tpsi)
   integer :: iup,idw,jup,jdw,kup,kdw
   integer :: icomm
   integer :: ireq(12)
+
+  if (.not. is_distributed_parallel()) then
+    call sendrecv_self(tpsi,0)
+    return
+  end if
   
   iup=iup_array(1)
   idw=idw_array(1)

--- a/src/atom/prep_pp.f90
+++ b/src/atom/prep_pp.f90
@@ -329,8 +329,8 @@ subroutine calc_uv(pp,save_udvtbl_a,save_udvtbl_b,save_udvtbl_c,save_udvtbl_d,uv
     end do
     endif
 
-!$omp parallel
-!$omp do private(j,x,y,z,r,ir,intr,xx,l,lm,m,uvr,duvr,ilma)
+!$omp parallel private(j,x,y,z,r,ir,intr,xx,l,lm,m,uvr,duvr,ilma)
+!$omp do
     do j=1,mps(a)
       x=lx(jxyz(j,a))*hx-(rion(1,a)+jxx(j,a)*alx)
       y=ly(jxyz(j,a))*hy-(rion(2,a)+jyy(j,a)*aly)

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -1619,7 +1619,7 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",I4)') 'num_rgrid(3)', num_rgrid(3)
 
       if(inml_kgrid >0)ierr_nml = ierr_nml +1
-      write(fh_variables_log, '("#namelist: ",A,", status=",I1)') 'kgrid', inml_kgrid
+      write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'kgrid', inml_kgrid
       write(fh_variables_log, '("#",4X,A,"=",I4)') 'num_kgrid(1)', num_kgrid(1)
       write(fh_variables_log, '("#",4X,A,"=",I4)') 'num_kgrid(2)', num_kgrid(2)
       write(fh_variables_log, '("#",4X,A,"=",I4)') 'num_kgrid(3)', num_kgrid(3)

--- a/src/parallel/salmon_communication.f90
+++ b/src/parallel/salmon_communication.f90
@@ -522,8 +522,8 @@ contains
     UNUSED_VARIABLE(invalue)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
     ABORT_MESSAGE(ndest,"comm_isend_array3d_double")
+    req = 0
 #endif
   end function
 
@@ -545,8 +545,8 @@ contains
     UNUSED_VARIABLE(invalue)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
     ABORT_MESSAGE(ndest,"comm_isend_array3d_dcomplex")
+    req = 0
 #endif
   end function
 
@@ -568,8 +568,8 @@ contains
     UNUSED_VARIABLE(invalue)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
     ABORT_MESSAGE(ndest,"comm_isend_array5d_double")
+    req = 0
 #endif
   end function
 
@@ -591,8 +591,8 @@ contains
     UNUSED_VARIABLE(invalue)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
     ABORT_MESSAGE(ndest,"comm_isend_array5d_dcomplex")
+    req = 0
 #endif
   end function
 
@@ -614,8 +614,8 @@ contains
     UNUSED_VARIABLE(outvalue)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
     ABORT_MESSAGE(nsrc,"comm_irecv_array3d_double")
+    req = 0
 #endif
   end function
 
@@ -637,8 +637,8 @@ contains
     UNUSED_VARIABLE(outvalue)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
     ABORT_MESSAGE(nsrc,"comm_irecv_array3d_dcomplex")
+    req = 0
 #endif
   end function
 
@@ -660,8 +660,8 @@ contains
     UNUSED_VARIABLE(outvalue)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
     ABORT_MESSAGE(nsrc,"comm_irecv_array5d_double")
+    req = 0
 #endif
   end function
 
@@ -683,8 +683,8 @@ contains
     UNUSED_VARIABLE(outvalue)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
     ABORT_MESSAGE(nsrc,"comm_irecv_array5d_dcomplex")
+    req = 0
 #endif
   end function
 
@@ -736,7 +736,7 @@ contains
     UNUSED_VARIABLE(ndest)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
+    req = 0
 #endif
   end function
 
@@ -757,7 +757,7 @@ contains
     UNUSED_VARIABLE(ndest)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
+    req = 0
 #endif
   end function
 
@@ -778,7 +778,7 @@ contains
     UNUSED_VARIABLE(ndest)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
+    req = 0
 #endif
   end function
 
@@ -799,7 +799,7 @@ contains
     UNUSED_VARIABLE(ndest)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
+    req = 0
 #endif
   end function
 
@@ -820,7 +820,7 @@ contains
     UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
+    req = 0
 #endif
   end function
 
@@ -841,7 +841,7 @@ contains
     UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
+    req = 0
 #endif
   end function
 
@@ -862,7 +862,7 @@ contains
     UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
+    req = 0
 #endif
   end function
 
@@ -883,7 +883,7 @@ contains
     UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    UNUSED_VARIABLE(req)
+    req = 0
 #endif
   end function
 

--- a/src/parallel/salmon_communication.f90
+++ b/src/parallel/salmon_communication.f90
@@ -27,7 +27,8 @@ module salmon_communication
 #else
   integer, public, parameter  :: ROOT_PROCID    = 0
   integer, public, parameter  :: COMM_PROC_NULL = int(z'0000BEEF')
-  integer, private, parameter :: COMM_WORLD_ID  = int(z'000ABEEF')
+  integer, private, parameter :: COMM_WORLD_ID  = COMM_PROC_NULL
+  integer, private, parameter :: DEAD_BEAF      = int(z'0000DEAD')
 #endif
 
   ! call once
@@ -317,7 +318,11 @@ contains
     implicit none
     integer, intent(in), optional :: ngid
     UNUSED_VARIABLE(ngid)
-    ! do nothing
+    if (present(ngid)) then
+      ABORT_MESSAGE(ngid,"comm_sync_all")
+    else
+      ! do nothing
+    end if
 #endif
   end subroutine
 
@@ -699,8 +704,7 @@ contains
 #else
     implicit none
     integer, intent(in) :: req
-    UNUSED_VARIABLE(req)
-    ! do nothing
+    ABORT_MESSAGE(req,"comm_wait")
 #endif
   end subroutine
 
@@ -733,10 +737,10 @@ contains
     integer, intent(in) :: ndest, ntag, ngroup
     integer :: req
     UNUSED_VARIABLE(invalue)
-    UNUSED_VARIABLE(ndest)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    req = 0
+    ABORT_MESSAGE(ndest,"comm_send_init_array3d_double")
+    req = DEAD_BEAF
 #endif
   end function
 
@@ -754,10 +758,10 @@ contains
     integer, intent(in)    :: ndest, ntag, ngroup
     integer :: req
     UNUSED_VARIABLE(invalue)
-    UNUSED_VARIABLE(ndest)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    req = 0
+    ABORT_MESSAGE(ndest,"comm_send_init_array3d_dcomplex")
+    req = DEAD_BEAF
 #endif
   end function
 
@@ -775,10 +779,10 @@ contains
     integer, intent(in) :: ndest, ntag, ngroup
     integer :: req
     UNUSED_VARIABLE(invalue)
-    UNUSED_VARIABLE(ndest)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    req = 0
+    ABORT_MESSAGE(ndest,"comm_send_init_array5d_double")
+    req = DEAD_BEAF
 #endif
   end function
 
@@ -796,10 +800,10 @@ contains
     integer, intent(in)    :: ndest, ntag, ngroup
     integer :: req
     UNUSED_VARIABLE(invalue)
-    UNUSED_VARIABLE(ndest)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    req = 0
+    ABORT_MESSAGE(ndest,"comm_send_init_array5d_dcomplex")
+    req = DEAD_BEAF
 #endif
   end function
 
@@ -817,10 +821,10 @@ contains
     integer, intent(in)  :: nsrc, ntag, ngroup
     integer :: req
     UNUSED_VARIABLE(outvalue)
-    UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    req = 0
+    ABORT_MESSAGE(nsrc,"comm_recv_init_array3d_double")
+    req = DEAD_BEAF
 #endif
   end function
 
@@ -838,10 +842,10 @@ contains
     integer, intent(in)     :: nsrc, ntag, ngroup
     integer :: req
     UNUSED_VARIABLE(outvalue)
-    UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    req = 0
+    ABORT_MESSAGE(nsrc,"comm_recv_init_array3d_dcomplex")
+    req = DEAD_BEAF
 #endif
   end function
 
@@ -859,10 +863,10 @@ contains
     integer, intent(in)  :: nsrc, ntag, ngroup
     integer :: req
     UNUSED_VARIABLE(outvalue)
-    UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    req = 0
+    ABORT_MESSAGE(nsrc,"comm_recv_init_array5d_double")
+    req = DEAD_BEAF
 #endif
   end function
 
@@ -880,10 +884,10 @@ contains
     integer, intent(in)     :: nsrc, ntag, ngroup
     integer :: req
     UNUSED_VARIABLE(outvalue)
-    UNUSED_VARIABLE(nsrc)
     UNUSED_VARIABLE(ntag)
     UNUSED_VARIABLE(ngroup)
-    req = 0
+    ABORT_MESSAGE(nsrc,"comm_recv_init_array5d_dcomplex")
+    req = DEAD_BEAF
 #endif
   end function
 
@@ -897,6 +901,7 @@ contains
     implicit none
     integer, intent(in) :: reqs(:)
     UNUSED_VARIABLE(reqs)
+    ! do nothing
 #endif
   end subroutine
 
@@ -921,8 +926,8 @@ contains
     integer, intent(out) :: outvalue
     integer, intent(in)  :: ngroup
     integer, optional, intent(in) :: dest
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_integer")
     outvalue = invalue
 #endif
   end subroutine
@@ -947,8 +952,8 @@ contains
     real(8), intent(out) :: outvalue
     integer, intent(in)  :: ngroup
     integer, optional, intent(in) :: dest
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_double")
     outvalue = invalue
 #endif
   end subroutine
@@ -973,8 +978,8 @@ contains
     complex(8), intent(out) :: outvalue
     integer, intent(in)     :: ngroup
     integer, optional, intent(in) :: dest
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_dcomplex")
     outvalue = invalue
 #endif
   end subroutine
@@ -1000,8 +1005,8 @@ contains
     integer, intent(in)  :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array1d_integer")
     outvalue = invalue
 #endif
   end subroutine
@@ -1027,8 +1032,8 @@ contains
     integer, intent(in)  :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array1d_double")
     outvalue = invalue
 #endif
   end subroutine
@@ -1054,8 +1059,8 @@ contains
     integer, intent(in)     :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array1d_dcomplex")
     outvalue = invalue
 #endif
   end subroutine
@@ -1081,8 +1086,8 @@ contains
     integer, intent(in)  :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array2d_integer")
     outvalue = invalue
 #endif
   end subroutine
@@ -1108,8 +1113,8 @@ contains
     integer, intent(in)  :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array2d_double")
     outvalue = invalue
 #endif
   end subroutine
@@ -1135,8 +1140,8 @@ contains
     integer, intent(in)     :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array2d_dcomplex")
     outvalue = invalue
 #endif
   end subroutine
@@ -1162,8 +1167,8 @@ contains
     integer, intent(in)  :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array3d_integer")
     outvalue = invalue
 #endif
   end subroutine
@@ -1189,8 +1194,8 @@ contains
     integer, intent(in)  :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array3d_double")
     outvalue = invalue
 #endif
   end subroutine
@@ -1216,8 +1221,8 @@ contains
     integer, intent(in)     :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array3d_dcomplex")
     outvalue = invalue
 #endif
   end subroutine
@@ -1243,8 +1248,8 @@ contains
     integer, intent(in)  :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array4d_double")
     outvalue = invalue
 #endif
   end subroutine
@@ -1270,8 +1275,8 @@ contains
     integer, intent(in)     :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array4d_dcomplex")
     outvalue = invalue
 #endif
   end subroutine
@@ -1297,8 +1302,8 @@ contains
     integer, intent(in)  :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array5d_double")
     outvalue = invalue
 #endif
   end subroutine
@@ -1324,8 +1329,8 @@ contains
     integer, intent(in)     :: N, ngroup
     integer, optional, intent(in) :: dest
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(dest)
+    ABORT_MESSAGE(ngroup,"comm_summation_array5d_dcomplex")
     outvalue = invalue
 #endif
   end subroutine
@@ -1351,9 +1356,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_integer")
 #endif
   end subroutine
 
@@ -1377,9 +1381,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_double")
 #endif
   end subroutine
 
@@ -1403,9 +1406,8 @@ contains
     integer,      intent(in)           :: ngroup
     integer,      intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_character")
 #endif
   end subroutine
 
@@ -1429,9 +1431,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_logical")
 #endif
   end subroutine
 
@@ -1455,9 +1456,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_array1d_integer")
 #endif
   end subroutine
 
@@ -1481,9 +1481,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_array1d_double")
 #endif
   end subroutine
 
@@ -1507,9 +1506,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_array2d_integer")
 #endif
   end subroutine
 
@@ -1533,9 +1531,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_array2d_double")
 #endif
   end subroutine
 
@@ -1559,9 +1556,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_array3d_double")
 #endif
   end subroutine
   
@@ -1585,9 +1581,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_array4d_double")
 #endif
   end subroutine
 
@@ -1611,9 +1606,8 @@ contains
     integer, intent(in)           :: ngroup
     integer, intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_array3d_dcomplex")
 #endif
   end subroutine
 
@@ -1637,9 +1631,8 @@ contains
     integer,      intent(in)           :: ngroup
     integer,      intent(in), optional :: root
     UNUSED_VARIABLE(val)
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(root)
-    ! do nothing
+    ABORT_MESSAGE(ngroup,"comm_bcast_array1d_character")
 #endif
   end subroutine
 
@@ -1665,7 +1658,7 @@ contains
     integer, intent(in)  :: ncounts(:)
     integer, intent(in)  :: displs(:)
     integer, intent(in)  :: ngroup
-    UNUSED_VARIABLE(ngroup)
+    ABORT_MESSAGE(ngroup,"comm_allgatherv_array1d_double")
     outvalue(displs(1)+1:displs(1)+ncounts(1)) = invalue(1:ncounts(1)-1)
 #endif
   end subroutine
@@ -1690,8 +1683,8 @@ contains
     complex(8), intent(out) :: outvalue(:)
     integer, intent(in)  :: ngroup
     integer, intent(in)  :: ncount
-    UNUSED_VARIABLE(ngroup)
     UNUSED_VARIABLE(ncount)
+    ABORT_MESSAGE(ngroup,"comm_alltoall_array1d_complex")
     outvalue = invalue
 #endif
   end subroutine
@@ -1712,7 +1705,7 @@ contains
     real(8), intent(out) :: outvalue(:)
     integer, intent(in)  :: N, ngroup
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
+    ABORT_MESSAGE(ngroup,"comm_get_min_array1d_double")
     outvalue = invalue
 #endif
   end subroutine
@@ -1732,7 +1725,7 @@ contains
     real(8), intent(out) :: outvalue(:)
     integer, intent(in)  :: N, ngroup
     UNUSED_VARIABLE(N)
-    UNUSED_VARIABLE(ngroup)
+    ABORT_MESSAGE(ngroup,"comm_get_max_array1d_double")
     outvalue = invalue
 #endif
   end subroutine
@@ -1750,7 +1743,7 @@ contains
     type(comm_maxloc_type), intent(in)  :: invalue
     type(comm_maxloc_type), intent(out) :: outvalue
     integer, intent(in)                 :: ngroup
-    UNUSED_VARIABLE(ngroup)
+    ABORT_MESSAGE(ngroup,"comm_get_maxloc")
     outvalue = invalue
 #endif
   end subroutine
@@ -1769,7 +1762,7 @@ contains
     logical, intent(in)  :: invalue
     logical, intent(out) :: outvalue
     integer, intent(in)  :: ngroup
-    UNUSED_VARIABLE(ngroup)
+    ABORT_MESSAGE(ngroup,"comm_logical_and_scalar")
     outvalue = invalue
 #endif
   end subroutine
@@ -1817,6 +1810,9 @@ contains
     implicit none
     character(*), intent(in) :: msg
     print '(A,A)', msg, ': this subroutine must not called (it takes MPI)'
+#ifdef __INTEL_COMPILER
+    call tracebackqq
+#endif
     stop
   end subroutine
   

--- a/src/parallel/salmon_communication.f90
+++ b/src/parallel/salmon_communication.f90
@@ -285,7 +285,9 @@ contains
     implicit none
     integer, intent(in) :: ngid, nprocs, key
     integer :: ngid_dst
-    ngid_dst = ngid + key * nprocs
+    UNUSED_VARIABLE(key)
+    UNUSED_VARIABLE(nprocs)
+    ngid_dst = ngid
 #endif
   end function
 

--- a/src/parallel/salmon_parallel.f90
+++ b/src/parallel/salmon_parallel.f90
@@ -94,6 +94,7 @@ module salmon_parallel
 
   ! util
   public :: get_thread_id
+  public :: is_distributed_parallel
 
 contains
   subroutine setup_parallel
@@ -120,5 +121,11 @@ contains
 #else
     nid = 0
 #endif
+  end function
+
+  function is_distributed_parallel() result(ret)
+    implicit none
+    logical :: ret
+    ret = (nproc_size_global > 1)
   end function
 end module


### PR DESCRIPTION
# Detail

I found the following 3 runtime errors... this pull request fixes the errors.

1. In ARTED part, **sometimes** multi-scale simulation test fails
    - revised commit 14c1b74
2. In GCEED part, Total Energy log diverges with **the several environments**
    - revised commit fd0c729
3. In GCEED part, test 112 and 113 fail when calculating by **a single process**
    - revised commit 42d116c

# Problem

However, this pull request fails the test 112 and 113 when using GCC 4.8.5 due to a few calculation error as below.

    ** Test 112
    Result Current = -3.074665e-04 (Reference = -3.085205e-04)
    Mismatch |-3.074665e-04 - -3.085205e-04| > 1.000000e-08)
    
    ** Test 113
    Result Current = -3.512077e-05 (Reference = -3.535045e-05)
    Mismatch |-3.512077e-05 - -3.535045e-05| > 1.000000e-08)

I think that this is a permissible range, could you please check the this calculation error is safe?