### PR TITLE
fix: increase version number to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ http://salmon-tddft.jp/
 
 SALMON is available under Apache License version 2.0.
 
-    Copyright 2018 SALMON developers
+    Copyright 2017-2019 SALMON developers
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/cmakefiles/Modules/FindLIBXCF90.cmake
+++ b/cmakefiles/Modules/FindLIBXCF90.cmake
@@ -1,5 +1,5 @@
 #
-#  Copyright 2018 SALMON developers
+#  Copyright 2017-2019 SALMON developers
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/configure.py
+++ b/configure.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 #
-#   Copyright 2017 SALMON developers
+#   Copyright 2017-2019 SALMON developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/src/ARTED/FDTD/FDTD.f90
+++ b/src/ARTED/FDTD/FDTD.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/FDTD/beam.f90
+++ b/src/ARTED/FDTD/beam.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/GS/CG.f90
+++ b/src/ARTED/GS/CG.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/GS/Fermi_Dirac_distribution.f90
+++ b/src/ARTED/GS/Fermi_Dirac_distribution.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/GS/Gram_Schmidt.f90
+++ b/src/ARTED/GS/Gram_Schmidt.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/GS/Occupation_Redistribution.f90
+++ b/src/ARTED/GS/Occupation_Redistribution.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/GS/diag.f90
+++ b/src/ARTED/GS/diag.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/GS/io_gs_wfn_k.f90
+++ b/src/ARTED/GS/io_gs_wfn_k.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/GS/sp_energy.f90
+++ b/src/ARTED/GS/sp_energy.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/GS/write_GS_data.f90
+++ b/src/ARTED/GS/write_GS_data.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/RT/Fourier_tr.f90
+++ b/src/ARTED/RT/Fourier_tr.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/RT/acc/current.f90
+++ b/src/ARTED/RT/acc/current.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/RT/acc/hamiltonian.f90
+++ b/src/ARTED/RT/acc/hamiltonian.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/RT/current.f90
+++ b/src/ARTED/RT/current.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/RT/dt_evolve.f90
+++ b/src/ARTED/RT/dt_evolve.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/RT/hamiltonian.f90
+++ b/src/ARTED/RT/hamiltonian.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/RT/init_Ac.f90
+++ b/src/ARTED/RT/init_Ac.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/Exc_Cor.f90
+++ b/src/ARTED/common/Exc_Cor.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/Hartree.f90
+++ b/src/ARTED/common/Hartree.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/acc/hpsi.f90
+++ b/src/ARTED/common/acc/hpsi.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/density_plot.f90
+++ b/src/ARTED/common/density_plot.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/hpsi.f90
+++ b/src/ARTED/common/hpsi.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/hpsi_test.f90
+++ b/src/ARTED/common/hpsi_test.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/ion_force.f90
+++ b/src/ARTED/common/ion_force.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/preprocessor.f90
+++ b/src/ARTED/common/preprocessor.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/projector.f90
+++ b/src/ARTED/common/projector.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/psi_rho.f90
+++ b/src/ARTED/common/psi_rho.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/restart.f90
+++ b/src/ARTED/common/restart.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/common/total_energy.f90
+++ b/src/ARTED/common/total_energy.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/ana_RT_useGS.f90
+++ b/src/ARTED/control/ana_RT_useGS.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/control_ms.f90
+++ b/src/ARTED/control/control_ms.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/control_ms_raman.f90
+++ b/src/ARTED/control/control_ms_raman.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/control_sc.f90
+++ b/src/ARTED/control/control_sc.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/ground_state.f90
+++ b/src/ARTED/control/ground_state.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/initialization.f90
+++ b/src/ARTED/control/initialization.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/inputfile.f90
+++ b/src/ARTED/control/inputfile.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/md_gs.f90
+++ b/src/ARTED/control/md_gs.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/control/optimization.f90
+++ b/src/ARTED/control/optimization.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/main.f90
+++ b/src/ARTED/main.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/modules/global_variables.f90
+++ b/src/ARTED/modules/global_variables.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/modules/nvtx.f90
+++ b/src/ARTED/modules/nvtx.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/modules/opt_variables.f90
+++ b/src/ARTED/modules/opt_variables.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/modules/performance_analyzer.f90
+++ b/src/ARTED/modules/performance_analyzer.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/perfcheck/main.c
+++ b/src/ARTED/perfcheck/main.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/perfcheck/stencil_perf_check.f90
+++ b/src/ARTED/perfcheck/stencil_perf_check.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/perfcheck/wrap_variables.f90
+++ b/src/ARTED/perfcheck/wrap_variables.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/preparation/fd_coef.f90
+++ b/src/ARTED/preparation/fd_coef.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/preparation/init.f90
+++ b/src/ARTED/preparation/init.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/preparation/init_wf.f90
+++ b/src/ARTED/preparation/init_wf.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/preparation/pp_postprocess.f90
+++ b/src/ARTED/preparation/pp_postprocess.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/preparation/prep_ps.f90
+++ b/src/ARTED/preparation/prep_ps.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/C/AVX/current.c
+++ b/src/ARTED/stencil/C/AVX/current.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/C/AVX/hpsi.c
+++ b/src/ARTED/stencil/C/AVX/hpsi.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/C/AVX/total_energy.c
+++ b/src/ARTED/stencil/C/AVX/total_energy.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/C/IMCI/current.c
+++ b/src/ARTED/stencil/C/IMCI/current.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/C/IMCI/hpsi.c
+++ b/src/ARTED/stencil/C/IMCI/hpsi.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/C/IMCI/total_energy.c
+++ b/src/ARTED/stencil/C/IMCI/total_energy.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/C/imci2avx512f.h
+++ b/src/ARTED/stencil/C/imci2avx512f.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/C/interop.h
+++ b/src/ARTED/stencil/C/interop.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 SALMON developers
+ *  Copyright 2017-2019 SALMON developers
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/F90/acc/current.f90
+++ b/src/ARTED/stencil/F90/acc/current.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/F90/acc/hpsi.f90
+++ b/src/ARTED/stencil/F90/acc/hpsi.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/F90/acc/total_energy.f90
+++ b/src/ARTED/stencil/F90/acc/total_energy.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/F90/current.f90
+++ b/src/ARTED/stencil/F90/current.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/F90/hpsi.f90
+++ b/src/ARTED/stencil/F90/hpsi.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/F90/hpsi_original.f90
+++ b/src/ARTED/stencil/F90/hpsi_original.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ARTED/stencil/F90/total_energy.f90
+++ b/src/ARTED/stencil/F90/total_energy.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/OUT_IN_data.f90
+++ b/src/GCEED/common/OUT_IN_data.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/allocate_sendrecv.f90
+++ b/src/GCEED/common/allocate_sendrecv.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/bisection.f90
+++ b/src/GCEED/common/bisection.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calcELF.f90
+++ b/src/GCEED/common/calcELF.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calcJxyz_all.f90
+++ b/src/GCEED/common/calcJxyz_all.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calcJxyz_all_periodic.f90
+++ b/src/GCEED/common/calcJxyz_all_periodic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calcVpsl.f90
+++ b/src/GCEED/common/calcVpsl.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calcVpsl_periodic.f90
+++ b/src/GCEED/common/calcVpsl_periodic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calcVpsl_periodic_FFTE.f90
+++ b/src/GCEED/common/calcVpsl_periodic_FFTE.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_allob.f90
+++ b/src/GCEED/common/calc_allob.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_force.f90
+++ b/src/GCEED/common/calc_force.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_force_c.f90
+++ b/src/GCEED/common/calc_force_c.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_gradient_fast.f90
+++ b/src/GCEED/common/calc_gradient_fast.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_gradient_fast_c.f90
+++ b/src/GCEED/common/calc_gradient_fast_c.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_iquotient.f90
+++ b/src/GCEED/common/calc_iquotient.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_iroot.f90
+++ b/src/GCEED/common/calc_iroot.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_myob.f90
+++ b/src/GCEED/common/calc_myob.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_ob_num.f90
+++ b/src/GCEED/common/calc_ob_num.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calc_pmax.f90
+++ b/src/GCEED/common/calc_pmax.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/calcuV.f90
+++ b/src/GCEED/common/calcuV.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/check_cep.f90
+++ b/src/GCEED/common/check_cep.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/check_corrkob.f90
+++ b/src/GCEED/common/check_corrkob.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/check_fourier.f90
+++ b/src/GCEED/common/check_fourier.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/check_mg.f90
+++ b/src/GCEED/common/check_mg.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/check_ng.f90
+++ b/src/GCEED/common/check_ng.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/check_numcpu.f90
+++ b/src/GCEED/common/check_numcpu.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/conv_p.f90
+++ b/src/GCEED/common/conv_p.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/conv_p0.f90
+++ b/src/GCEED/common/conv_p0.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/exc_cor_ns.f90
+++ b/src/GCEED/common/exc_cor_ns.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/hartree.f90
+++ b/src/GCEED/common/hartree.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/hartree_FFTE.f90
+++ b/src/GCEED/common/hartree_FFTE.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/hartree_boundary.f90
+++ b/src/GCEED/common/hartree_boundary.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/hartree_cg.f90
+++ b/src/GCEED/common/hartree_cg.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/hartree_periodic.f90
+++ b/src/GCEED/common/hartree_periodic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/init_k_rd.f90
+++ b/src/GCEED/common/init_k_rd.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/init_wf.f90
+++ b/src/GCEED/common/init_wf.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/inner_product3.f90
+++ b/src/GCEED/common/inner_product3.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/inner_product4.f90
+++ b/src/GCEED/common/inner_product4.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/inner_product7.f90
+++ b/src/GCEED/common/inner_product7.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/laplacianh.f90
+++ b/src/GCEED/common/laplacianh.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/nabla.f90
+++ b/src/GCEED/common/nabla.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/prep_poisson_fft.f90
+++ b/src/GCEED/common/prep_poisson_fft.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/psl.f90
+++ b/src/GCEED/common/psl.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/read_copy_pot.f90
+++ b/src/GCEED/common/read_copy_pot.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/sendrecv_copy.f90
+++ b/src/GCEED/common/sendrecv_copy.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/set_filename.f90
+++ b/src/GCEED/common/set_filename.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/set_gridcoo.f90
+++ b/src/GCEED/common/set_gridcoo.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/set_icoo1d.f90
+++ b/src/GCEED/common/set_icoo1d.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/set_imesh_oddeven.f90
+++ b/src/GCEED/common/set_imesh_oddeven.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/set_ispin.f90
+++ b/src/GCEED/common/set_ispin.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/set_isstaend.f90
+++ b/src/GCEED/common/set_isstaend.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/setbN.f90
+++ b/src/GCEED/common/setbN.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/setcN.f90
+++ b/src/GCEED/common/setcN.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/storevpp.f90
+++ b/src/GCEED/common/storevpp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/total_energy_periodic.f90
+++ b/src/GCEED/common/total_energy_periodic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/writeavs.f90
+++ b/src/GCEED/common/writeavs.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/writecube.f90
+++ b/src/GCEED/common/writecube.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/writedns.f90
+++ b/src/GCEED/common/writedns.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/writeelf.f90
+++ b/src/GCEED/common/writeelf.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/writeestatic.f90
+++ b/src/GCEED/common/writeestatic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/writepsi.f90
+++ b/src/GCEED/common/writepsi.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/writevtk.f90
+++ b/src/GCEED/common/writevtk.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/common/ylm.f90
+++ b/src/GCEED/common/ylm.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/gceed.f90
+++ b/src/GCEED/gceed.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/misc/setk.f90
+++ b/src/GCEED/misc/setk.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/misc/setlg.f90
+++ b/src/GCEED/misc/setlg.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/misc/setmg.f90
+++ b/src/GCEED/misc/setmg.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/misc/setng.f90
+++ b/src/GCEED/misc/setng.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/allocate_mat.f90
+++ b/src/GCEED/modules/allocate_mat.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/allocate_psl.f90
+++ b/src/GCEED/modules/allocate_psl.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/calc_density.f90
+++ b/src/GCEED/modules/calc_density.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/change_order.f90
+++ b/src/GCEED/modules/change_order.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/copyVlocal.f90
+++ b/src/GCEED/modules/copyVlocal.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/copy_psi_mesh.f90
+++ b/src/GCEED/modules/copy_psi_mesh.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/deallocate_mat.f90
+++ b/src/GCEED/modules/deallocate_mat.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/gradient.f90
+++ b/src/GCEED/modules/gradient.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/gradient2.f90
+++ b/src/GCEED/modules/gradient2.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/hpsi2.f90
+++ b/src/GCEED/modules/hpsi2.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/hpsi2_test.f90
+++ b/src/GCEED/modules/hpsi2_test.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/init_sendrecv.f90
+++ b/src/GCEED/modules/init_sendrecv.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/inner_product.f90
+++ b/src/GCEED/modules/inner_product.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/laplacian2.f90
+++ b/src/GCEED/modules/laplacian2.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/new_world.f90
+++ b/src/GCEED/modules/new_world.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/pack_unpack.f90
+++ b/src/GCEED/modules/pack_unpack.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/persistent_comm.f90
+++ b/src/GCEED/modules/persistent_comm.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/read_pslfile.f90
+++ b/src/GCEED/modules/read_pslfile.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/readbox_rt.f90
+++ b/src/GCEED/modules/readbox_rt.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/rmmdiis_eigen_lapack.f90
+++ b/src/GCEED/modules/rmmdiis_eigen_lapack.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/scf_data.f90
+++ b/src/GCEED/modules/scf_data.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/sendrecv.f90
+++ b/src/GCEED/modules/sendrecv.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/sendrecv_groupob.f90
+++ b/src/GCEED/modules/sendrecv_groupob.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/sendrecv_groupob_ngp.f90
+++ b/src/GCEED/modules/sendrecv_groupob_ngp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/sendrecv_groupob_tmp.f90
+++ b/src/GCEED/modules/sendrecv_groupob_tmp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/sendrecv_self.f90
+++ b/src/GCEED/modules/sendrecv_self.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/sendrecv_tmp.f90
+++ b/src/GCEED/modules/sendrecv_tmp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/sendrecvh.f90
+++ b/src/GCEED/modules/sendrecvh.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/share_mesh_1d_old.f90
+++ b/src/GCEED/modules/share_mesh_1d_old.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/structure_opt.f90
+++ b/src/GCEED/modules/structure_opt.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/total_energy.f90
+++ b/src/GCEED/modules/total_energy.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/modules/writebox_rt.f90
+++ b/src/GCEED/modules/writebox_rt.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/read_input_gceed.f90
+++ b/src/GCEED/read_input_gceed.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/add_polynomial.f90
+++ b/src/GCEED/rt/add_polynomial.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/aft_fourier.f90
+++ b/src/GCEED/rt/aft_fourier.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/calcAext.f90
+++ b/src/GCEED/rt/calcAext.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/calcEstatic.f90
+++ b/src/GCEED/rt/calcEstatic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/calcVbox.f90
+++ b/src/GCEED/rt/calcVbox.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/calc_current.f90
+++ b/src/GCEED/rt/calc_current.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/calc_env_trigon.f90
+++ b/src/GCEED/rt/calc_env_trigon.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/check_ae_shape.f90
+++ b/src/GCEED/rt/check_ae_shape.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/convert_input_rt.f90
+++ b/src/GCEED/rt/convert_input_rt.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/dip.f90
+++ b/src/GCEED/rt/dip.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/gradient_ex.f90
+++ b/src/GCEED/rt/gradient_ex.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/hpsi_groupob.f90
+++ b/src/GCEED/rt/hpsi_groupob.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/initA.f90
+++ b/src/GCEED/rt/initA.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/projection.f90
+++ b/src/GCEED/rt/projection.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/read_rt.f90
+++ b/src/GCEED/rt/read_rt.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/real_time_dft.f90
+++ b/src/GCEED/rt/real_time_dft.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/set_numcpu_rt.f90
+++ b/src/GCEED/rt/set_numcpu_rt.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/set_numcpu_rt_sp.f90
+++ b/src/GCEED/rt/set_numcpu_rt_sp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/set_vonf_sd.f90
+++ b/src/GCEED/rt/set_vonf_sd.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/taylor.f90
+++ b/src/GCEED/rt/taylor.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/taylor_coe.f90
+++ b/src/GCEED/rt/taylor_coe.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/taylor_test.f90
+++ b/src/GCEED/rt/taylor_test.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/time_evolution_step.f90
+++ b/src/GCEED/rt/time_evolution_step.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/total_energy_groupob.f90
+++ b/src/GCEED/rt/total_energy_groupob.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/rt/xc_fast.f90
+++ b/src/GCEED/rt/xc_fast.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/buffer_broyden_ns.f90
+++ b/src/GCEED/scf/buffer_broyden_ns.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/calc_dos.f90
+++ b/src/GCEED/scf/calc_dos.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/calc_occupation.f90
+++ b/src/GCEED/scf/calc_occupation.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/calc_pdos.f90
+++ b/src/GCEED/scf/calc_pdos.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/check_dos_pdos.f90
+++ b/src/GCEED/scf/check_dos_pdos.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/convert_input_scf.f90
+++ b/src/GCEED/scf/convert_input_scf.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/copy_density.f90
+++ b/src/GCEED/scf/copy_density.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/deallocate_sendrecv.f90
+++ b/src/GCEED/scf/deallocate_sendrecv.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/eigen_subdiag_lapack.f90
+++ b/src/GCEED/scf/eigen_subdiag_lapack.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/eigen_subdiag_periodic_lapack.f90
+++ b/src/GCEED/scf/eigen_subdiag_periodic_lapack.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/eigen_subdiag_periodic_scalapack.f90
+++ b/src/GCEED/scf/eigen_subdiag_periodic_scalapack.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/eigen_subdiag_scalapack.f90
+++ b/src/GCEED/scf/eigen_subdiag_scalapack.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/gram_schmidt.f90
+++ b/src/GCEED/scf/gram_schmidt.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/gram_schmidt_periodic.f90
+++ b/src/GCEED/scf/gram_schmidt_periodic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/gscg.f90
+++ b/src/GCEED/scf/gscg.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/gscg_periodic.f90
+++ b/src/GCEED/scf/gscg_periodic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/prep_ini.f90
+++ b/src/GCEED/scf/prep_ini.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/real_space_dft.f90
+++ b/src/GCEED/scf/real_space_dft.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/rmmdiis.f90
+++ b/src/GCEED/scf/rmmdiis.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/rmmdiis_eigen.f90
+++ b/src/GCEED/scf/rmmdiis_eigen.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/set_numcpu_scf.f90
+++ b/src/GCEED/scf/set_numcpu_scf.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/simple_mixing.f90
+++ b/src/GCEED/scf/simple_mixing.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/subdgemm_lapack.f90
+++ b/src/GCEED/scf/subdgemm_lapack.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/subspace_diag.f90
+++ b/src/GCEED/scf/subspace_diag.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/subspace_diag_periodic.f90
+++ b/src/GCEED/scf/subspace_diag_periodic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/total_energy_periodic_scf.f90
+++ b/src/GCEED/scf/total_energy_periodic_scf.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/write_eigen.f90
+++ b/src/GCEED/scf/write_eigen.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/ybcg.f90
+++ b/src/GCEED/scf/ybcg.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/GCEED/scf/ybcg_periodic.f90
+++ b/src/GCEED/scf/ybcg_periodic.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/atom/pp/Ylm_dYlm.f90
+++ b/src/atom/pp/Ylm_dYlm.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/atom/pp/input_pp.f90
+++ b/src/atom/pp/input_pp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/atom/pp/prep_pp.f90
+++ b/src/atom/pp/prep_pp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/atom/pp/salmon_pp.f90
+++ b/src/atom/pp/salmon_pp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/common/broyden.f90
+++ b/src/common/broyden.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/common/hpsi.f90
+++ b/src/common/hpsi.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/common/stencil.f90
+++ b/src/common/stencil.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/common/update_overlap.f90
+++ b/src/common/update_overlap.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ext/FFTE/alltoall_1d.f90
+++ b/src/ext/FFTE/alltoall_1d.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/ext/FFTE/pzfft3dv_mod.f
+++ b/src/ext/FFTE/pzfft3dv_mod.f
@@ -1,5 +1,5 @@
 C
