### PR TITLE
Add lr-calculation in eh-FDTD

### DIFF
--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -398,7 +398,8 @@ contains
       & rmu, &
       & sigma, &
       & omega_p_d, &
-      & gamma_d
+      & gamma_d, &
+      & wf_em
 
     namelist/analysis/ &
       & projection_option, &
@@ -735,6 +736,7 @@ contains
     sigma(:)        = 0d0
     omega_p_d(:)    = 0d0
     gamma_d(:)      = 0d0
+    wf_em           = 'y'
 
 !! == default for &analysis
     projection_option   = 'no'
@@ -1152,8 +1154,9 @@ contains
     call comm_bcast(sigma        ,nproc_group_global)
     call comm_bcast(omega_p_d    ,nproc_group_global)
     omega_p_d = omega_p_d * uenergy_to_au
-    call comm_bcast(gamma_d       ,nproc_group_global)
+    call comm_bcast(gamma_d      ,nproc_group_global)
     gamma_d = gamma_d * uenergy_to_au
+    call comm_bcast(wf_em        ,nproc_group_global)
     
 !! == bcast for &analysis
     call comm_bcast(projection_option,nproc_group_global)
@@ -1789,6 +1792,7 @@ contains
         write(fh_variables_log, '("#",4X,A,I3,A,"=",ES12.5)') 'omega_p_d(',i,')', omega_p_d(i)
         write(fh_variables_log, '("#",4X,A,I3,A,"=",ES12.5)') 'gamma_d(',i,')', gamma_d(i)
       end do
+      write(fh_variables_log, '("#",4X,A,"=",A)')      'wf_em', wf_em
 
       if(inml_analysis >0)ierr_nml = ierr_nml +1
       write(fh_variables_log, '("#namelist: ",A,", status=",I3)') 'analysis', inml_analysis

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -231,6 +231,7 @@ module salmon_global
   real(8)        :: sigma(0:200)
   real(8)        :: omega_p_d(0:200)
   real(8)        :: gamma_d(0:200)
+  character(1)   :: wf_em
   
 !! &analysis
   character(2)   :: projection_option

--- a/src/maxwell/eh_calc.f90
+++ b/src/maxwell/eh_calc.f90
@@ -207,6 +207,7 @@ contains
     use salmon_parallel,      only: nproc_group_global
     use salmon_communication, only: comm_summation
     implicit none
+    real(8) :: sum_lr_x,sum_lr_y,sum_lr_z
     real(8) :: sum_lr(3),sum_lr2(3)
     
     !update time and prepare window function
@@ -259,36 +260,41 @@ contains
       end do
 !$omp end do
 !$omp end parallel
+      sum_lr_x=0.0d0;  sum_lr_y=0.0d0;  sum_lr_z=0.0d0;
       sum_lr(:)=0.0d0; sum_lr2(:)=0.0d0;
 !$omp parallel
-!$omp do private(ix,iy,iz) reduction( + : sum_lr )
+!$omp do private(ix,iy,iz) reduction( + : sum_lr_x,sum_lr_y,sum_lr_z )
       do iz=grid%ng_sta(3),grid%ng_end(3)
       do iy=grid%ng_sta(2),grid%ng_end(2)
       do ix=grid%ng_sta(1),grid%ng_end(1)
-        sum_lr(1)=sum_lr(1)+tmp%px_lr(ix,iy,iz)
-        sum_lr(2)=sum_lr(2)+tmp%py_lr(ix,iy,iz)
-        sum_lr(3)=sum_lr(3)+tmp%pz_lr(ix,iy,iz)
+        sum_lr_x=sum_lr_x+tmp%px_lr(ix,iy,iz)
+        sum_lr_y=sum_lr_y+tmp%py_lr(ix,iy,iz)
+        sum_lr_z=sum_lr_z+tmp%pz_lr(ix,iy,iz)
       end do
       end do
       end do
 !$omp end do
 !$omp end parallel
+      sum_lr(1)=sum_lr_x; sum_lr(2)=sum_lr_y; sum_lr(3)=sum_lr_z;
       call comm_summation(sum_lr,sum_lr2,3,nproc_group_global)
       tmp%dip_lr(tmp%iter_lr,:)=sum_lr2(:)*grid%hgs(1)*grid%hgs(2)*grid%hgs(3)
     elseif(iperiodic==3) then
+      sum_lr_x=0.0d0;  sum_lr_y=0.0d0;  sum_lr_z=0.0d0;
+      sum_lr(:)=0.0d0; sum_lr2(:)=0.0d0;
 !$omp parallel
-!$omp do private(ix,iy,iz) reduction( + : sum_lr )
+!$omp do private(ix,iy,iz) reduction( + : sum_lr_x,sum_lr_y,sum_lr_z )
       do iz=grid%ng_sta(3),grid%ng_end(3)
       do iy=grid%ng_sta(2),grid%ng_end(2)
       do ix=grid%ng_sta(1),grid%ng_end(1)
