### PR TITLE
remove unused variables

### DIFF
--- a/src/ARTED/preparation/prep_ps.f90
+++ b/src/ARTED/preparation/prep_ps.f90
@@ -29,19 +29,10 @@ Subroutine prep_ps_periodic(property)
   implicit none
   character(17) :: property
   logical :: flag_alloc1, flag_alloc2
-  integer :: ik,n,i,a,j,ix,iy,iz,lma,l,m,lm,ir,intr
-  integer :: PNLx,PNLy,PNLz,ilma,narray
-  real(8) :: G2sq,s,G2,Gd,Gr,x,y,z,r,dr,tmpx,tmpy,tmpz
-  real(8) :: Ylm,dYlm,uVr(0:Lmax),duVr(0:Lmax),Vpsl_ia_l(NL,NI) !,Vpsl_l(NL)
-  complex(8) :: Vion_G_ia(NG_s:NG_e,NI),tmp_exp !, Vion_G(NG_s:NG_e)
-  !spline interpolation
-  real(8) :: xx
-  real(8) :: dudVtbl_a(Nrmax,0:Lmax), dudVtbl_b(Nrmax,0:Lmax)
-  real(8) :: dudVtbl_c(Nrmax,0:Lmax), dudVtbl_d(Nrmax,0:Lmax)
-!  real(8) :: udVtbl_a(Nrmax,0:Lmax), udVtbl_b(Nrmax,0:Lmax)
-!  real(8) :: udVtbl_c(Nrmax,0:Lmax), udVtbl_d(Nrmax,0:Lmax)
-  real(8),allocatable :: xn(:),yn(:),an(:),bn(:),cn(:),dn(:)  
-  real(8) :: vloc_av, ratio1,ratio2,rc
+  integer :: ik,i,a,j,ix,iy,iz,lma,l,m,lm,ir,intr
+  integer :: PNLx,PNLy,PNLz,narray
+  real(8) :: x,y,z,r
+  real(8) :: ratio1,ratio2,rc
 
 
   !(Local pseudopotential in G-space (radial part))

--- a/src/GCEED/common/calcVpsl_periodic_FFTE.f90
+++ b/src/GCEED/common/calcVpsl_periodic_FFTE.f90
@@ -26,7 +26,6 @@ subroutine calcVpsl_periodic_FFTE
   integer :: ii,ix,iy,iz,ak
   integer :: iix,iiy,iiz
   integer :: iatom
-  real(8) :: x,y,z
   
   integer :: n
   real(8) :: bLx,bLy,bLz
@@ -37,14 +36,11 @@ subroutine calcVpsl_periodic_FFTE
   complex(8),parameter :: zI=(0.d0,1.d0)
   real(8) :: G2sq,G2
   real(8) :: Gd
-  real(8) :: Gr
   real(8) :: s
   real(8) :: r
   integer :: imax
-  real(8) :: Vpsl_tmp(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
   integer :: iy_sta,iy_end,iz_sta,iz_end
   integer :: i,iix2,iiy2,iiz2
-  integer :: icommy_dummy,icommz_dummy
   
 
 !calculate reciprocal lattice vector

--- a/src/GCEED/common/exc_cor_ns.f90
+++ b/src/GCEED/common/exc_cor_ns.f90
@@ -23,7 +23,6 @@ subroutine exc_cor_ns
   use sendrecvh_sub
   implicit none
   integer :: ix,iy,iz,is
-  integer :: jspin
   real(8) :: tot_exc
   real(8),allocatable :: rhd(:,:,:), delr(:,:,:,:)
   integer :: iwk_dum

--- a/src/GCEED/common/hartree_FFTE.f90
+++ b/src/GCEED/common/hartree_FFTE.f90
@@ -14,7 +14,7 @@
 !  limitations under the License.
 !
 !SUBROUTINE Hartree_periodic
-!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------130
+!--------10--------20--------30--------40--------50--------60--------70--------80--------90--------100-------110-------120--------
 subroutine Hartree_FFTE(trho,tVh)
   use salmon_parallel, only: nproc_group_global
   use salmon_parallel, only: nproc_id_icommy, nproc_group_icommy
@@ -35,18 +35,12 @@ subroutine Hartree_FFTE(trho,tVh)
   real(8) :: trho(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
   real(8) :: tVh(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
   real(8) :: inv_lgnum3
-  real(8),allocatable :: trho4(:,:,:),trho5(:,:,:)
   complex(8),parameter :: zI=(0.d0,1.d0)
   integer :: n
   real(8) :: bLx,bLy,bLz
   complex(8) :: A_FFTE_tmp(1:lg_num(1),1:lg_num(2)/NPUY,1:lg_num(3)/NPUZ)
   integer :: ng_sta_2(3),ng_end_2(3),ng_num_2(3)
   integer :: lg_sta_2(3),lg_end_2(3),lg_num_2(3)
-  real(8) :: r
-  integer :: iatom,ak
-  real(8) :: fact
-  real(8) :: fact_in_exp
-  integer :: icommy_dummy, icommz_dummy
 
   lg_sta_2(1:3)=lg_sta(1:3)
   lg_end_2(1:3)=lg_end(1:3)

--- a/src/GCEED/scf/total_energy_periodic_scf.f90
+++ b/src/GCEED/scf/total_energy_periodic_scf.f90
@@ -35,7 +35,7 @@ integer :: ia_sta,ia_end
 real(8) :: x,y,z
 integer :: ik,iik
 integer :: ix,iy,iz
-integer :: iix,iiy,iiz,iia
+integer :: iix,iiy,iiz
 integer :: aewald_sta,aewald_end,aewald_num
 integer :: totnum_aewald
 real(8) :: rab(3),rab2

--- a/src/xc/salmon_xc.f90
+++ b/src/xc/salmon_xc.f90
@@ -611,7 +611,6 @@ contains
       real(8) :: j_s_1d(nl, 3)
       real(8) :: eexc_1d(nl)
       real(8) :: vexc_1d(nl)
-      integer :: ii
 
       rho_1d = reshape(rho, (/nl/))
       rho_s_1d = rho_1d * 0.5


### PR DESCRIPTION
I remove unused variables at the part I affected for the development. This modification reduces compiler warnings. 