-C  Copyright 2018 SALMON developers
+C  Copyright 2017-2019 SALMON developers
 C
 C  Licensed under the Apache License, Version 2.0 (the "License");
 C  you may not use this file except in compliance with the License.

--- a/src/io/inputoutput.f90
+++ b/src/io/inputoutput.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/io/salmon_file.f90
+++ b/src/io/salmon_file.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/io/salmon_global.f90
+++ b/src/io/salmon_global.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/math/math_constants.f90
+++ b/src/math/math_constants.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/math/salmon_math.f90
+++ b/src/math/salmon_math.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/classic_em.f90
+++ b/src/maxwell/classic_em.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/coulomb_calc.f90
+++ b/src/maxwell/coulomb_calc.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/coulomb_finalize.f90
+++ b/src/maxwell/coulomb_finalize.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/coulomb_init.f90
+++ b/src/maxwell/coulomb_init.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/eh_calc.f90
+++ b/src/maxwell/eh_calc.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/eh_finalize.f90
+++ b/src/maxwell/eh_finalize.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/eh_init.f90
+++ b/src/maxwell/eh_init.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/salmon_maxwell.f90
+++ b/src/maxwell/salmon_maxwell.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/weyl_calc.f90
+++ b/src/maxwell/weyl_calc.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/weyl_finalize.f90
+++ b/src/maxwell/weyl_finalize.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/maxwell/weyl_init.f90
+++ b/src/maxwell/weyl_init.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/misc/backup_routines.f90
+++ b/src/misc/backup_routines.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/misc/misc_routines.f90
+++ b/src/misc/misc_routines.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/misc/timer.f90
+++ b/src/misc/timer.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/misc/unusedvar.f90
+++ b/src/misc/unusedvar.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/parallel/salmon_communication.f90
+++ b/src/parallel/salmon_communication.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/parallel/salmon_parallel.f90
+++ b/src/parallel/salmon_parallel.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2017 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -7,6 +7,6 @@
 
 #define SALMON_VER_MAJOR  1
 #define SALMON_VER_MINOR  2
