### PR TITLE
Bugfix: upper bounds of Ac load

### DIFF
--- a/src/ARTED/RT/init_Ac.f90
+++ b/src/ARTED/RT/init_Ac.f90
@@ -129,7 +129,7 @@ Subroutine init_Ac
     Ac_ext=0d0
     if(comm_is_root(nproc_id_global))then
       open(899,file='input_Ac.dat')
-      do iter=0,Nt
+      do iter=0,Nt+1
         read(899,*)Ac_ext(iter,1),Ac_ext(iter,2),Ac_ext(iter,3)
       end do
       close(899)


### PR DESCRIPTION
This pull request provides a bugfix in a reading of `input_Ac.dat` file to initialize the value of `Ac_ext(Nt+1,:)`.