### PR TITLE
add function of gscg

### DIFF
--- a/src/GCEED/common/CMakeLists.txt
+++ b/src/GCEED/common/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     init_k_rd.f90
     inner_product3.f90
     inner_product4.f90
+    inner_product7.f90
     laplacianh.f90
     nabla.f90
     OUT_IN_data.f90

--- a/src/GCEED/common/inner_product7.f90
+++ b/src/GCEED/common/inner_product7.f90
@@ -1,0 +1,50 @@
+!
+!  Copyright 2018 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+!=======================================================================
+subroutine inner_product7(matbox1,matbox2,rbox2)
+  use salmon_parallel, only: nproc_group_korbital
+  use salmon_communication, only: comm_summation
+  use misc_routines, only: get_wtime
+  use scf_data
+  use new_world_sub
+  implicit none
+  integer :: ix,iy,iz,iob,iob_allob
+  real(8) :: matbox1(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum)
+  real(8) :: matbox2(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum)
+  real(8) :: rbox,rbox1(itotMST),rbox2(itotMST)
+  
+  rbox1(:)=0.d0
+ 
+  do iob=1,iobnum
+    call calc_allob(iob,iob_allob)
+    rbox=0.d0
+    !$omp parallel do private(iz,iy,ix) collapse(2) reduction(+ : rbox)
+    do iz=mg_sta(3),mg_end(3)
+    do iy=mg_sta(2),mg_end(2)
+    do ix=mg_sta(1),mg_end(1)
+      rbox=rbox+matbox1(ix,iy,iz,iob)*matbox2(ix,iy,iz,iob)
+    end do
+    end do
+    end do
+    rbox1(iob_allob)=rbox*Hvol
+  end do
+  
+  elp3(186)=get_wtime()
+  call comm_summation(rbox1,rbox2,itotMST,nproc_group_korbital)
+  elp3(187)=get_wtime()
+  elp3(190)=elp3(190)+elp3(187)-elp3(186)
+  
+end subroutine inner_product7

--- a/src/GCEED/modules/allocate_mat.f90
+++ b/src/GCEED/modules/allocate_mat.f90
@@ -168,6 +168,22 @@ if(iSCFRT==2)then
 
 end if
 