-#define SALMON_VER_MICRO  0
+#define SALMON_VER_MICRO  1
 
 #endif

--- a/src/versionf.h.in
+++ b/src/versionf.h.in
@@ -4,4 +4,4 @@ character(*), parameter :: GIT_COMMIT_HASH = '@GIT_COMMIT_HASH@'
 
 integer, parameter :: SALMON_VER_MAJOR = 1
 integer, parameter :: SALMON_VER_MINOR = 2
-integer, parameter :: SALMON_VER_MICRO = 0
+integer, parameter :: SALMON_VER_MICRO = 1

--- a/src/xc/builtin_pbe.f90
+++ b/src/xc/builtin_pbe.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/xc/builtin_pz.f90
+++ b/src/xc/builtin_pz.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/xc/builtin_pz_sp.f90
+++ b/src/xc/builtin_pz_sp.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/xc/builtin_pzm.f90
+++ b/src/xc/builtin_pzm.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/xc/builtin_tbmbj.f90
+++ b/src/xc/builtin_tbmbj.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/src/xc/salmon_xc.f90
+++ b/src/xc/salmon_xc.f90
@@ -1,5 +1,5 @@
 !
-!  Copyright 2018 SALMON developers
+!  Copyright 2017-2019 SALMON developers
 !
 !  Licensed under the Apache License, Version 2.0 (the "License");
 !  you may not use this file except in compliance with the License.