-        sum_lr(1)=sum_lr(1)+tmp%rjx_lr(ix,iy,iz)
-        sum_lr(2)=sum_lr(2)+tmp%rjy_lr(ix,iy,iz)
-        sum_lr(3)=sum_lr(3)+tmp%rjz_lr(ix,iy,iz)
+        sum_lr_x=sum_lr_x+tmp%rjx_lr(ix,iy,iz)
+        sum_lr_y=sum_lr_y+tmp%rjy_lr(ix,iy,iz)
+        sum_lr_z=sum_lr_z+tmp%rjz_lr(ix,iy,iz)
       end do
       end do
       end do
 !$omp end do
 !$omp end parallel
+      sum_lr(1)=sum_lr_x; sum_lr(2)=sum_lr_y; sum_lr(3)=sum_lr_z;
       call comm_summation(sum_lr,sum_lr2,3,nproc_group_global)
       tmp%curr_lr(tmp%iter_lr,:)=sum_lr2(:)*grid%hgs(1)*grid%hgs(2)*grid%hgs(3) &
                                  /(grid%rlsize(1)*grid%rlsize(2)*grid%rlsize(3))

--- a/src/maxwell/eh_calc.f90
+++ b/src/maxwell/eh_calc.f90
@@ -41,6 +41,11 @@ subroutine eh_calc(grid,tmp)
       call eh_update_drude
     end if
     
+    !calculate linear response
+    if(ae_shape1=='impulse'.or.ae_shape2=='impulse') then
+      call eh_calc_lr
+    end if
+    
     !update e
     call eh_fd(tmp%iex_y_sta,tmp%iex_y_end,      grid%ng_sta,grid%ng_end,tmp%Nd,&
                tmp%c1_ex_y,tmp%c2_ex_y,tmp%ex_y,tmp%hz_x,tmp%hz_y,      'e','y') !ex_y
@@ -194,6 +199,105 @@ contains
     end do
     
   end subroutine eh_update_drude
+  
+  !=========================================================================================
+  != calculate linear response =============================================================
+  subroutine eh_calc_lr
+    use inputoutput,          only: iperiodic
+    use salmon_parallel,      only: nproc_group_global
+    use salmon_communication, only: comm_summation
+    implicit none
+    real(8) :: sum_lr(3),sum_lr2(3)
+    
+    !update time and prepare window function
+    tmp%time_lr(tmp%iter_lr)=dble(tmp%iter_lr)*grid%dt
+    
+    !initialize current density
+!$omp parallel
+!$omp do private(ix,iy,iz)
+    do iz=grid%ng_sta(3),grid%ng_end(3)
+    do iy=grid%ng_sta(2),grid%ng_end(2)
+    do ix=grid%ng_sta(1),grid%ng_end(1)
+      tmp%rjx_lr(ix,iy,iz)=0.0d0; tmp%rjy_lr(ix,iy,iz)=0.0d0; tmp%rjz_lr(ix,iy,iz)=0.0d0;
+    end do
+    end do
+    end do
+!$omp end do
+!$omp end parallel
+    
+    !add all current density
+    if(tmp%inum_d>0) then
+      do ii=1,tmp%inum_d
+!$omp parallel
+!$omp do private(ix,iy,iz)
+        do iz=grid%ng_sta(3),grid%ng_end(3)
+        do iy=grid%ng_sta(2),grid%ng_end(2)
+        do ix=grid%ng_sta(1),grid%ng_end(1)
+          tmp%rjx_lr(ix,iy,iz)=tmp%rjx_lr(ix,iy,iz)+tmp%rjx_d(ix,iy,iz,ii)
+          tmp%rjy_lr(ix,iy,iz)=tmp%rjy_lr(ix,iy,iz)+tmp%rjy_d(ix,iy,iz,ii)
+          tmp%rjz_lr(ix,iy,iz)=tmp%rjz_lr(ix,iy,iz)+tmp%rjz_d(ix,iy,iz,ii)
+        end do
+        end do
+        end do
+!$omp end do
+!$omp end parallel
+      end do
+    end if
+    
+    !calculate dip or curr
+    if(iperiodic==0) then
+!$omp parallel
+!$omp do private(ix,iy,iz)
+      do iz=grid%ng_sta(3),grid%ng_end(3)
+      do iy=grid%ng_sta(2),grid%ng_end(2)
+      do ix=grid%ng_sta(1),grid%ng_end(1)
+        tmp%px_lr(ix,iy,iz)=tmp%px_lr(ix,iy,iz)+tmp%rjx_lr(ix,iy,iz)*grid%dt
+        tmp%py_lr(ix,iy,iz)=tmp%py_lr(ix,iy,iz)+tmp%rjy_lr(ix,iy,iz)*grid%dt
+        tmp%pz_lr(ix,iy,iz)=tmp%pz_lr(ix,iy,iz)+tmp%rjz_lr(ix,iy,iz)*grid%dt
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+      sum_lr(:)=0.0d0; sum_lr2(:)=0.0d0;
+!$omp parallel
+!$omp do private(ix,iy,iz) reduction( + : sum_lr )
+      do iz=grid%ng_sta(3),grid%ng_end(3)
+      do iy=grid%ng_sta(2),grid%ng_end(2)
+      do ix=grid%ng_sta(1),grid%ng_end(1)
+        sum_lr(1)=sum_lr(1)+tmp%px_lr(ix,iy,iz)
+        sum_lr(2)=sum_lr(2)+tmp%py_lr(ix,iy,iz)
+        sum_lr(3)=sum_lr(3)+tmp%pz_lr(ix,iy,iz)
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+      call comm_summation(sum_lr,sum_lr2,3,nproc_group_global)
+      tmp%dip_lr(tmp%iter_lr,:)=sum_lr2(:)*grid%hgs(1)*grid%hgs(2)*grid%hgs(3)
+    elseif(iperiodic==3) then
+!$omp parallel
+!$omp do private(ix,iy,iz) reduction( + : sum_lr )
+      do iz=grid%ng_sta(3),grid%ng_end(3)
+      do iy=grid%ng_sta(2),grid%ng_end(2)
+      do ix=grid%ng_sta(1),grid%ng_end(1)
+        sum_lr(1)=sum_lr(1)+tmp%rjx_lr(ix,iy,iz)
+        sum_lr(2)=sum_lr(2)+tmp%rjy_lr(ix,iy,iz)
+        sum_lr(3)=sum_lr(3)+tmp%rjz_lr(ix,iy,iz)
+      end do
+      end do
+      end do
+!$omp end do
+!$omp end parallel
+      call comm_summation(sum_lr,sum_lr2,3,nproc_group_global)
+      tmp%curr_lr(tmp%iter_lr,:)=sum_lr2(:)*grid%hgs(1)*grid%hgs(2)*grid%hgs(3) &
+                                 /(grid%rlsize(1)*grid%rlsize(2)*grid%rlsize(3))
+    end if
+    
+    !update time iteration
+    tmp%iter_lr=tmp%iter_lr+1
+    
+  end subroutine eh_calc_lr
   
   !=========================================================================================
   != add incident current source ===========================================================