+if(iSCFRT==1.and.iperiodic==0)then
+  allocate (rxk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+  allocate (rhxk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+  allocate (rgk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+  allocate (rpk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+end if
+
+if(iSCFRT==1.and.iperiodic==3)then
+  allocate (zxk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+  allocate (zhxk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+  allocate (zgk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+  allocate (zpk_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+  allocate (zpko_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+  allocate (zhtpsi_ob(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),1:iobnum))
+end if
+
 allocate (rho_tmp(ng_num(1), ng_num(2), ng_num(3)))
 allocate (rho_s_tmp(ng_num(1), ng_num(2), ng_num(3), 2))
 allocate (vxc_tmp(ng_num(1), ng_num(2), ng_num(3)))

--- a/src/GCEED/modules/deallocate_mat.f90
+++ b/src/GCEED/modules/deallocate_mat.f90
@@ -57,6 +57,15 @@ else if(iSCFRT==2.and.icalcforce==1)then
   deallocate(cgrad_wk)
 end if
 
+if(iSCFRT==1.and.iperiodic==0)then
+  deallocate(rxk_ob,rhxk_ob,rgk_ob,rpk_ob)
+end if
+
+if(iSCFRT==1.and.iperiodic==3)then
+  deallocate(zxk_ob,zhxk_ob,zgk_ob,zpk_ob)
+  deallocate(zpko_ob,zhtpsi_ob)
+end if
+
 deallocate (rho_tmp)
 deallocate (rho_s_tmp)
 deallocate (vxc_tmp)

--- a/src/GCEED/modules/scf_data.f90
+++ b/src/GCEED/modules/scf_data.f90
@@ -428,6 +428,11 @@ real(8) :: absorption_id(0:100000)
 integer :: iflag_dos
 integer :: iflag_pdos
 
+real(8) , allocatable :: rxk_ob(:,:,:,:),rhxk_ob(:,:,:,:),rgk_ob(:,:,:,:),rpk_ob(:,:,:,:)
+
+complex(8) , allocatable :: zxk_ob(:,:,:,:),zhxk_ob(:,:,:,:),zgk_ob(:,:,:,:),zpk_ob(:,:,:,:)
+complex(8) , allocatable :: zpko_ob(:,:,:,:),zhtpsi_ob(:,:,:,:)
+
 integer :: iflag_ELF
 
 integer :: iflag_indA

--- a/src/GCEED/scf/CMakeLists.txt
+++ b/src/GCEED/scf/CMakeLists.txt
@@ -12,6 +12,8 @@ set(SOURCES
     inner_product5.f90
     gram_schmidt.f90
     gram_schmidt_periodic.f90
+    gscg.f90
+    gscg_periodic.f90
     prep_ini.f90
     real_space_dft.f90
     rmmdiis_eigen.f90

--- a/src/GCEED/scf/gscg.f90
+++ b/src/GCEED/scf/gscg.f90
@@ -1,0 +1,293 @@
+!
+!  Copyright 2018 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+!=======================================================================
+!======================================= Conjugate-Gradient minimization
+
+subroutine sgscg(psi_in,iflag)
+use salmon_parallel, only: nproc_group_grid, nproc_group_global, nproc_group_korbital
+use salmon_communication, only: comm_summation, comm_bcast
+use misc_routines, only: get_wtime
+use scf_data
+use new_world_sub
+use inner_product_sub
+use hpsi2_sub
+!$ use omp_lib
+implicit none
+
+real(8):: psi_in(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),  &
+               1:iobnum,1)
+integer :: iter,iob,job,iflag
+integer :: ix,iy,iz
+integer :: is,iobsta(2),iobend(2)
+real(8) :: sum0,sum1
+real(8) :: sum_ob0(itotMST)
+real(8) :: sum_obmat0(itotMST,itotMST),sum_obmat1(itotMST,itotMST)
+real(8) :: xkHxk_ob(itotMST),xkxk_ob(itotMST),Rk_ob(itotMST)
+real(8) :: gkgk_ob(itotMST),pkpk_ob(itotMST),xkpk_ob(itotMST)
+real(8) :: pkHxk_ob(itotMST),pkHpk_ob(itotMST)
+real(8) :: uk,alpha,Ak,Bk,Ck
+real(8) , allocatable :: gk(:,:,:)
+real(8) :: elp2(2000)
+real(8):: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd,mg_sta(2)-Nd:mg_end(2)+Nd,mg_sta(3)-Nd:mg_end(3)+Nd)
+real(8):: htpsi(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3))
+integer :: iob_myob,job_myob
+integer :: iob_allob
+integer :: icorr,jcorr,icorr_iob,icorr_job
+integer :: iroot
+integer :: is_sta,is_end
+
+allocate (gk(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
+
+iwk_size=2
+call make_iwksta_iwkend
+
+call set_isstaend(is_sta,is_end)
+
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+do iz=mg_sta(3)-Nd,mg_end(3)+Nd
+do iy=mg_sta(2)-Nd,mg_end(2)+Nd
+do ix=mg_sta(1)-Nd,mg_end(1)+Nd
+  tpsi(ix,iy,iz)=0.d0
+end do
+end do
+end do
+
+elp2(:)=0d0
+elp2(1)=get_wtime()
+
+if(ilsda == 0)then
+  iobsta(1)=1
+  iobend(1)=itotMST
+else if(ilsda == 1)then
+  iobsta(1)=1
+  iobend(1)=MST(1)
+  iobsta(2)=MST(1)+1
+  iobend(2)=itotMST
+end if
+
+do iob=1,iobnum
+  call calc_allob(iob,iob_allob)
+
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+  do iz=mg_sta(3),mg_end(3)
+  do iy=mg_sta(2),mg_end(2)
+  do ix=mg_sta(1),mg_end(1)
+    rxk_ob(ix,iy,iz,iob)=psi_in(ix,iy,iz,iob,1)
+    tpsi(ix,iy,iz)=rxk_ob(ix,iy,iz,iob)
+  end do
+  end do
+  end do
+  call hpsi2(tpsi,htpsi,iob_allob,1,0,0)
+  
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+  do iz=mg_sta(3),mg_end(3)
+  do iy=mg_sta(2),mg_end(2)
+  do ix=mg_sta(1),mg_end(1)
+    rhxk_ob(ix,iy,iz,iob)=htpsi(ix,iy,iz)
+  end do
+  end do
+  end do
+end do
+
+call inner_product7(rxk_ob,rhxk_ob,xkHxk_ob)
+
+xkxk_ob(:)=1.d0 
+Rk_ob(:)=xkHxk_ob(:)/xkxk_ob(:)
+
+Iteration : do iter=1,Ncg
+elp2(2)=get_wtime()
+  do iob=1,iobnum
+    call calc_allob(iob,iob_allob)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+    do iz=mg_sta(3),mg_end(3)
+    do iy=mg_sta(2),mg_end(2)
+    do ix=mg_sta(1),mg_end(1)
+      rgk_ob(ix,iy,iz,iob) = 2*( rhxk_ob(ix,iy,iz,iob) - Rk_ob(iob_allob)*rxk_ob(ix,iy,iz,iob) )
+    end do
+    end do
+    end do
+  end do
+ if(nproc_ob==1)then
+    do is=is_sta,is_end
+    do iob=iobsta(is),iobend(is)
+      do job=iobsta(is),iob-1
+        sum0=0.d0
+  !$omp parallel do private(iz,iy,ix) collapse(2) reduction(+ : sum0)
+        do iz=mg_sta(3),mg_end(3)
+        do iy=mg_sta(2),mg_end(2)
+        do ix=mg_sta(1),mg_end(1)
+          sum0=sum0+psi_in(ix,iy,iz,job,1)*rgk_ob(ix,iy,iz,iob)
+        end do
+        end do
+        end do
+        sum_obmat0(iob,job)=sum0*Hvol
+      end do
+    end do 
+    end do
+    call comm_summation(sum_obmat0,sum_obmat1,itotMST*itotMST,nproc_group_global)
+    do is=is_sta,is_end
+    do iob=iobsta(is),iobend(is)
+      do job=iobsta(is),iob-1
+  !$omp parallel do private(iz,iy,ix) collapse(2)
+        do iz=mg_sta(3),mg_end(3)
+        do iy=mg_sta(2),mg_end(2)
+        do ix=mg_sta(1),mg_end(1)
+          rgk_ob(ix,iy,iz,iob)=rgk_ob(ix,iy,iz,iob)-sum_obmat1(iob,job)*psi_in(ix,iy,iz,job,1)
+        end do
+        end do
+        end do
+      end do
+    end do
+    end do
+  else
+    do iob=iobsta(is),iobend(is)
+      call calc_myob(iob,iob_myob)
+      call check_corrkob(iob,1,icorr_iob)
+      do job=iobsta(is),iob-1
+        call calc_myob(job,job_myob)
+        call check_corrkob(job,1,icorr_job)
+        if(icorr_job==1)then
+  !$omp parallel do private(iz,iy,ix) collapse(2)
+          do iz=mg_sta(3),mg_end(3)
+          do iy=mg_sta(2),mg_end(2)
+          do ix=mg_sta(1),mg_end(1)
+            matbox_m(ix,iy,iz)=psi_in(ix,iy,iz,job_myob,1)
+          end do
+          end do
+          end do
+        end if
+        call calc_iroot(job,iroot)
+        call comm_bcast(matbox_m,nproc_group_grid,iroot)
+        sum0=0.d0
+  !$omp parallel do private(iz,iy,ix) collapse(2) reduction(+ : sum0)
+        do iz=iwk3sta(3),iwk3end(3)
+        do iy=iwk3sta(2),iwk3end(2)
+        do ix=iwk3sta(1),iwk3end(1)
+          sum0=sum0+matbox_m(ix,iy,iz)*rgk_ob(ix,iy,iz,iob_myob)
+        end do
+        end do
+        end do
+        sum0=sum0*Hvol
+        call comm_summation(sum0,sum1,nproc_group_korbital)
+        do iz=mg_sta(3),mg_end(3)
+        do iy=mg_sta(2),mg_end(2)
+        do ix=mg_sta(1),mg_end(1)
+          rgk_ob(ix,iy,iz,iob_myob)=rgk_ob(ix,iy,iz,iob_myob)-sum1*matbox_m(ix,iy,iz)
+        end do
+        end do
+        end do
+      end do
+    end do
+  end if 
+ call inner_product7(rgk_ob,rgk_ob,sum_ob0)
+ if ( iter==1 ) then
+    do iob=1,iobnum
+      call calc_allob(iob,iob_allob)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+      do iz=mg_sta(3),mg_end(3)
+      do iy=mg_sta(2),mg_end(2)
+      do ix=mg_sta(1),mg_end(1)
+        rpk_ob(ix,iy,iz,iob) = -rgk_ob(ix,iy,iz,iob)
+      end do
+      end do
+      end do
+    end do
+  else
+    do iob=1,iobnum
+      call calc_allob(iob,iob_allob)
+      uk=sum_ob0(iob_allob)/gkgk_ob(iob_allob)
+!$OMP parallel do private(iz,iy,ix)
+      do iz=mg_sta(3),mg_end(3)
+      do iy=mg_sta(2),mg_end(2)
+      do ix=mg_sta(1),mg_end(1)
+        rpk_ob(ix,iy,iz,iob) = -rgk_ob(ix,iy,iz,iob) + uk*rpk_ob(ix,iy,iz,iob)
+      end do
+      end do
+      end do
+    end do
+  end if 
+  gkgk_ob(:)=sum_ob0(:)
+  call inner_product7(rxk_ob,rpk_ob,xkpk_ob)
+  call inner_product7(rpk_ob,rpk_ob,pkpk_ob)
+  call inner_product7(rpk_ob,rhxk_ob,pkHxk_ob)
+
+  do iob=1,iobnum
+    call calc_allob(iob,iob_allob)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+    do iz=mg_sta(3),mg_end(3)
+    do iy=mg_sta(2),mg_end(2)
+    do ix=mg_sta(1),mg_end(1)
+      tpsi(ix,iy,iz) = rpk_ob(ix,iy,iz,iob)
+    end do
+    end do
+    end do
+    call hpsi2(tpsi,htpsi,iob_allob,1,0,0)
+    
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+    do iz=mg_sta(3),mg_end(3)
+    do iy=mg_sta(2),mg_end(2)
+    do ix=mg_sta(1),mg_end(1)
+       rgk_ob(ix,iy,iz,iob)=htpsi(ix,iy,iz)
+    end do
+    end do
+    end do
+  end do
+  call inner_product7(rpk_ob,rgk_ob,pkHpk_ob)
+ do iob=1,iobnum
+    call calc_allob(iob,iob_allob)
+    Ak=pkHpk_ob(iob_allob)*xkpk_ob(iob_allob)-pkHxk_ob(iob_allob)*pkpk_ob(iob_allob)
+    Bk=pkHpk_ob(iob_allob)*xkxk_ob(iob_allob)-xkHxk_ob(iob_allob)*pkpk_ob(iob_allob)
+    Ck=pkHxk_ob(iob_allob)*xkxk_ob(iob_allob)-xkHxk_ob(iob_allob)*xkpk_ob(iob_allob)
+    alpha=(-Bk+sqrt(Bk*Bk-4*Ak*Ck))/(2*Ak)
+
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+    do iz=mg_sta(3),mg_end(3)
+    do iy=mg_sta(2),mg_end(2)
+    do ix=mg_sta(1),mg_end(1)
+      rxk_ob(ix,iy,iz,iob) = rxk_ob(ix,iy,iz,iob) + alpha*rpk_ob(ix,iy,iz,iob)
+      rhxk_ob(ix,iy,iz,iob) = rhxk_ob(ix,iy,iz,iob) + alpha*rgk_ob(ix,iy,iz,iob)
+    end do
+    end do
+    end do
+  end do
+  call inner_product7(rxk_ob,rhxk_ob,xkHxk_ob)
+  call inner_product7(rxk_ob,rxk_ob,xkxk_ob)
+  Rk_ob(:)=xkHxk_ob(:)/xkxk_ob(:)
+
+
+end do Iteration
+
+call inner_product7(rxk_ob,rxk_ob,sum_ob0)
+do iob=1,iobnum
+  call calc_allob(iob,iob_allob)
+!$OMP parallel do private(iz,iy,ix) collapse(2)
+  do iz=mg_sta(3),mg_end(3)
+  do iy=mg_sta(2),mg_end(2)
+  do ix=mg_sta(1),mg_end(1)
+    psi_in(ix,iy,iz,iob,1)=rxk_ob(ix,iy,iz,iob)/sqrt(sum_ob0(iob_allob))
+  end do
+  end do
+  end do
+end do
+
+if(iflag.eq.1) then
+  iflag=0
+end if
+
+deallocate (gk)
+return
+
+end subroutine sgscg

--- a/src/GCEED/scf/gscg_periodic.f90
+++ b/src/GCEED/scf/gscg_periodic.f90
@@ -1,0 +1,335 @@
+!
+!  Copyright 2018 SALMON developers
+!
+!  Licensed under the Apache License, Version 2.0 (the "License");
+!  you may not use this file except in compliance with the License.
+!  You may obtain a copy of the License at
+!
+!      http://www.apache.org/licenses/LICENSE-2.0
+!
+!  Unless required by applicable law or agreed to in writing, software
+!  distributed under the License is distributed on an "AS IS" BASIS,
+!  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+!  See the License for the specific language governing permissions and
+!  limitations under the License.
+!
+!=======================================================================
+!======================================= Conjugate-Gradient minimization
+
+subroutine gscg_periodic(psi_in,iflag)
+  use salmon_parallel, only: nproc_group_kgrid, nproc_group_korbital, nproc_group_k
+  use salmon_communication, only: comm_bcast, comm_summation
+  use misc_routines, only: get_wtime
+  use scf_data
+  use new_world_sub
+  use inner_product_sub
+  use allocate_mat_sub
+  use hpsi2_sub
+  !$ use omp_lib
+  implicit none
+  
+  complex(8) :: psi_in(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3),  &
+                 1:iobnum,k_sta:k_end)
+  integer :: iter,iob,job,iflag
+  integer :: ik
+  integer :: ix,iy,iz
+  integer :: is,iobsta(2),iobend(2)
+  complex(8) :: sum0,sum1
+  complex(8) :: sum_ob1(itotMST)
+  complex(8) :: sum_obmat0(itotMST,itotMST),sum_obmat1(itotMST,itotMST)
+  complex(8) :: xkxk_ob(itotMST),xkHxk_ob(itotMST),xkHpk_ob(itotMST),pkHpk_ob(itotMST),gkgk_ob(itotMST)
+  complex(8) :: uk
+  real(8) :: ev
+  complex(8) :: cx,cp
+  complex(8) :: zs_ob(itotMST)
+  complex(8) , allocatable :: htpsi(:,:,:)
+  real(8) :: elp2(2000)
+  complex(8):: tpsi(mg_sta(1)-Nd:mg_end(1)+Nd,mg_sta(2)-Nd:mg_end(2)+Nd,mg_sta(3)-Nd:mg_end(3)+Nd)
+  integer :: iob_myob,job_myob
+  integer :: iob_allob
+  integer :: icorr_iob,icorr_job
+  integer :: iroot
+  integer :: is_sta,is_end
+  integer :: iter_bak_ob(itotMST)
+  
+  allocate (htpsi(mg_sta(1):mg_end(1),mg_sta(2):mg_end(2),mg_sta(3):mg_end(3)))
+  
+  call set_isstaend(is_sta,is_end)
+  
+  iwk_size=2
+  call make_iwksta_iwkend
+  
+  !$OMP parallel do private(iz,iy,ix) collapse(2)
+  do iz=mg_sta(3)-Nd,mg_end(3)+Nd
+  do iy=mg_sta(2)-Nd,mg_end(2)+Nd
+  do ix=mg_sta(1)-Nd,mg_end(1)+Nd
+    tpsi(ix,iy,iz)=0.d0
+  end do
+  end do
+  end do
+  
+  elp2(:)=0d0
+  elp2(1)=get_wtime()
+  
+  if(ilsda == 0)then
+    iobsta(1)=1
+    iobend(1)=itotMST
+  else if(ilsda == 1)then
+    iobsta(1)=1
+    iobend(1)=MST(1)
+    iobsta(2)=MST(1)+1
+    iobend(2)=itotMST
+  end if
+  
+  do ik=k_sta,k_end
+  do is=is_sta,is_end
+
+    iter_bak_ob(:)=0 
+  
+    do iob_myob=1,iobnum
+      call calc_allob(iob_myob,iob_allob)
+    
+      elp2(2)=get_wtime()
+      
+    !$omp parallel do private(iz,iy,ix) collapse(2) 
+      do iz=mg_sta(3),mg_end(3)
+      do iy=mg_sta(2),mg_end(2)
+      do ix=mg_sta(1),mg_end(1)
+        zxk_ob(ix,iy,iz,iob_myob)=psi_in(ix,iy,iz,iob_myob,ik)
+        tpsi(ix,iy,iz)=zxk_ob(ix,iy,iz,iob_myob)
+      end do
+      end do
+      end do
+     
+      call hpsi2(tpsi,htpsi,iob_allob,ik,0,0)
+      
+    !$omp parallel do private(iz,iy,ix) collapse(2) 
+      do iz=mg_sta(3),mg_end(3)
+      do iy=mg_sta(2),mg_end(2)
+      do ix=mg_sta(1),mg_end(1)
+        zhxk_ob(ix,iy,iz,iob_myob)=htpsi(ix,iy,iz)
+      end do
+      end do
+      end do
+  
+    end do
+    call inner_product5(zxk_ob,zhxk_ob,xkHxk_ob)
+
+    Iteration : do iter=1,Ncg
+      do iob_myob=1,iobnum
+        call calc_allob(iob_myob,iob_allob)
+    
+    !$OMP parallel do private(iz,iy,ix) collapse(2)
+        do iz=mg_sta(3),mg_end(3)
+        do iy=mg_sta(2),mg_end(2)
+        do ix=mg_sta(1),mg_end(1)
+          zgk_ob(ix,iy,iz,iob_myob) = zhxk_ob(ix,iy,iz,iob_myob) - xkHxk_ob(iob_allob)*zxk_ob(ix,iy,iz,iob_myob) 
+        end do
+        end do
+        end do
+      end do
+
+      if(nproc_ob==1)then
+        sum_obmat0(:,:)=0.d0
+        elp3(1506)=get_wtime()
+        do iob=iobsta(is),iobend(is)
+          do job=iobsta(is),iob-1
+            sum0=0.d0
+    !$omp parallel do private(iz,iy,ix) collapse(2) reduction(+ : sum0)
+            do iz=mg_sta(3),mg_end(3)
+            do iy=mg_sta(2),mg_end(2)
+            do ix=mg_sta(1),mg_end(1)
+              sum0=sum0+conjg(psi_in(ix,iy,iz,job,ik))*zgk_ob(ix,iy,iz,iob)
+            end do
+            end do
+            end do
+            sum_obmat0(iob,job)=sum0*Hvol
+          end do
+        end do
+        elp3(1507)=get_wtime()
+        elp3(1557)=elp3(1557)+elp3(1507)-elp3(1506)
+        call comm_summation(sum_obmat0,sum_obmat1,itotMST*itotMST,nproc_group_k)
+        elp3(1508)=get_wtime()
+        elp3(1558)=elp3(1558)+elp3(1508)-elp3(1507)
+        do iob=iobsta(is),iobend(is)
+          do job=iobsta(is),iob-1
+    !$omp parallel do collapse(2)
+            do iz=mg_sta(3),mg_end(3)
+            do iy=mg_sta(2),mg_end(2)
+            do ix=mg_sta(1),mg_end(1)
+              zgk_ob(ix,iy,iz,iob)=zgk_ob(ix,iy,iz,iob)-sum_obmat1(iob,job)*psi_in(ix,iy,iz,job,ik)
+            end do
+            end do
+            end do
+          end do
+        end do
+        elp3(1507)=get_wtime()
+        elp3(1557)=elp3(1557)+elp3(1507)-elp3(1508)
+      else
+        do iob=iobsta(is),iobend(is)
+          call calc_myob(iob,iob_myob)
+          call check_corrkob(iob,ik,icorr_iob)
+          do job=iobsta(is),iob-1
+            call calc_myob(job,job_myob)
+            call check_corrkob(job,ik,icorr_job)
+            if(icorr_job==1)then
+    !$omp parallel do private(iz,iy,ix) collapse(2)
+              do iz=mg_sta(3),mg_end(3)
+              do iy=mg_sta(2),mg_end(2)
+              do ix=mg_sta(1),mg_end(1)
+                cmatbox_m(ix,iy,iz)=psi_in(ix,iy,iz,job_myob,ik)
+              end do
+              end do
+              end do
+            end if
+            call calc_iroot(job,iroot)
+            call comm_bcast(cmatbox_m,nproc_group_kgrid,iroot)
+            sum0=0.d0
+    !$omp parallel do private(iz,iy,ix) collapse(2) reduction(+ : sum0)
+            do iz=iwk3sta(3),iwk3end(3)
+            do iy=iwk3sta(2),iwk3end(2)
+            do ix=iwk3sta(1),iwk3end(1)
+              sum0=sum0+conjg(cmatbox_m(ix,iy,iz))*zgk_ob(ix,iy,iz,iob_myob)
+            end do
+            end do
+            end do
+            sum0=sum0*Hvol
+            call comm_summation(sum0,sum1,nproc_group_korbital)
+            do iz=iwk3sta(3),iwk3end(3)
+            do iy=iwk3sta(2),iwk3end(2)
+            do ix=iwk3sta(1),iwk3end(1)
+              zgk_ob(ix,iy,iz,iob_myob)=zgk_ob(ix,iy,iz,iob_myob)-sum1*cmatbox_m(ix,iy,iz)
+            end do
+            end do
+            end do
+          end do
+        end do
+      end if
+      call inner_product5(zgk_ob,zgk_ob,sum_ob1)
+        
+      do iob_myob=1,iobnum
+        call calc_allob(iob_myob,iob_allob)
+    
+        if(iter==1)then
+    !$OMP parallel do private(iz,iy,ix) collapse(2)
+          do iz=mg_sta(3),mg_end(3)
+          do iy=mg_sta(2),mg_end(2)
+          do ix=mg_sta(1),mg_end(1)
+            zpk_ob(ix,iy,iz,iob_myob)=zgk_ob(ix,iy,iz,iob_myob)
+          end do
+          end do
+          end do
+        else
+          uk=sum_ob1(iob_allob)/gkgk_ob(iob_allob)
+    !$OMP parallel do private(iz,iy,ix) collapse(2)
+          do iz=mg_sta(3),mg_end(3)
+          do iy=mg_sta(2),mg_end(2)
+          do ix=mg_sta(1),mg_end(1)
+            zpk_ob(ix,iy,iz,iob_myob)=zgk_ob(ix,iy,iz,iob_myob)+uk*zpk_ob(ix,iy,iz,iob_myob)
+          end do
+          end do
+          end do
+        end if
+        gkgk_ob(iob_allob)=sum_ob1(iob_allob)
+      end do
+
+      call inner_product5(zxk_ob,zpk_ob,zs_ob)
+
+      do iob_myob=1,iobnum
+        call calc_allob(iob_myob,iob_allob)
+    !$OMP parallel do private(iz,iy,ix) collapse(2)
+        do iz=mg_sta(3),mg_end(3)
+        do iy=mg_sta(2),mg_end(2)
+        do ix=mg_sta(1),mg_end(1)
+          zpko_ob(ix,iy,iz,iob_myob)=zpk_ob(ix,iy,iz,iob_myob)-zs_ob(iob_allob)*zxk_ob(ix,iy,iz,iob_myob)
+        end do
+        end do
+        end do
+      end do
+      call inner_product5(zpko_ob,zpko_ob,sum_ob1)
+
+      do iob_myob=1,iobnum
+        call calc_allob(iob_myob,iob_allob)
+    !$OMP parallel do private(iz,iy,ix) collapse(2)
+        do iz=mg_sta(3),mg_end(3)
+        do iy=mg_sta(2),mg_end(2)
+        do ix=mg_sta(1),mg_end(1)
+          zpko_ob(ix,iy,iz,iob_myob)=zpko_ob(ix,iy,iz,iob_myob)/sqrt(sum_ob1(iob_allob))
+          tpsi(ix,iy,iz)=zpko_ob(ix,iy,iz,iob_myob)
+        end do
+        end do
+        end do
+
+        call hpsi2(tpsi,htpsi,iob_allob,ik,0,0)
+
+    !$OMP parallel do private(iz,iy,ix) collapse(2)
+        do iz=mg_sta(3),mg_end(3)
+        do iy=mg_sta(2),mg_end(2)
+        do ix=mg_sta(1),mg_end(1)
+          zhtpsi_ob(ix,iy,iz,iob_myob)=htpsi(ix,iy,iz)
+        end do
+        end do
+        end do
+      end do
+      call inner_product5(zxk_ob,zhtpsi_ob,xkHpk_ob)
+      call inner_product5(zpko_ob,zhtpsi_ob,pkHpk_ob)
+        
+    
+      do iob_myob=1,iobnum
+        call calc_allob(iob_myob,iob_allob)
+
+        ev=0.5d0*((xkHxk_ob(iob_allob)+pkHpk_ob(iob_allob))   &
+                 -sqrt((xkHxk_ob(iob_allob)-pkHpk_ob(iob_allob))**2+4.d0*abs(xkHpk_ob(iob_allob))**2))
+        cx=xkHpk_ob(iob_allob)/(ev-xkHxk_ob(iob_allob))
+        cp=1.d0/sqrt(1.d0+abs(cx)**2)
+        cx=cx*cp
+        
+    !$OMP parallel do private(iz,iy,ix) collapse(2)
+        do iz=mg_sta(3),mg_end(3)
+        do iy=mg_sta(2),mg_end(2)
+        do ix=mg_sta(1),mg_end(1)
+          zxk_ob(ix,iy,iz,iob_myob)=cx*zxk_ob(ix,iy,iz,iob_myob)+cp*zpko_ob(ix,iy,iz,iob_myob)
+          zhxk_ob(ix,iy,iz,iob_myob)=cx*zhxk_ob(ix,iy,iz,iob_myob)+cp*zhtpsi_ob(ix,iy,iz,iob_myob)
+        end do
+        end do
+        end do
+      end do 
+    
+      call inner_product5(zxk_ob,zhxk_ob,xkHxk_ob)
+      call inner_product5(zxk_ob,zxk_ob,xkxk_ob)
+
+      do iob_myob=1,iobnum
+        call calc_allob(iob_myob,iob_allob)
+
+        if(abs(xkxk_ob(iob_allob))<=1.d30)then
+    !$OMP parallel do private(iz,iy,ix) collapse(2)
+          do iz=mg_sta(3),mg_end(3)
+          do iy=mg_sta(2),mg_end(2)
+          do ix=mg_sta(1),mg_end(1)
+            psi_in(ix,iy,iz,iob_myob,ik)=zxk_ob(ix,iy,iz,iob_myob)/sqrt(xkxk_ob(iob_allob))
+          end do
+          end do
+          end do
+          iter_bak_ob(iob_allob)=iter
+        else
+          if(mg_sta(1)==lg_sta(1).and.mg_sta(2)==lg_sta(2).and.mg_sta(3)==lg_sta(3))then
+            write(*,'("CG termination. orbital ",i6," iter ",i3)') iob_allob,iter_bak_ob(iob_allob)+1
+          end if
+        end if
+    
+      end do
+    end do Iteration
+  
+  end do
+  end do
+  
+  
+  if(iflag.eq.1) then
+    iflag=0
+  end if
+  
+  deallocate (htpsi)
+  
+  return
+  
+end subroutine gscg_periodic

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -399,9 +399,19 @@ DFT_Iteration : do iter=1,iDiter(img)
       elp3(181)=get_wtime()
       select case(iperiodic)
       case(0)
-        call DTcg(psi,iflag)
+        select case(gscg)
+        case('y')
+          call sgscg(psi,iflag)
+        case('n')
+          call DTcg(psi,iflag)
+        end select
       case(3)
-        call DTcg_periodic(zpsi,iflag)
+        select case(gscg)
+        case('y')
+          call gscg_periodic(zpsi,iflag)
+        case('n')
+          call DTcg_periodic(zpsi,iflag)
+        end select
       end select
       elp3(182)=get_wtime()
       elp3(183)=elp3(183)+elp3(182)-elp3(181)
@@ -536,9 +546,19 @@ DFT_Iteration : do iter=1,iDiter(img)
     if( amin_routine == 'cg' .or. (amin_routine == 'cg-diis' .and. Miter <= iDiterYBCG) ) then
       select case(iperiodic)
       case(0)
-        call DTcg(psi,iflag)
+        select case(gscg)
+        case('y')
+          call sgscg(psi,iflag)
+        case('n')
+          call DTcg(psi,iflag)
+        end select
       case(3)
-        call DTcg_periodic(zpsi,iflag)
+        select case(gscg)
+        case('y')
+          call gscg_periodic(zpsi,iflag)
+        case('n')
+          call DTcg_periodic(zpsi,iflag)
+        end select
       end select
     else if( amin_routine == 'diis' .or. amin_routine == 'cg-diis' ) then
       select case(iperiodic)

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -322,7 +322,8 @@ contains
       & threshold_norm_pot, &
       & omp_loop, &
       & skip_gsortho, &
-      & iditer_notemperature
+      & iditer_notemperature, &
+      & gscg
 
     namelist/emfield/ &
       & trans_longi, &
@@ -654,6 +655,7 @@ contains
     omp_loop      = 'k'
     skip_gsortho  = 'n'
     iditer_notemperature = 10
+    gscg          = 'y'
 
 !! == default for &emfield
     trans_longi    = 'tr'
@@ -1044,6 +1046,7 @@ contains
     call comm_bcast(omp_loop                ,nproc_group_global)
     call comm_bcast(skip_gsortho            ,nproc_group_global)
     call comm_bcast(iditer_notemperature    ,nproc_group_global)
+    call comm_bcast(gscg                    ,nproc_group_global)
 !! == bcast for &emfield
     call comm_bcast(trans_longi,nproc_group_global)
     call comm_bcast(ae_shape1  ,nproc_group_global)
@@ -1658,6 +1661,7 @@ contains
       write(fh_variables_log, '("#",4X,A,"=",A)') 'omp_loop', omp_loop
       write(fh_variables_log, '("#",4X,A,"=",A)') 'skip_gsortho', skip_gsortho
       write(fh_variables_log, '("#",4X,A,"=",I3)') 'iditer_notemperature', iditer_notemperature
+      write(fh_variables_log, '("#",4X,A,"=",A)') 'gscg', gscg
 
       if(inml_emfield >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'emfield', inml_emfield

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -151,6 +151,7 @@ module salmon_global
   character(1)   :: omp_loop
   character(1)   :: skip_gsortho
   integer        :: iditer_notemperature
+  character(1)   :: gscg
 
 !! &emfield
   character(2)   :: trans_longi

--- a/testsuites/103_C2H2_rt_pulse/verification
+++ b/testsuites/103_C2H2_rt_pulse/verification
@@ -20,7 +20,7 @@ checklist = {
     # Dipole moment
     "Dipole Moment": [
         -100, # Temporary value for result
-        1.7072501e-04,  # Reference value 
+        1.7765919e-04,  # Reference value 
         1.e-6,  # Permissible error 
     ], 
 } 


### PR DESCRIPTION
In a CG routine, a method like modified Gram Schmidt is used. Although this method ensures the accuracy, it causes a bottleneck of communication. This PR enables for users to choose a method like normal Gram Schmidt. 

@tt-ims san, could you check this PR?