--- a/tools/cuda_mps_run
+++ b/tools/cuda_mps_run
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-#   Copyright 2017 SALMON developers
+#   Copyright 2017-2019 SALMON developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tools/env_wrapper
+++ b/tools/env_wrapper
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-#   Copyright 2017 SALMON developers
+#   Copyright 2017-2019 SALMON developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tools/get_mpi_configuration
+++ b/tools/get_mpi_configuration
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-#   Copyright 2017 SALMON developers
+#   Copyright 2017-2019 SALMON developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tools/mpirun.gpu
+++ b/tools/mpirun.gpu
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-#   Copyright 2017 SALMON developers
+#   Copyright 2017-2019 SALMON developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tools/mpirun.symm
+++ b/tools/mpirun.symm
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-#   Copyright 2017 SALMON developers
+#   Copyright 2017-2019 SALMON developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tools/select_cuda_device
+++ b/tools/select_cuda_device
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-#   Copyright 2017 SALMON developers
+#   Copyright 2017-2019 SALMON developers
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Congratulations! 
![logo_fish](https://user-images.githubusercontent.com/5200546/42065569-a8e765ce-7b76-11e8-823a-de3ba7c20b3d.png)
Thanks to the effort of many developers and collaborators, we can release SALMON-v.1.2.1 !

```
##############################################################################
# SALMON: Scalable Ab-initio Light-Matter simulator for Optics and Nanoscience
#
#                             Version 1.2.1
```