--- a/src/maxwell/eh_finalize.f90
+++ b/src/maxwell/eh_finalize.f90
@@ -73,7 +73,7 @@ subroutine eh_finalize(grid,tmp)
       case('au','a.u.')
         write(tmp%ifn,'(A)') "# time[a.u.],  current(x,y,z)[a.u.]" 
       case('A_eV_fs')
-        write(tmp%ifn,'(A)') "# time[fs],    current(x,y,z)[A]" 
+        write(tmp%ifn,'(A)') "# time[fs],    current(x,y,z)[A/Ang.^2]" 
       end select
       do ii=1,nt_em
         write(tmp%ifn, '(E13.5)',advance="no")     tmp%time_lr(ii)*utime_from_au

--- a/src/maxwell/salmon_maxwell.f90
+++ b/src/maxwell/salmon_maxwell.f90
@@ -94,6 +94,14 @@ module salmon_maxwell
     real(8),allocatable :: c1_j_d(:),c2_j_d(:)                          !Drude: coefficient for j
     integer             :: iwk_size_eh                                  !tmporary variable for sendrecvh
     real(8),allocatable :: rmedia(:,:,:)                                !Material information for tmp.
+    real(8),allocatable :: time_lr(:)                                   !LR: time
+    integer             :: iter_lr                                      !LR: time iteration for save
+    real(8),allocatable :: fr_lr(:,:)                                   !LR: Re[f]
+    real(8),allocatable :: fi_lr(:,:)                                   !LR: Im[f]
+    real(8),allocatable :: rjx_lr(:,:,:),rjy_lr(:,:,:),rjz_lr(:,:,:)    !LR: poparization current density
+    real(8),allocatable :: px_lr(:,:,:), py_lr(:,:,:), pz_lr(:,:,:)     !LR: poparization vector
+    real(8),allocatable :: curr_lr(:,:)                                 !LR: current
+    real(8),allocatable :: dip_lr(:,:)                                  !LR: dipolemoment
   end type fdtd_tmp
   
   contains


### PR DESCRIPTION
This PR adds linear response calculation in eh-FDTD. Attachments are input files for test.
[Mtes_3_lr.zip](https://github.com/SALMON-TDDFT/SALMON/files/2631356/Mtes_3_lr.zip)
[Mtes_0_lr.zip](https://github.com/SALMON-TDDFT/SALMON/files/2631357/Mtes_0_lr.zip)
